### PR TITLE
Include libffi-dev dependency for Ubuntu 

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -105,7 +105,7 @@ Debian 7.0 Wheezy or newer, Ubuntu 11.10 Oneiric or newer:
 
 .. code-block:: sh
 
-    sudo apt-get install python-dev python-pip python-lxml libcairo2 libpango1.0-0 libgdk-pixbuf2.0-0
+    sudo apt-get install python-dev python-pip python-lxml libcairo2 libpango1.0-0 libgdk-pixbuf2.0-0 libffi-dev
 
 
 Debian 6.0 Squeeze, Ubuntu 10.04 Lucid:


### PR DESCRIPTION
I've just installed WeasyPrint 0.17 on Ubuntu 12.10. It required first installing libffi-dev. (I haven't checked if this also applies to other Ubuntu and Debian versions.)
