### PR TITLE
Pyphen requires easy_install with Python 2.6

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -118,6 +118,14 @@ GDK-PixBuf is part of GTK+, which also depends on cairo and Pango.
 
     sudo apt-get install python-dev python-pip python-lxml libgtk2.0-0 libffi-dev
 
+If you're using Pyhton 2.6, pip can't be used to install Pyphen (because `its
+package contains symlinks <http://bugs.python.org/issue10292>`_), so install it
+with easy_install first:
+
+.. code-block:: sh
+
+    sudo easy_install Pyphen
+
 
 Archlinux
 ~~~~~~~~~


### PR DESCRIPTION
I was installing WeasyPrint 0.17 on an Ubuntu 10.04 LTS server. This is still running Python 2.6, and the Pyphen install with pip failed there (full error message below). It looks to be a bug with the tar library on Python 2.6, which won't ever be fixed: http://bugs.python.org/issue10292

Using easy_install instead for Pyphen worked fine, then I was able to use pip to install WeasyPrint as normal.

I mentioned this in the bit which covers old version of Ubuntu and Debian. If there are other platforms still using Python 2.6 then that may not be the best placed for it.

```
Downloading/unpacking Pyphen (from WeasyPrint)
  Downloading Pyphen-0.7.tar.gz (933Kb): 933Kb downloaded
Exception:
Traceback (most recent call last):
  File "/usr/lib/python2.6/dist-packages/pip.py", line 252, in main
    self.run(options, args)
  File "/usr/lib/python2.6/dist-packages/pip.py", line 408, in run
    requirement_set.install_files(finder, force_root_egg_info=self.bundle)
  File "/usr/lib/python2.6/dist-packages/pip.py", line 1757, in install_files
    self.unpack_url(url, location)
  File "/usr/lib/python2.6/dist-packages/pip.py", line 1901, in unpack_url
    self.unpack_file(temp_location, location, content_type, link)
  File "/usr/lib/python2.6/dist-packages/pip.py", line 1919, in unpack_file
    self.untar_file(filename, location)
  File "/usr/lib/python2.6/dist-packages/pip.py", line 1988, in untar_file
    fp = tar.extractfile(member)
  File "/usr/lib/python2.6/tarfile.py", line 2122, in extractfile
    tarinfo))
  File "/usr/lib/python2.6/tarfile.py", line 2105, in extractfile
    if tarinfo.isreg():
AttributeError: 'NoneType' object has no attribute 'isreg'
```
