### PR TITLE
Add support for Gzip encoding

### DIFF
--- a/weasyprint/compat.py
+++ b/weasyprint/compat.py
@@ -14,13 +14,15 @@ from __future__ import division, unicode_literals
 
 import sys
 import email
+import gzip
 
 
-__all__ = ['Request', 'base64_decode', 'base64_encode', 'basestring',
-           'ints_from_bytes', 'iteritems', 'izip', 'parse_email', 'parse_qs',
-           'pathname2url', 'quote', 'unicode', 'unquote', 'unquote_to_bytes',
-           'urlencode', 'urljoin', 'urlopen', 'urlopen_contenttype',
-           'urlparse_uses_relative', 'urlsplit', 'xrange']
+__all__ = ['ClosingGzipFile', 'Request', 'base64_decode', 'base64_encode',
+           'basestring', 'ints_from_bytes', 'iteritems', 'izip', 'parse_email',
+           'parse_qs', 'pathname2url', 'quote', 'unicode', 'unquote',
+           'unquote_to_bytes', 'urlencode', 'urljoin', 'urlopen',
+           'urlopen_contenttype', 'urlparse_uses_relative', 'urlsplit',
+           'xrange']
 
 
 if sys.version_info[0] >= 3:
@@ -30,6 +32,7 @@ if sys.version_info[0] >= 3:
         urlencode, uses_relative as urlparse_uses_relative)
     from urllib.request import urlopen, Request, pathname2url
     from array import array
+    from io import StringIO
     from base64 import (decodebytes as base64_decode,
                         encodebytes as base64_encode)
 
@@ -56,6 +59,7 @@ if sys.version_info[0] >= 3:
         """Return a list of ints from a byte string"""
         return list(byte_string)
 
+
 else:
     # Python 2
     from urlparse import (urljoin, urlsplit, parse_qs,
@@ -66,6 +70,11 @@ else:
     from itertools import izip, imap
     from base64 import (decodestring as base64_decode,
                         encodestring as base64_encode)
+
+    try:
+        from cStringIO import StringIO
+    except ImportError:
+        from StringIO import StringIO
 
     unicode = unicode
     basestring = basestring
@@ -96,3 +105,41 @@ else:
     def ints_from_bytes(byte_string):
         """Return a list of ints from a byte string"""
         return imap(ord, byte_string)
+
+
+if sys.version_info[0] < 3 or \
+    sys.version_info[0] == 3 and sys.version_info[1] < 2:
+
+    # GzipFile cannot be used for streaming before Python 3.2
+    # http://bugs.python.org/issue11608
+    class ClosingGzipFile(gzip.GzipFile):
+        def __init__(self, filename=None, mode=None, compresslevel=None,
+                fileobj=None, mtime=None, *args, **kwargs):
+            if fileobj:
+                fake_fileobj = StringIO(fileobj.read())
+                fileobj.close()
+                fileobj = fake_fileobj
+            known_kwargs = {
+                'filename': filename, 'mode': mode,
+                'compresslevel': compresslevel, 'fileobj': fileobj,
+                'mtime': mtime}
+            kwargs.update((k, v) for k, v in known_kwargs.items() if v is not None)
+            super(ClosingGzipFile, self).__init__(*args, **kwargs)
+
+else:
+
+    class ClosingGzipFile(gzip.GzipFile):
+        def __init__(self, filename=None, mode=None, compresslevel=None,
+                fileobj=None, mtime=None, *args, **kwargs):
+            self.my_fileobj = fileobj
+            known_kwargs = {
+                'filename': filename, 'mode': mode,
+                'compresslevel': compresslevel, 'fileobj': fileobj,
+                'mtime': mtime}
+            kwargs.update((k, v) for k, v in known_kwargs.items() if v is not None)
+            super(ClosingGzipFile, self).__init__(*args, **kwargs)
+
+        def close(self):
+            super(ClosingGzipFile, self).close()
+            if self.my_fileobj:
+                self.my_fileobj.close()

--- a/weasyprint/urls.py
+++ b/weasyprint/urls.py
@@ -22,7 +22,7 @@ from . import VERSION_STRING
 from .logger import LOGGER
 from .compat import (
     urljoin, urlsplit, quote, unquote, unquote_to_bytes, urlopen_contenttype,
-    Request, parse_email, pathname2url, unicode, base64_decode)
+    Request, ClosingGzipFile, parse_email, pathname2url, unicode, base64_decode)
 
 
 # Unlinke HTML, CSS and PNG, the SVG MIME type is not always builtin
@@ -258,9 +258,15 @@ def default_url_fetcher(url):
         return open_data_url(url)
     elif UNICODE_SCHEME_RE.match(url):
         url = iri_to_uri(url)
-        result, mime_type, charset = urlopen_contenttype(Request(
-            url, headers={'User-Agent': VERSION_STRING}))
-        return dict(file_obj=result, redirected_url=result.geturl(),
+        headers = {'User-Agent': VERSION_STRING, 'Accept-Encoding': 'gzip'}
+        result, mime_type, charset = urlopen_contenttype(
+            Request(url, headers=headers))
+        redirected_url = result.geturl()
+
+        if result.info().get('Content-Encoding') == 'gzip':
+            result = ClosingGzipFile(fileobj=result)
+       
+        return dict(file_obj=result, redirected_url=redirected_url,
                     mime_type=mime_type, encoding=charset)
     else:
         raise ValueError('Not an absolute URI: %r' % url)


### PR DESCRIPTION
Some websites, like Wikipedia, send us a Gzip-encoded web page even if we don't ask for it. This usually happens when the page is very large. Try this to see what I mean:

```
curl -vI http://en.wikipedia.org/wiki/Spanish_language |& grep '^[<>]'
```

This patch helps us deal with those websites, and speeds things up, at least on Python 3.2 and up. Previous versions [don't support GzipFile streaming](http://bugs.python.org/issue11608), so we read the whole file to a StringIO before decoding with GzipFile.
