### PR TITLE
Position and size text decorations with font metrics

### DIFF
--- a/weasyprint/draw.py
+++ b/weasyprint/draw.py
@@ -666,28 +666,39 @@ def draw_text(context, textbox, enable_hinting):
     context.set_source_rgba(*textbox.style.color)
     show_first_line(context, textbox.pango_layout, enable_hinting)
     values = textbox.style.text_decoration
+
+    metrics = textbox.pango_layout.get_font_metrics()
+    thickness = textbox.style.font_size / 18
+    if enable_hinting and thickness < 1:
+        thickness = 1
+
     if 'overline' in values:
         draw_text_decoration(
             context, textbox,
-            textbox.baseline - 0.15 * textbox.style.font_size,
+            textbox.baseline - metrics.ascent + thickness / 2,
+            thickness,
             enable_hinting)
     elif 'underline' in values:
         draw_text_decoration(
             context, textbox,
-            textbox.baseline + 0.15 * textbox.style.font_size,
+            textbox.baseline - metrics.underline_position + thickness / 2,
+            thickness,
             enable_hinting)
     elif 'line-through' in values:
-        draw_text_decoration(context, textbox, textbox.height * 0.5,
-                             enable_hinting)
+        draw_text_decoration(
+            context, textbox,
+            textbox.baseline - metrics.strikethrough_position,
+            thickness,
+            enable_hinting)
 
 
-def draw_text_decoration(context, textbox, offset_y, enable_hinting):
+def draw_text_decoration(context, textbox, offset_y, thickness, enable_hinting):
     """Draw text-decoration of ``textbox`` to a ``cairo.Context``."""
     with stacked(context):
         if enable_hinting:
             context.set_antialias(cairo.ANTIALIAS_NONE)
         context.set_source_rgba(*textbox.style.color)
-        context.set_line_width(1)  # TODO: make this proportional to font_size?
+        context.set_line_width(thickness)
         context.move_to(textbox.position_x, textbox.position_y + offset_y)
         context.rel_line_to(textbox.width, 0)
         context.stroke()


### PR DESCRIPTION
[The spec](http://dev.w3.org/csswg/css-text-decor-3/#line-position) asks that overlines be drawn aligned "with respect to the highest over EM-box edge" of the text. I don't know what that means, but I looked at [Firefox](http://mxr.mozilla.org/mozilla-central/source/layout/generic/nsTextFrameThebes.cpp?rev=747173e387c9#5915)'s and [Chrome](https://github.com/WebKit/webkit/blob/bd7748145a239da220a6fe6bb4b2898d65977be8/Source/WebCore/rendering/InlineTextBox.cpp#L1144)'s source code, and they use ascent of the font. Now we do too.

I took the opportunity to let Pango tell us where to place the underline and the strikethrough.

Finally, I made the decoration line width proportional to the font size, with a factor of 18. This roughly simulates Firefox's behavior on my computer, since I couldn't find the relevant code.
