### PR TITLE
fix issues #74 and #100 : trailing space crash

### DIFF
--- a/weasyprint/layout/inlines.py
+++ b/weasyprint/layout/inlines.py
@@ -678,8 +678,7 @@ def split_text_box(context, box, available_width, line_width, skip):
     assert isinstance(box, boxes.TextBox)
     font_size = box.style.font_size
     text = box.text[skip:]
-    no_space_left = available_width is not None and int(available_width) == 0
-    if font_size == 0 or not text or no_space_left:
+    if font_size == 0 or not text:
         return None, None, False
     # XXX ``resume_at`` is an index in UTF-8 bytes, not unicode codepoints.
     layout, length, resume_at, width, height, baseline = split_first_line(


### PR DESCRIPTION
If available width is known and equals to 0, we don't have space to write to, so return.
