### PR TITLE
Add PDF metadata parsed from HTML. Fix #77.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -34,7 +34,9 @@ Python API
 .. autofunction:: default_url_fetcher
 
 .. module:: weasyprint.document
-.. autoclass:: Document()
+.. autoclass:: Document
+    :members:
+.. autoclass:: DocumentMetadata
     :members:
 .. autoclass:: Page()
     :members:

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -130,6 +130,8 @@ See the :ref:`python-api` for details. A few random example:
     for i, page in enumerate(document.pages):
         document.copy([page]).write_png('page_%s.png' % i)
 
+.. code-block:: python
+
     # Some previous versions of WeasyPrint had a method like this:
     def get_png_pages(document):
         """Yield (png_bytes, width, height) tuples."""

--- a/weasyprint/__init__.py
+++ b/weasyprint/__init__.py
@@ -105,6 +105,9 @@ class HTML(object):
     def _ua_stylesheets(self):
         return [HTML5_UA_STYLESHEET]
 
+    def _get_metadata(self):
+        return get_html_metadata(self.root_element)
+
     def render(self, stylesheets=None, enable_hinting=False):
         """Lay out and paginate the document, but do not (yet) export it
         to PDF or another format.
@@ -305,5 +308,5 @@ def _select_source(guess=None, filename=None, url=None, file_obj=None,
 
 # Work around circular imports.
 from .css import PARSER, preprocess_stylesheet
-from .html import find_base_url, HTML5_UA_STYLESHEET
+from .html import find_base_url, HTML5_UA_STYLESHEET, get_html_metadata
 from .document import Document, Page

--- a/weasyprint/css/__init__.py
+++ b/weasyprint/css/__init__.py
@@ -151,6 +151,15 @@ class StyleDict(object):
     anonymous = False
 
 
+def get_child_text(element):
+    """Return the text directly in the element, not descendants."""
+    content = [element.text] if element.text else []
+    for child in element:
+        if child.tail:
+            content.append(child.tail)
+    return ''.join(content)
+
+
 def find_stylesheets(element_tree, device_media_type, url_fetcher):
     """Yield the stylesheets in ``element_tree``.
 
@@ -169,10 +178,7 @@ def find_stylesheets(element_tree, device_media_type, url_fetcher):
         if element.tag == 'style':
             # Content is text that is directly in the <style> element, not its
             # descendants
-            content = [element.text or '']
-            for child in element:
-                content.append(child.tail or '')
-            content = ''.join(content)
+            content = get_child_text(element)
             # lxml should give us either unicode or ASCII-only bytestrings, so
             # we don't need `encoding` here.
             css = CSS(string=content, base_url=element_base_url(element),

--- a/weasyprint/document.py
+++ b/weasyprint/document.py
@@ -99,7 +99,11 @@ class _TaggedTuple(tuple):
     """
 
 
-def _get_metadata(box, bookmarks, links, anchors, matrix):
+def _gather_links_and_bookmarks(box, bookmarks, links, anchors, matrix):
+    transform = _get_matrix(box)
+    if transform:
+        matrix = transform * matrix if matrix else transform
+
     bookmark_label = box.bookmark_label
     bookmark_level = box.bookmark_level
     link = box.style.link
@@ -130,14 +134,8 @@ def _get_metadata(box, bookmarks, links, anchors, matrix):
         if has_anchor:
             anchors[anchor_name] = pos_x, pos_y
 
-
-def _prepare(box, bookmarks, links, anchors, matrix):
-    transform = _get_matrix(box)
-    if transform:
-        matrix = transform * matrix if matrix else transform
-    _get_metadata(box, bookmarks, links, anchors, matrix)
     for child in box.all_children():
-        _prepare(child, bookmarks, links, anchors, matrix)
+        _gather_links_and_bookmarks(child, bookmarks, links, anchors, matrix)
 
 
 class Page(object):
@@ -169,15 +167,18 @@ class Page(object):
         #:
         #: * ``'external'``: :obj:`target` is an absolute URL
         #: * ``'internal'``: :obj:`target` is an anchor name (see
-        #:   :attr:`Page.anchors`). The anchor might be defined in
-        #:   another page, in multiple pages, or not at all.
+        #:   :attr:`Page.anchors`).
+        #    The anchor might be defined in another page,
+        #    in multiple pages (in which case the first occurence is used),
+        #    or not at all.
         self.links = links = []
 
         #: A dict mapping anchor names to their target, ``(x, y)`` points
         #: in CSS pixels form the top-left of the page.)
         self.anchors = anchors = {}
 
-        _prepare(page_box, bookmarks, links, anchors, matrix=None)
+        _gather_links_and_bookmarks(
+            page_box, bookmarks, links, anchors, matrix=None)
         self._page_box = page_box
         self._enable_hinting = enable_hinting
 
@@ -235,14 +236,61 @@ class Page(object):
             draw_page(self._page_box, cairo_context, self._enable_hinting)
 
 
+class DocumentMetadata(object):
+    """Contains meta-information about a :class:`Document`
+    that do not belong to specific pages but to the whole document.
+
+    New attributes may be added in future versions of WeasyPrint.
+
+    .. _W3C’s profile of ISO 8601: http://www.w3.org/TR/NOTE-datetime
+
+    """
+    def __init__(self, title=None, authors=None, description=None,
+                 keywords=None, generator=None, created=None, modified=None):
+        #: The title of the document, as a string or :obj:`None`.
+        #: Extracted from the ``<title>`` element in HTML
+        #: and written to the ``/Title`` info field in PDF.
+        self.title = title
+        #: The authors of the document as a list of strings.
+        #: Extracted from the ``<meta name=author>`` elements in HTML
+        #: and written to the ``/Author`` info field in PDF.
+        self.authors = authors or []
+        #: The description of the document, as a string or :obj:`None`.
+        #: Extracted from the ``<meta name=description>`` element in HTML
+        #: and written to the ``/Subject`` info field in PDF.
+        self.description = description
+        #: Keywords associated with the document, as a list of strings.
+        #: (Defaults to the empty list.)
+        #: Extracted from ``<meta name=keywords>`` elements in HTML
+        #: and written to the ``/Keywords`` info field in PDF.
+        self.keywords = keywords or []
+        #: The name of one of the software packages
+        #: used to generate the document, as a string or :obj:`None`.
+        #: Extracted from the ``<meta name=generator>`` element in HTML
+        #: and written to the ``/Creator`` info field in PDF.
+        self.generator = generator
+        #: The creation date of the document, as a string or :obj:`None`.
+        #: Dates are in one of the six formats specified in
+        #: `W3C’s profile of ISO 8601`_.
+        #: Extracted from the ``<meta name=dcterms.created>`` element in HTML
+        #: and written to the ``/CreationDate`` info field in PDF.
+        self.created = created
+        #: The modification date of the document, as a string or :obj:`None`.
+        #: Dates are in one of the six formats specified in
+        #: `W3C’s profile of ISO 8601`_.
+        #: Extracted from the ``<meta name=dcterms.modified>`` element in HTML
+        #: and written to the ``/ModDate`` info field in PDF.
+        self.modified = modified
+
+
 class Document(object):
     """A rendered document, with access to individual pages
     ready to be painted on any cairo surfaces.
 
-    .. versionadded:: 0.15
-
-    Should be obtained from :meth:`HTML.render() <weasyprint.HTML.render>`
-    but not instantiated directly.
+    Typically obtained from :meth:`HTML.render() <weasyprint.HTML.render>`,
+    but can also be instantiated directly
+    with a list of :class:`pages <Page>`
+    and a set of :class:`metadata <DocumentMetadata>`.
 
     """
     @classmethod
@@ -257,11 +305,16 @@ class Document(object):
             enable_hinting, style_for, get_image_from_uri,
             build_formatting_structure(
                 html.root_element, style_for, get_image_from_uri))
-        return cls([Page(p, enable_hinting) for p in page_boxes])
+        return cls([Page(p, enable_hinting) for p in page_boxes],
+                   DocumentMetadata(**html._get_metadata()))
 
-    def __init__(self, pages):
+    def __init__(self, pages, metadata):
         #: A list of :class:`Page` objects.
         self.pages = pages
+        #: A :class:`DocumentMetadata` object.
+        #: Contains information that does not belong to a specific page
+        #: but to the whole document.
+        self.metadata = metadata
 
     def copy(self, pages='all'):
         """Take a subset of the pages.
@@ -296,7 +349,7 @@ class Document(object):
             pages = self.pages
         elif not isinstance(pages, list):
             pages = list(pages)
-        return type(self)(pages)
+        return type(self)(pages, self.metadata)
 
     def resolve_links(self):
         """Resolve internal hyperlinks.
@@ -413,7 +466,7 @@ class Document(object):
             surface.show_page()
         surface.finish()
 
-        write_pdf_metadata(self, file_obj, scale)
+        write_pdf_metadata(self, file_obj, scale, self.metadata)
 
         if target is None:
             return file_obj.getvalue()

--- a/weasyprint/tests/test_api.py
+++ b/weasyprint/tests/test_api.py
@@ -928,10 +928,63 @@ def test_url_fetcher():
     with capture_logs() as logs:
         test('<body><img src="custom:foo/bar">', blank=True)
     assert len(logs) == 1
-    assert logs[0].startswith('WARNING: Failed to load image at custom:foo/bar')
+    assert logs[0].startswith(
+        'WARNING: Failed to load image at custom:foo/bar')
 
     def fetcher_2(url):
         assert url == 'weasyprint-custom:%C3%A9_%e9.css'
         return dict(string='', mime_type='text/css')
     TestHTML(string='<link rel=stylesheet href="weasyprint-custom:'
                     'é_%e9.css"><body>', url_fetcher=fetcher_2).render()
+
+
+@assert_no_logs
+def test_html_meta():
+    def assert_meta(html, **meta):
+        meta.setdefault('title', None)
+        meta.setdefault('authors', [])
+        meta.setdefault('keywords', [])
+        meta.setdefault('generator', None)
+        meta.setdefault('description', None)
+        meta.setdefault('created', None)
+        meta.setdefault('modified', None)
+        assert vars(TestHTML(string=html).render().metadata) == meta
+
+    assert_meta('<body>')
+    assert_meta(
+        '''
+            <meta name=author content="I Me &amp; Myself">
+            <meta name=author content="Smith, John">
+            <title>Test document</title>
+            <h1>Another title</h1>
+            <meta name=generator content="Human after all">
+            <meta name=dummy content=ignored>
+            <meta name=dummy>
+            <meta content=ignored>
+            <meta>
+            <meta name=keywords content="html ,	css,
+                                         pdf,css">
+            <meta name=dcterms.created content=2011-04>
+            <meta name=dcterms.created content=2011-05>
+            <meta name=dcterms.modified content=2013>
+            <meta name=keywords content="Python; cairo">
+            <meta name=description content="Blah… ">
+        ''',
+        authors=['I Me & Myself', 'Smith, John'],
+        title='Test document',
+        generator='Human after all',
+        keywords=['html', 'css', 'pdf', 'Python; cairo'],
+        description="Blah… ",
+        created='2011-04',
+        modified='2013')
+    assert_meta(
+        '''
+            <title>One</title>
+            <meta name=Author>
+            <title>Two</title>
+            <title>Three</title>
+            <meta name=author content=Me>
+        ''',
+        title='One',
+        authors=['', 'Me'])
+

--- a/weasyprint/tests/test_pdf.py
+++ b/weasyprint/tests/test_pdf.py
@@ -1,9 +1,9 @@
 # coding: utf8
 """
-    weasyprint.tests.test_metadata
-    ------------------------------
+    weasyprint.tests.test_pdf
+    -------------------------
 
-    Test metadata of the document (bookmarks and hyperlinks).
+    Test PDF-related code, including metadata, bookmarks and hyperlinks.
 
     :copyright: Copyright 2011-2013 Simon Sapin and contributors, see AUTHORS.
     :license: BSD, see LICENSE for details.
@@ -308,3 +308,29 @@ def test_jpeg():
     assert b'/Filter /DCTDecode' not in render('<img src="pattern.gif">')
     # JPEG-encoded image, embedded in PDF:
     assert b'/Filter /DCTDecode' in render('<img src="blue.jpg">')
+
+
+@assert_no_logs
+def test_document_info():
+    pdf_bytes = TestHTML(string='''
+        <meta name=author content="I Me &amp; Myself">
+        <title>Test document</title>
+        <h1>Another title</h1>
+        <meta name=generator content="Human after all">
+        <meta name=keywords content="html ,	css,
+                                     pdf,css">
+        <meta name=description content="Blah… ">
+        <meta name=dcterms.created content=2011-04>
+        <meta name=dcterms.modified content=2013-07-21T23:46+01:00>
+    ''').write_pdf()
+    assert (b'/Author (\xfe\xff\x00I\x00 \x00M\x00e\x00 \x00&\x00 \x00'
+            b'M\x00y\x00s\x00e\x00l\x00f)' in pdf_bytes)
+    assert (b'/Title (\xfe\xff\x00T\x00e\x00s\x00t\x00 \x00d\x00o\x00c'
+            b'\x00u\x00m\x00e\x00n\x00t)' in pdf_bytes)
+    assert (b'/Creator (\xfe\xff\x00H\x00u\x00m\x00a\x00n\x00\xa0\x00a'
+            b'\x00f\x00t\x00e\x00r\x00\xa0\x00a\x00l\x00l)' in pdf_bytes)
+    assert (b'/Keywords (\xfe\xff\x00h\x00t\x00m\x00l\x00,\x00 '
+            b'\x00c\x00s\x00s\x00,\x00 \x00p\x00d\x00f)' in pdf_bytes)
+    assert b'/Subject (\xfe\xff\x00B\x00l\x00a\x00h &\x00 )' in pdf_bytes
+    assert b'/CreationDate (D:201104)' in pdf_bytes
+    assert b"/ModDate (D:20130721234600+01'00')" in pdf_bytes


### PR DESCRIPTION
`<title>` → /Title
`<meta name=author>` → /Author
`<meta name=description>` → /Subject
`<meta name=keywords>` → /Keywords
`<meta name=generator>` → /Creator
`<meta name=dcterms.created>` → /CreationDate
`<meta name=dcterms.modified>` → /ModDate
"WeasyPrint vX.Y" → /Producer
