### PR TITLE
Switch to html5lib to parse HTML. Fix #12.

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -8,6 +8,7 @@ WeasyPrint |version| depends on:
 * Pango_
 * CFFI_ ≥ 0.5
 * lxml_
+* html5lib ≥ 1.0b3
 * cairocffi_ ≥ 0.3
 * tinycss_ = 0.3
 * cssselect_ ≥ 0.6

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ LONG_DESCRIPTION = open(path.join(path.dirname(__file__), 'README')).read()
 REQUIREMENTS = [
     # XXX: Keep this in sync with docs/install.rst
     'lxml',
+    'html5lib>=1.0b3',
     'tinycss==0.3',
     'cssselect>=0.6',
     'CairoSVG>=0.4.1',

--- a/weasyprint/css/tests_ua.css
+++ b/weasyprint/css/tests_ua.css
@@ -10,16 +10,16 @@ br:before       { content: '\A'; white-space: pre-line }
 ol              { list-style-type: decimal }
 ol, ul          { counter-reset: list-item }
 
-table           { display: table;
+table, x-table  { display: table;
                   box-sizing: border-box }
-tr              { display: table-row }
-thead           { display: table-header-group }
-tbody           { display: table-row-group }
-tfoot           { display: table-footer-group }
-col             { display: table-column }
-colgroup        { display: table-column-group }
-td, th          { display: table-cell }
-caption         { display: table-caption }
+tr, x-tr        { display: table-row }
+thead, x-thead  { display: table-header-group }
+tbody, x-tbody  { display: table-row-group }
+tfoot, x-tfoot  { display: table-footer-group }
+col, x-col      { display: table-column }
+colgroup, x-colgroup { display: table-column-group }
+td, th, x-td, x-th   { display: table-cell }
+caption, x-caption   { display: table-caption }
 
 *[lang] { -weasy-lang: attr(lang); }
 a[href] { -weasy-link: attr(href); }

--- a/weasyprint/tests/test_layout.py
+++ b/weasyprint/tests/test_layout.py
@@ -1411,7 +1411,7 @@ def test_page_breaks():
             body { margin: 0 }
             div { height: 30px }
         </style>
-        <div/><div/><div/><div/><div/>
+        <div></div><div></div><div></div><div></div><div></div>
     ''')
     page_divs = []
     for page in pages:
@@ -2603,10 +2603,10 @@ def test_text_align_justify():
             @page { size: 300px 1000px }
             body { text-align: justify }
         </style>
-        <p><img src="pattern.png" style="width: 40px"> &#20;
+        <p><img src="pattern.png" style="width: 40px">
             <strong>
-                <img src="pattern.png" style="width: 60px"> &#20;
-                <img src="pattern.png" style="width: 10px"> &#20;
+                <img src="pattern.png" style="width: 60px">
+                <img src="pattern.png" style="width: 10px">
                 <img src="pattern.png" style="width: 100px"
             ></strong><img src="pattern.png" style="width: 290px"
             ><!-- Last image will be on its own line. -->''')
@@ -2655,8 +2655,7 @@ def test_word_spacing():
     # (Not a string.)
     page, = parse('''
         <style></style>
-        <body><strong>Lorem ipsum dolor<em>sit amet</em></strong></body>
-    ''')
+        <body><strong>Lorem ipsum dolor<em>sit amet</em></strong>''')
     html, = page.children
     body, = html.children
     line, = body.children
@@ -2667,8 +2666,7 @@ def test_word_spacing():
     # of a TextBox. Is this what we want?
     page, = parse('''
         <style>strong { word-spacing: 11px }</style>
-        <body><strong>Lorem ipsum dolor<em>sit amet</em></strong></body>
-    ''')
+        <body><strong>Lorem ipsum dolor<em>sit amet</em></strong>''')
     html, = page.children
     body, = html.children
     line, = body.children
@@ -2680,8 +2678,7 @@ def test_word_spacing():
 def test_letter_spacing():
     """Test letter-spacing."""
     page, = parse('''
-        <body><strong>Supercalifragilisticexpialidocious</strong></body>
-    ''')
+        <body><strong>Supercalifragilisticexpialidocious</strong>''')
     html, = page.children
     body, = html.children
     line, = body.children
@@ -2690,8 +2687,7 @@ def test_letter_spacing():
 
     page, = parse('''
         <style>strong { letter-spacing: 11px }</style>
-        <body><strong>Supercalifragilisticexpialidocious</strong></body>
-    ''')
+        <body><strong>Supercalifragilisticexpialidocious</strong>''')
     html, = page.children
     body, = html.children
     line, = body.children
@@ -2851,8 +2847,8 @@ def test_table_column_width():
     with capture_logs() as logs:
         page, = parse(source)
     assert len(logs) == 1
-    assert logs[0] == ('WARNING: This table row has more columns than '
-                       'the table, ignored 1 cells: (<TableCellBox td 25>,)')
+    assert logs[0].startswith('WARNING: This table row has more columns than '
+                              'the table, ignored 1 cell')
     html, = page.children
     body, = html.children
     wrapper, = body.children
@@ -2975,8 +2971,8 @@ def test_table_row_height():
             <tr>
                 <td rowspan=0 style="height: 420px; vertical-align: top"></td>
                 <td>X<br>X<br>X</td>
-                <td><table style="margin-top: 20px;
-                                  border-spacing: 0">X</table></td>
+                <td><table style="margin-top: 20px; border-spacing: 0">
+                    <tr><td>X</td></tr></table></td>
                 <td style="vertical-align: top">X</td>
                 <td style="vertical-align: middle">X</td>
                 <td style="vertical-align: bottom">X</td>

--- a/weasyprint/tests/test_stacking.py
+++ b/weasyprint/tests/test_stacking.py
@@ -21,14 +21,10 @@ def to_lists(page):
     return serialize_stacking(StackingContext.from_box(html, page))
 
 
-def serialize_box(box):
-    return '%s %s' % (box.element_tag, box.sourceline)
-
-
 def serialize_stacking(context):
     return (
-        serialize_box(context.box),
-        [serialize_box(b) for b in context.blocks_and_cells],
+        context.box.element_tag,
+        [b.element_tag for b in context.blocks_and_cells],
         [serialize_stacking(c) for c in context.zero_z_contexts],
     )
 
@@ -39,14 +35,14 @@ def test_nested():
         <p id=lorem></p>
         <div style="position: relative">
             <p id=lipsum></p>
-        </p>
+        </div>
     ''')
     assert to_lists(page) == (
-        'html 1',
-        ['body 1', 'p 1'],
+        'html',
+        ['body', 'p'],
         [(
-            'div 2',
-            ['p 3'],
+            'div',
+            ['p'],
             [])])
 
     page, = parse('''\
@@ -55,10 +51,10 @@ def test_nested():
         </div>
     ''')
     assert to_lists(page) == (
-        'html 1',
-        ['body 1'],
-        [('div 1', [], []),  # In this order
-         ('p 2', [], [])])
+        'html',
+        ['body'],
+        [('div', [], []),  # In this order
+         ('p', [], [])])
 
 
 @assert_no_logs


### PR DESCRIPTION
Recent html5lib versions run on Python 3.x and 2.x with the same code base; and I discovered the existence of the `namespaceHTMLElements` parameter that can be set to `False` to work around cssselect’s namespace issues described in #12.

… so nothing blocks WeasyPrint from using it anymore. This HTML parser is much closer to what web browsers do (Yay standards!), easier to upgrade (pure Python), and is generally less buggy. (See #65 for example.)

Rather than adding API to choose between parsers, this patch goes with simplicity and always uses html5lib. If a user really want libxml2’s parser for some reason, they can pass a parsed tree to `weasyprint.HTML(tree=…)`.

html5lib is much slower at parsing than libxml2, but the difference is dominated by the time taken by the rest of WeasyPrint. Quick unscientific testing shows a 2~5% slow-down on my machine, which seems acceptable.

Before this is merged, I’d like to get feedback from users on real documents:
- Is the performance acceptable?
- Does this break something? Is it easy to fix?

The recommended way to try this branch is to run this in a virtualenv:

```
pip uninstall WeasyPrint
pip install git+https://github.com/Kozea/WeasyPrint.git@html5lib
```

If you pull this branch in a long-lived repository, be advised that I may rebase it amend it as long as it is not merged into master.
