### PR TITLE
Add 'image-resolution' from css-images-3.

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -126,7 +126,7 @@ as invalid with ``*``.
 .. _hyphenation:
 
 CSS Text: hyphenation
-~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~
 
 
 The experimental_ ``-weasy-hyphens`` property controls hyphenation
@@ -185,8 +185,11 @@ The following features are supported:
 * `CSS Transforms`_ (2D only)
 * The background part of `CSS Backgrounds and Borders Level 3`_,
   including multiple background layers per element/box.
-* ``linear-gradient()`` and ``radial-gradient()`` (as background images)
-  from `CSS Images Level 3`_
+* ``linear-gradient()`` and ``radial-gradient()`` (as background images),
+  from `CSS Images Level 3`_.
+* The ``image-resolution`` property from `CSS Images Level 3`_.
+  The ``snap`` and ``from-image`` values are not supported yet,
+  so the property only takes a single ``<resolution>`` value.
 * The ``box-sizing`` property from `CSS Basic User Interface`_:
 
 .. _CSS Colors Level 3: http://www.w3.org/TR/css3-color/

--- a/weasyprint/css/properties.py
+++ b/weasyprint/css/properties.py
@@ -137,6 +137,9 @@ INITIAL_VALUES = {
     # http://www.w3.org/TR/SVG/painting.html#ImageRenderingProperty
     'image_rendering': 'auto',
 
+    # http://www.w3.org/TR/css3-images/#the-image-resolution
+    'image_resolution': 1,  # dppx
+
     # Proprietary
     'anchor': None,  # computed value of 'none'
     'link': None,  # computed value of 'none'
@@ -231,6 +234,7 @@ INHERITED = set("""
     hyphenate_limit_chars
     hyphenate_limit_zone
     image_rendering
+    image_resolution
     lang
     link
 """.split())

--- a/weasyprint/css/validation.py
+++ b/weasyprint/css/validation.py
@@ -195,8 +195,23 @@ ANGLE_TO_RADIANS = {
 
 
 def get_angle(token):
-    """Return whether the argument is an angle token."""
+    """Return the value in radians of an <angle> token, or None."""
     factor = ANGLE_TO_RADIANS.get(token.unit)
+    if factor is not None:
+        return token.value * factor
+
+
+# http://dev.w3.org/csswg/css-values/#resolution
+RESOLUTION_TO_DPPX = {
+    'dppx': 1,
+    'dpi': 1 / computed_values.LENGTHS_TO_PIXELS['in'],
+    'dpcm': 1 / computed_values.LENGTHS_TO_PIXELS['cm'],
+}
+
+
+def get_resolution(token):
+    """Return the value in dppx of a <resolution> token, or None."""
+    factor = RESOLUTION_TO_DPPX.get(token.unit)
     if factor is not None:
         return token.value * factor
 
@@ -840,6 +855,13 @@ def font_weight(token):
     if token.type == 'INTEGER':
         if token.value in [100, 200, 300, 400, 500, 600, 700, 800, 900]:
             return token.value
+
+
+@validator()
+@single_token
+def image_resolution(token):
+    # TODO: support 'snap' and 'from-image'
+    return get_resolution(token)
 
 
 @validator('letter-spacing')

--- a/weasyprint/layout/backgrounds.py
+++ b/weasyprint/layout/backgrounds.py
@@ -72,7 +72,7 @@ def layout_box_backgrounds(page, box, get_image_from_uri):
 
     box.background = Background(
         color=color, image_rendering=style.image_rendering, layers=[
-            layout_background_layer(box, page, *layer)
+            layout_background_layer(box, page, style.image_resolution, *layer)
             for layer in zip(images, *map(cycle, [
                 style.background_size,
                 style.background_clip,
@@ -93,8 +93,8 @@ def percentage(value, refer_to):
         return refer_to * value.value / 100
 
 
-def layout_background_layer(box, page, image, size, clip, repeat, origin,
-                            position, attachment):
+def layout_background_layer(box, page, resolution, image, size, clip, repeat,
+                            origin, position, attachment):
 
     if box is not page:
         painting_area = box_rectangle(box, clip)
@@ -110,8 +110,7 @@ def layout_background_layer(box, page, image, size, clip, repeat, origin,
         # XXX: how does border-radius work on pages?
         rounded_box = box.rounded_border_box()
 
-    if (image is None or image.intrinsic_width == 0
-            or image.intrinsic_height == 0):
+    if image is None or 0 in image.get_intrinsic_size(1):
         return BackgroundLayer(
             image=None, unbounded=(box is page), painting_area=painting_area,
             size='unused', position='unused', repeat='unused',
@@ -136,9 +135,9 @@ def layout_background_layer(box, page, image, size, clip, repeat, origin,
             positioning_width, positioning_height, image.intrinsic_ratio)
     else:
         size_width, size_height = size
+        iwidth, iheight = image.get_intrinsic_size(resolution)
         image_width, image_height = replaced.default_image_sizing(
-            image.intrinsic_width, image.intrinsic_height,
-            image.intrinsic_ratio,
+            iwidth, iheight, image.intrinsic_ratio,
             percentage(size_width, positioning_width),
             percentage(size_height, positioning_height),
             positioning_width, positioning_height)

--- a/weasyprint/layout/inlines.py
+++ b/weasyprint/layout/inlines.py
@@ -17,7 +17,8 @@ from .float import avoid_collisions, float_layout
 from .replaced import image_marker_layout
 from .min_max import handle_min_max_width, handle_min_max_height
 from .percentages import resolve_percentages, resolve_one_percentage
-from .preferred import shrink_to_fit, inline_preferred_minimum_width, trailing_whitespace_size
+from .preferred import (shrink_to_fit, inline_preferred_minimum_width,
+                        trailing_whitespace_size)
 from .tables import find_in_flow_baseline, table_wrapper_width
 from ..text import split_first_line
 from ..formatting_structure import boxes
@@ -248,8 +249,8 @@ def replaced_box_width(box, device_size):
     Compute and set the used width for replaced boxes (inline- or block-level)
     """
     # http://www.w3.org/TR/CSS21/visudet.html#inline-replaced-width
-    intrinsic_width = box.replacement.intrinsic_width
-    intrinsic_height = box.replacement.intrinsic_height
+    intrinsic_width, intrinsic_height = box.replacement.get_intrinsic_size(
+        box.style.image_resolution)
     # TODO: update this when we have replaced elements that do not
     # always have an intrinsic width. (See commented code below.)
     assert intrinsic_width is not None
@@ -297,8 +298,8 @@ def replaced_box_height(box, device_size):
     Compute and set the used height for replaced boxes (inline- or block-level)
     """
     # http://www.w3.org/TR/CSS21/visudet.html#inline-replaced-height
-    intrinsic_width = box.replacement.intrinsic_width
-    intrinsic_height = box.replacement.intrinsic_height
+    intrinsic_width, intrinsic_height = box.replacement.get_intrinsic_size(
+        box.style.image_resolution)
     # TODO: update this when we have replaced elements that do not
     # always have intrinsic dimensions. (See commented code below.)
     assert intrinsic_width is not None

--- a/weasyprint/layout/preferred.py
+++ b/weasyprint/layout/preferred.py
@@ -472,7 +472,8 @@ def replaced_preferred_width(box, outer=True):
     """Return the preferred minimum width for an ``InlineReplacedBox``."""
     width = box.style.width
     if width == 'auto' or width.unit == '%':
-        width = box.replacement.intrinsic_width
+        width, _ = box.replacement.get_intrinsic_size(
+            box.style.image_resolution)
         # TODO: handle the images with no intinsic width
         assert width is not None
     else:

--- a/weasyprint/layout/replaced.py
+++ b/weasyprint/layout/replaced.py
@@ -23,9 +23,10 @@ def image_marker_layout(box):
     """
     image = box.replacement
     one_em = box.style.font_size
+    iwidth, iheight = image.get_intrinsic_size(box.style.image_resolution)
     box.width, box.height = default_image_sizing(
-        image.intrinsic_width, image.intrinsic_height, image.intrinsic_ratio,
-        box.width, box.height, default_width=one_em, default_height=one_em)
+        iwidth, iheight, image.intrinsic_ratio, box.width, box.height,
+        default_width=one_em, default_height=one_em)
 
 
 def default_image_sizing(intrinsic_width, intrinsic_height, intrinsic_ratio,

--- a/weasyprint/tests/test_draw.py
+++ b/weasyprint/tests/test_draw.py
@@ -1411,6 +1411,33 @@ def test_images():
     ''')
 
 
+def test_image_resolution():
+    assert_same_rendering(20, 20, [
+        ('image_resolution_ref', '''
+            <style>@page { size: 20px; margin: 2px; background: #fff }</style>
+            <div style="font-size: 0">
+                <img src="pattern.png" style="width: 8px"></div>
+        '''),
+        ('image_resolution_img', '''
+            <style>@page { size: 20px; margin: 2px; background: #fff }</style>
+            <div style="image-resolution: .5dppx; font-size: 0">
+                <img src="pattern.png"></div>
+        '''),
+        ('image_resolution_content', '''
+            <style>@page { size: 20px; margin: 2px; background: #fff }
+                   div::before { content: url(pattern.png) }
+            </style>
+            <div style="image-resolution: .5dppx; font-size: 0"></div>
+        '''),
+        ('image_resolution_background', '''
+            <style>@page { size: 20px; margin: 2px; background: #fff }
+            </style>
+            <div style="height: 16px; image-resolution: .5dppx;
+                        background: url(pattern.png) no-repeat"></div>
+        '''),
+    ])
+
+
 @assert_no_logs
 def test_visibility():
     source = '''


### PR DESCRIPTION
This is the only way to use high-resolution images in the 'content' property, where individual images can not be selected to use the 'width' or 'height' properties.
