### PR TITLE
Add mention about shared-mime-data

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -109,7 +109,7 @@ Debian 7.0 Wheezy or newer, Ubuntu 11.10 Oneiric or newer:
 
 .. code-block:: sh
 
-    sudo apt-get install python-dev python-pip python-lxml libcairo2 libpango1.0-0 libgdk-pixbuf2.0-0 libffi-dev
+    sudo apt-get install python-dev python-pip python-lxml libcairo2 libpango1.0-0 libgdk-pixbuf2.0-0 libffi-dev shared-mime-data
 
 
 Debian 6.0 Squeeze, Ubuntu 10.04 Lucid:


### PR DESCRIPTION
After about 4 hours or more of hair-pulling and fervent debugging, we discovered that (at least on Ubuntu 12.04) the  `shared-mime-data` package is required for GDK-PixBuf (and thus `cairocffi.pixbuf`) to be able to read files without throwing a cryptic "Unrecognized image file format" error.
