### PR TITLE
Explicitly specify encoding when inspecting __init__.py in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,11 +12,13 @@
 
 import re
 import sys
+import codecs
 from os import path
 from setuptools import setup, find_packages
 
-VERSION = re.search("VERSION = '([^']+)'", open(
-    path.join(path.dirname(__file__), 'weasyprint', '__init__.py')
+VERSION = re.search("VERSION = '([^']+)'", codecs.open(
+    path.join(path.dirname(__file__), 'weasyprint', '__init__.py'),
+    encoding="utf-8",
 ).read().strip()).group(1)
 
 LONG_DESCRIPTION = open(path.join(path.dirname(__file__), 'README')).read()


### PR DESCRIPTION
In Windows, open() uses system codepage by default, this caused setup to fail with UnicodeDecodeError on systems with Chinese codepage (and possibly others).
