### PR TITLE
Ubuntu package system only knows shared-mim-info.

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -111,7 +111,7 @@ Debian 7.0 Wheezy or newer, Ubuntu 11.10 Oneiric or newer:
 
 .. code-block:: sh
 
-    sudo apt-get install python-dev python-pip python-lxml libcairo2 libpango1.0-0 libgdk-pixbuf2.0-0 libffi-dev shared-mime-data
+    sudo apt-get install python-dev python-pip python-lxml libcairo2 libpango1.0-0 libgdk-pixbuf2.0-0 libffi-dev shared-mime-info
 
 
 Debian 6.0 Squeeze, Ubuntu 10.04 Lucid:


### PR DESCRIPTION
cf PR #120.
