### PR TITLE
Added more alternative names for dlopen (Mac)

### DIFF
--- a/weasyprint/text.py
+++ b/weasyprint/text.py
@@ -200,9 +200,9 @@ def dlopen(ffi, *names):
     return ffi.dlopen(names[0])  # pragma: no cover
 
 
-gobject = dlopen(ffi, 'gobject-2.0', 'libgobject-2.0-0')
-pango = dlopen(ffi, 'pango-1.0', 'libpango-1.0-0')
-pangocairo = dlopen(ffi, 'pangocairo-1.0', 'libpangocairo-1.0-0')
+gobject = dlopen(ffi, 'gobject-2.0', 'libgobject-2.0-0', 'libgobject-2.0.dylib')
+pango = dlopen(ffi, 'pango-1.0', 'libpango-1.0-0', 'libpango-1.0.dylib')
+pangocairo = dlopen(ffi, 'pangocairo-1.0', 'libpangocairo-1.0-0', 'libpangocairo-1.0.dylib')
 
 gobject.g_type_init()
 


### PR DESCRIPTION
While the installation of weasyprint via pip on OS X works without any issues, weasyprint cannot be imported. This is because dlopen'ing the appropriate libraries doesn't work without adding more alternative names to the dlopen call. The additional names have been added with this commit.
