### PR TITLE
cannot find pango, gobject, etc. libraries on some platforms

### DIFF
--- a/weasyprint/text.py
+++ b/weasyprint/text.py
@@ -200,11 +200,12 @@ def dlopen(ffi, *names):
     return ffi.dlopen(names[0])  # pragma: no cover
 
 
-gobject = dlopen(ffi, 'gobject-2.0', 'libgobject-2.0-0',
+gobject = dlopen(ffi, 'gobject-2.0', 'libgobject-2.0-0', 'libgobject-2.0.so',
                  'libgobject-2.0.dylib')
-pango = dlopen(ffi, 'pango-1.0', 'libpango-1.0-0', 'libpango-1.0.dylib')
+pango = dlopen(ffi, 'pango-1.0', 'libpango-1.0-0', 'libpango-1.0.so',
+               'libpango-1.0.dylib')
 pangocairo = dlopen(ffi, 'pangocairo-1.0', 'libpangocairo-1.0-0',
-                    'libpangocairo-1.0.dylib')
+                    'libpangocairo-1.0.so', 'libpangocairo-1.0.dylib')
 
 gobject.g_type_init()
 


### PR DESCRIPTION
This pull request adds full library names including .so, required on some platforms that compile libraries from sources (i.e within SlapOS)
