### PR TITLE
Rely on the font size for rounding bug workaround

### DIFF
--- a/weasyprint/text.py
+++ b/weasyprint/text.py
@@ -422,7 +422,7 @@ def split_first_line(text, style, hinting, max_width, line_width):
     # Increase the value a bit to compensate and not introduce
     # an unexpected line break.
     if max_width is not None:
-        max_width *= 1.0001
+        max_width += style.font_size * 0.2
     # Step #1: Get a draft layout with the first line
     layout = None
     if max_width:


### PR DESCRIPTION
Only relying on the line length is awful in real-life test cases when the font size is big and the line short (ex. titles), causing the last word of some lines to disappear.

This new workaround gives an 0.2em extra space for latest characters (instead of line-height/10000).