### PR TITLE
Support for named strings in margin-boxes

### DIFF
--- a/weasyprint/css/properties.py
+++ b/weasyprint/css/properties.py
@@ -97,8 +97,8 @@ INITIAL_VALUES = {
     'quotes': list('“”‘’'),  # depends on user agent
     'position': 'static',
     'right': 'auto',
-    #default not defined in spec http://dev.w3.org/csswg/css-gcpm/#named-strings
-    'string_set': '',
+    # http://dev.w3.org/csswg/css-gcpm/#named-strings
+    'string_set': 'none',
     'table_layout': 'auto',
     # Taken from CSS3 Text.
     # The only other supported value form CSS3 is -weasy-end.

--- a/weasyprint/css/properties.py
+++ b/weasyprint/css/properties.py
@@ -97,6 +97,8 @@ INITIAL_VALUES = {
     'quotes': list('“”‘’'),  # depends on user agent
     'position': 'static',
     'right': 'auto',
+    #default not defined in spec http://dev.w3.org/csswg/css-gcpm/#named-strings
+    'string_set': '',
     'table_layout': 'auto',
     # Taken from CSS3 Text.
     # The only other supported value form CSS3 is -weasy-end.

--- a/weasyprint/css/validation.py
+++ b/weasyprint/css/validation.py
@@ -1291,8 +1291,8 @@ def string_set(tokens):
             keyword = args[0].value.lower()
         if name != 'content':
             raise InvalidValues
-        if tokens[0].type == "IDENT"
-                and keyword in ('none', 'text', 'after', 'before'):
+        if (tokens[0].type == "IDENT"
+                and keyword in ('none', 'text', 'after', 'before')):
             return (var_name, keyword)
     elif len(tokens) and tokens[0].value == 'none':
         return 'none'

--- a/weasyprint/css/validation.py
+++ b/weasyprint/css/validation.py
@@ -685,6 +685,8 @@ def validate_content_token(base_url, token):
             style = args[-1]
             if style in ('none', 'decimal') or style in counters.STYLES:
                 return (name, args)
+        elif prototype in (('string', ['IDENT']),('string', ['IDENT', 'IDENT'])):
+            return (name, args)
 
 
 def parse_function(function_token):
@@ -1265,6 +1267,16 @@ def bookmark_level(token):
             return value
     elif get_keyword(token) == 'none':
         return 'none'
+
+
+@validator(prefixed=True)  # CSS3 GCPM, experimental
+def string_set(tokens):
+    """Validation for ``string-set``."""
+    function = parse_function(tokens[1])
+    keyword = function[1][0].value
+    name = get_keyword(tokens[0])
+    if len(tokens) == 2 and tokens[0].type == "IDENT" and keyword in ('text', 'before', 'after'):
+        return ('keyword', keyword, 'name', name)
 
 
 @validator(unprefixed=True)

--- a/weasyprint/css/validation.py
+++ b/weasyprint/css/validation.py
@@ -1291,7 +1291,7 @@ def string_set(tokens):
             keyword = args[0].value.lower()
         if name != 'content':
             raise InvalidValues
-        if tokens[0].type == "IDENT" and keyword in ('none', 'text'):
+        if tokens[0].type == "IDENT" and keyword in ('none', 'text', 'after', 'before'):
             return (var_name, keyword)
     elif len(tokens) and tokens[0].value == 'none':
         return 'none'

--- a/weasyprint/css/validation.py
+++ b/weasyprint/css/validation.py
@@ -686,7 +686,8 @@ def validate_content_token(base_url, token):
             style = args[-1]
             if style in ('none', 'decimal') or style in counters.STYLES:
                 return (name, args)
-        elif prototype in (('string', ['IDENT']),('string', ['IDENT', 'IDENT'])):
+        elif prototype in (('string', ['IDENT']),
+                           ('string', ['IDENT', 'IDENT'])):
             if len(args) > 1:
                 args[1] = args[1].lower()
                 if args[1] not in ('first', 'start', 'last', 'first-except'):

--- a/weasyprint/css/validation.py
+++ b/weasyprint/css/validation.py
@@ -1272,11 +1272,18 @@ def bookmark_level(token):
 @validator(prefixed=True)  # CSS3 GCPM, experimental
 def string_set(tokens):
     """Validation for ``string-set``."""
+    if len(tokens) != 2:
+        raise InvalidValues("Only one value is supported. Received %s" %len(tokens)-1)
     function = parse_function(tokens[1])
-    keyword = function[1][0].value
-    name = get_keyword(tokens[0])
-    if len(tokens) == 2 and tokens[0].type == "IDENT" and keyword in ('text', 'before', 'after'):
-        return ('keyword', keyword, 'name', name)
+    if function is None:
+        keyword = 'text'
+    else:
+        name, args = function
+        keyword = args[0].value
+    var_name = get_keyword(tokens[0])
+    if tokens[0].type == "IDENT" and keyword in ('text', 'before', 'after'):
+        return ('keyword', keyword, 'name', var_name)
+    raise InvalidValues
 
 
 @validator(unprefixed=True)

--- a/weasyprint/css/validation.py
+++ b/weasyprint/css/validation.py
@@ -1291,7 +1291,8 @@ def string_set(tokens):
             keyword = args[0].value.lower()
         if name != 'content':
             raise InvalidValues
-        if tokens[0].type == "IDENT" and keyword in ('none', 'text', 'after', 'before'):
+        if tokens[0].type == "IDENT"
+                and keyword in ('none', 'text', 'after', 'before'):
             return (var_name, keyword)
     elif len(tokens) and tokens[0].value == 'none':
         return 'none'

--- a/weasyprint/formatting_structure/build.py
+++ b/weasyprint/formatting_structure/build.py
@@ -154,6 +154,7 @@ def element_to_box(element, style_for, get_image_from_uri, state=None):
     text = element.text
     if text:
         children.append(boxes.TextBox.anonymous_from(box, text))
+
     for child_element in element:
         children.extend(element_to_box(
             child_element, style_for, get_image_from_uri, state))
@@ -211,7 +212,7 @@ def pseudo_to_box(element, pseudo_type, state, style_for, get_image_from_uri):
 
 
 def content_to_boxes(style, parent_box, quote_depth, counter_values,
-                     get_image_from_uri):
+                     get_image_from_uri, context=None):
     """Takes the value of a ``content`` property and yield boxes."""
     texts = []
     for type_, value in style.content:
@@ -235,6 +236,10 @@ def content_to_boxes(style, parent_box, quote_depth, counter_values,
                 counters.format(counter_value, counter_style)
                 for counter_value in counter_values.get(counter_name, [0])
             ))
+        elif type_ == 'string':
+            text = context.get_string_set_for(*tuple(value))
+            texts.append(text)
+            string_set = value
         else:
             assert type_ == 'QUOTE'
             is_open, insert = value

--- a/weasyprint/formatting_structure/build.py
+++ b/weasyprint/formatting_structure/build.py
@@ -1114,8 +1114,8 @@ def box_text_content_before(box):
 def box_text_content_after(box):
     if isinstance(box, boxes.ParentBox):
         return ''.join(
-            box_text_contents(child) for child in box.descendants()
-            if child.element_tag.endswith(':after') and not isinstance(child, boxes.ParentBox))
+            box_text_contents(child) for child in box.children
+            if child.element_tag.endswith(':after'))
     else:
         return ''
 

--- a/weasyprint/formatting_structure/build.py
+++ b/weasyprint/formatting_structure/build.py
@@ -1107,8 +1107,9 @@ def box_text_content_element(box):
 def box_text_content_before(box):
     if isinstance(box, boxes.ParentBox):
         return ''.join(
-            box_text_contents(child) for child in box.children
-            if child.element_tag.endswith(':before'))
+            box_text_contents(child) for child in box.descendants()
+            if child.element_tag.endswith(':before')
+            and not isinstance(child, boxes.ParentBox))
     else:
         return ''
 
@@ -1116,8 +1117,9 @@ def box_text_content_before(box):
 def box_text_content_after(box):
     if isinstance(box, boxes.ParentBox):
         return ''.join(
-            box_text_contents(child) for child in box.children
-            if child.element_tag.endswith(':after'))
+            box_text_contents(child) for child in box.descendants()
+            if child.element_tag.endswith(':after')
+            and not isinstance(child, boxes.ParentBox))
     else:
         return ''
 
@@ -1127,7 +1129,9 @@ TEXT_CONTENT_EXTRACTORS = {
     'content-element': box_text_content_element,
     'content-before': box_text_content_before,
     'content-after': box_text_content_after,
-    'text': box_text_contents}
+    'text': box_text_contents,
+    'before': box_text_content_before,
+    'after': box_text_content_after}
 
 
 def resolve_bookmark_labels(box):

--- a/weasyprint/formatting_structure/build.py
+++ b/weasyprint/formatting_structure/build.py
@@ -239,7 +239,6 @@ def content_to_boxes(style, parent_box, quote_depth, counter_values,
         elif type_ == 'string':
             text = context.get_string_set_for(*tuple(value))
             texts.append(text)
-            string_set = value
         else:
             assert type_ == 'QUOTE'
             is_open, insert = value
@@ -1115,8 +1114,8 @@ def box_text_content_before(box):
 def box_text_content_after(box):
     if isinstance(box, boxes.ParentBox):
         return ''.join(
-            box_text_contents(child) for child in box.children
-            if child.element_tag.endswith(':after'))
+            box_text_contents(child) for child in box.descendants()
+            if child.element_tag.endswith(':after') and not isinstance(child, boxes.ParentBox))
     else:
         return ''
 

--- a/weasyprint/formatting_structure/build.py
+++ b/weasyprint/formatting_structure/build.py
@@ -236,8 +236,8 @@ def content_to_boxes(style, parent_box, quote_depth, counter_values,
                 counters.format(counter_value, counter_style)
                 for counter_value in counter_values.get(counter_name, [0])
             ))
-        elif type_ == 'string':
-            text = context.get_string_set_for(*tuple(value))
+        elif type_ == 'string' and context is not None:
+            text = context.get_string_set_for(*value)
             texts.append(text)
         else:
             assert type_ == 'QUOTE'
@@ -1088,7 +1088,9 @@ def box_text_contents(box):
     if isinstance(box, boxes.TextBox):
         return box.text
     elif isinstance(box, boxes.ParentBox):
-        return ''.join(box_text_contents(child) for child in box.children)
+        return ''.join(
+            child.text for child in box.descendants()
+            if isinstance(child, boxes.TextBox))
     else:
         return ''
 
@@ -1124,7 +1126,8 @@ TEXT_CONTENT_EXTRACTORS = {
     'contents': box_text_contents,
     'content-element': box_text_content_element,
     'content-before': box_text_content_before,
-    'content-after': box_text_content_after}
+    'content-after': box_text_content_after,
+    'text': box_text_contents}
 
 
 def resolve_bookmark_labels(box):

--- a/weasyprint/layout/__init__.py
+++ b/weasyprint/layout/__init__.py
@@ -20,6 +20,7 @@
 """
 from __future__ import division, unicode_literals
 from collections import defaultdict
+from ..compat import xrange
 
 from .absolute import absolute_box_layout
 from .pages import make_all_pages, make_margin_boxes
@@ -70,7 +71,7 @@ class LayoutContext(object):
         self.get_image_from_uri = get_image_from_uri
         self._excluded_shapes_lists = []
         self.excluded_shapes = None  # Not initialized yet
-        self.string_set = defaultdict(lambda:defaultdict(lambda:[]))
+        self.string_set = defaultdict(lambda:defaultdict(lambda:list()))
         self.current_page = None
 
     def create_block_formatting_context(self):
@@ -99,8 +100,9 @@ class LayoutContext(object):
             Value depends on current page - http://dev.w3.org/csswg/css-gcpm/#funcdef-string
 
             :param name: the name of the named string.
-            :param name: indicates which value of the named string should be used.
-                         Default is the first assignment on the current page else the most recent assignment (entry value)
+            :param keyword: indicates which value of the named string should be used.
+                            Default is the first assignment on the current page else the most
+                            recent assignment (entry value)
             :returns: text
 
         """

--- a/weasyprint/layout/__init__.py
+++ b/weasyprint/layout/__init__.py
@@ -26,6 +26,7 @@ from .absolute import absolute_box_layout
 from .pages import make_all_pages, make_margin_boxes
 from .backgrounds import layout_backgrounds
 
+
 def layout_fixed_boxes(context, pages):
     """Lay out and yield the fixed boxes of ``pages``."""
     for page in pages:
@@ -34,6 +35,7 @@ def layout_fixed_boxes(context, pages):
             # fixed box has already been added to page.fixed_boxes, we don't
             # want to get them again
             yield absolute_box_layout(context, box, page, [])
+
 
 def layout_document(enable_hinting, style_for, get_image_from_uri, root_box):
     """Lay out the whole document.
@@ -71,7 +73,7 @@ class LayoutContext(object):
         self.get_image_from_uri = get_image_from_uri
         self._excluded_shapes_lists = []
         self.excluded_shapes = None  # Not initialized yet
-        self.string_set = defaultdict(lambda:defaultdict(lambda:list()))
+        self.string_set = defaultdict(lambda: defaultdict(lambda: list()))
         self.current_page = None
 
     def create_block_formatting_context(self):
@@ -91,18 +93,22 @@ class LayoutContext(object):
             self.excluded_shapes = self._excluded_shapes_lists[-1]
         else:
             self.excluded_shapes = None
+
     def get_string_set_for(self, name, keyword=None):
         """ Resolve value of string function (as set by string set)
 
-            We'll have something like this that represents all assignments on a given page
-            {1: [u'First Header'], 3: [u'Second Header'], 4: [u'Third Header', u'3.5th Header']}
+            We'll have something like this that represents all assignments
+            on a given page
+            {1: [u'First Header'], 3: [u'Second Header'],
+             4: [u'Third Header', u'3.5th Header']}
 
-            Value depends on current page - http://dev.w3.org/csswg/css-gcpm/#funcdef-string
+            Value depends on current page
+            http://dev.w3.org/csswg/css-gcpm/#funcdef-string
 
             :param name: the name of the named string.
-            :param keyword: indicates which value of the named string should be used.
-                            Default is the first assignment on the current page else the most
-                            recent assignment (entry value)
+            :param keyword: indicates which value of the named string to use.
+                            Default is the first assignment on the current page
+                            else the most recent assignment (entry value)
             :returns: text
 
         """
@@ -113,11 +119,11 @@ class LayoutContext(object):
                 # 'first-except' excludes the page it was assinged on
                 return ""
             elif last:
-                # most recent assignment
+                # use the most recent assignment
                 return self.string_set[name][self.current_page][-1]
             return self.string_set[name][self.current_page][0]
         else:
-            # no assignment on this page - search backwards; through previous page
+            # search backwards through previous pages
             for previous_page in xrange(self.current_page, 0, -1):
                 if previous_page in self.string_set[name]:
                     return self.string_set[name][previous_page][-1]

--- a/weasyprint/layout/__init__.py
+++ b/weasyprint/layout/__init__.py
@@ -91,15 +91,32 @@ class LayoutContext(object):
         else:
             self.excluded_shapes = None
     def get_string_set_for(self, name, keyword=None):
+        """ Resolve value of string function (as set by string set)
+
+            We'll have something like this that represents all assignments on a given page
+            {1: [u'First Header'], 3: [u'Second Header'], 4: [u'Third Header', u'3.5th Header']}
+
+            Value depends on current page - http://dev.w3.org/csswg/css-gcpm/#funcdef-string
+
+            :param name: the name of the named string.
+            :param name: indicates which value of the named string should be used.
+                         Default is the first assignment on the current page else the most recent assignment (entry value)
+            :returns: text
+
+        """
         last = keyword == "last"
         if self.current_page in self.string_set[name]:
-            if keyword == "first-except":
+            # a value was assigned on this page
+            if keyword == 'first-except':
+                # 'first-except' excludes the page it was assinged on
                 return ""
             elif last:
+                # most recent assignment
                 return self.string_set[name][self.current_page][-1]
             return self.string_set[name][self.current_page][0]
         else:
-            for lower_page in xrange(self.current_page, 0, -1):
-                if lower_page in self.string_set[name]:
-                    return self.string_set[name][lower_page][-1]
+            # no assignment on this page - search backwards; through previous page
+            for previous_page in xrange(self.current_page, 0, -1):
+                if previous_page in self.string_set[name]:
+                    return self.string_set[name][previous_page][-1]
         return ""

--- a/weasyprint/layout/pages.py
+++ b/weasyprint/layout/pages.py
@@ -529,7 +529,8 @@ def make_page(context, root_box, page_type, resume_at, content_empty, page_numbe
             name = child.style.string_set[3]
             keyword = child.style.string_set[1]
             text = TEXT_CONTENT_EXTRACTORS[keyword](child)
-            context.string_set[name][page_number].append(text)
+            if text:
+                context.string_set[name][page_number].append(text)
     if content_empty:
         resume_at = previous_resume_at
     return page, resume_at, next_page

--- a/weasyprint/layout/pages.py
+++ b/weasyprint/layout/pages.py
@@ -529,8 +529,7 @@ def make_page(context, root_box, page_type, resume_at, content_empty, page_numbe
             name = child.style.string_set[3]
             keyword = child.style.string_set[1]
             text = TEXT_CONTENT_EXTRACTORS[keyword](child)
-            if text:
-                context.string_set[name][page_number].append(text)
+            context.string_set[name][page_number].append(text)
     if content_empty:
         resume_at = previous_resume_at
     return page, resume_at, next_page

--- a/weasyprint/layout/pages.py
+++ b/weasyprint/layout/pages.py
@@ -283,6 +283,7 @@ def make_margin_boxes(context, page, counter_values):
         :param containing_block: as expected by :func:`resolve_percentages`.
 
         """
+
         style = context.style_for(page.page_type, at_keyword)
         if style is None:
             style = page.style.inherit_from()
@@ -295,7 +296,7 @@ def make_margin_boxes(context, page, counter_values):
             quote_depth = [0]
             children = build.content_to_boxes(
                 box.style, box, quote_depth, counter_values,
-                context.get_image_from_uri)
+                context.get_image_from_uri, context)
             box = box.copy_with_children(children)
             # content_to_boxes() only produces inline-level boxes, no need to
             # run other post-processors from build.build_formatting_structure()
@@ -453,8 +454,19 @@ def page_width(box, context, containing_block_width):
 def page_height(box, context, containing_block_height):
     page_width_or_height(VerticalBox(context, box), containing_block_height)
 
-
-def make_page(context, root_box, page_type, resume_at, content_empty):
+def box_text_contents(box):
+    if isinstance(box, boxes.TextBox):
+        return box.text
+    elif isinstance(box, boxes.ParentBox):
+        return ''.join(box_text_contents(child) for child in box.children)
+    else:
+        return ''
+TEXT_CONTENT_EXTRACTORS = {
+    'text': build.box_text_contents,
+    # 'content-element': build.box_text_content_element,
+    'before': build.box_text_content_before,
+    'after': build.box_text_content_after}
+def make_page(context, root_box, page_type, resume_at, content_empty, page_number=None):
     """Take just enough content from the beginning to fill one page.
 
     Return ``(page, finished)``. ``page`` is a laid out PageBox object
@@ -511,6 +523,13 @@ def make_page(context, root_box, page_type, resume_at, content_empty):
     context.finish_block_formatting_context(root_box)
 
     page = page.copy_with_children([root_box])
+    descendants = list(page.descendants())
+    for child in descendants:
+        if child.style.string_set:
+            name = child.style.string_set[3]
+            keyword = child.style.string_set[1]
+            text = TEXT_CONTENT_EXTRACTORS[keyword](child)
+            context.string_set[name][page_number].append(text)
     if content_empty:
         resume_at = previous_resume_at
     return page, resume_at, next_page
@@ -531,14 +550,16 @@ def make_all_pages(context, root_box):
 
     resume_at = None
     next_page = 'any'
+    page_number = 0
     while True:
+        page_number += 1
         content_empty = ((next_page == 'left' and right_page) or
                          (next_page == 'right' and not right_page))
         if content_empty:
             prefix += 'blank_'
         page_type = prefix + ('right_page' if right_page else 'left_page')
         page, resume_at, next_page = make_page(
-            context, root_box, page_type, resume_at, content_empty)
+            context, root_box, page_type, resume_at, content_empty, page_number)
         assert next_page
         yield page
         if resume_at is None:

--- a/weasyprint/layout/pages.py
+++ b/weasyprint/layout/pages.py
@@ -454,7 +454,9 @@ def page_width(box, context, containing_block_width):
 def page_height(box, context, containing_block_height):
     page_width_or_height(VerticalBox(context, box), containing_block_height)
 
-def make_page(context, root_box, page_type, resume_at, content_empty, page_number=None):
+
+def make_page(context, root_box, page_type, resume_at, content_empty,
+              page_number=None):
     """Take just enough content from the beginning to fill one page.
 
     Return ``(page, finished)``. ``page`` is a laid out PageBox object
@@ -526,6 +528,7 @@ def make_page(context, root_box, page_type, resume_at, content_empty, page_numbe
         resume_at = previous_resume_at
     return page, resume_at, next_page
 
+
 def make_all_pages(context, root_box):
     """Return a list of laid out pages without margin boxes."""
     prefix = 'first_'
@@ -550,7 +553,8 @@ def make_all_pages(context, root_box):
             prefix += 'blank_'
         page_type = prefix + ('right_page' if right_page else 'left_page')
         page, resume_at, next_page = make_page(
-            context, root_box, page_type, resume_at, content_empty, page_number)
+            context, root_box, page_type, resume_at, content_empty,
+            page_number)
         assert next_page
         yield page
         if resume_at is None:

--- a/weasyprint/tests/test_boxes.py
+++ b/weasyprint/tests/test_boxes.py
@@ -1233,6 +1233,7 @@ def test_margin_box_string_set():
     """
     Test string-set / string() in margin boxes
     """
+    # Test that both pages get string
     page_1, page_2 = render_pages('''
         <style>
             @page {
@@ -1249,75 +1250,36 @@ def test_margin_box_string_set():
         <div class="page"></div>
     ''')
 
-    html, top_center = page_2.children[:2]
+    html, top_center = page_2.children
     line_box, = top_center.children
     text_box, = line_box.children
     assert text_box.text == 'first assignment'
 
-@assert_no_logs
-def test_margin_box_string_set_text():
-    """
-    Test string-set / string() in margin boxes with 'text' (default value)
-    """
-    page_1, page_2 = render_pages('''
+    html, top_center = page_1.children
+    line_box, = top_center.children
+    text_box, = line_box.children
+    assert text_box.text == 'first assignment'
+
+    # Test `text` (default value)
+    page_1, = render_pages('''
         <style>
             @page {
-                @top-center { content: string(header); }
+                @top-center { content: string(text_header); }
             }
             p{
-                -weasy-string-set: header content(text);
-            }
-            .page{
-                page-break-before: always;
+                -weasy-string-set: text_header content(text);
             }
         </style>
         <p>first assignment</p>
         <div class="page"></div>
     ''')
 
-    html, top_center = page_2.children[:2]
-    print top_center.children
+    html, top_center = page_1.children
     line_box, = top_center.children
     text_box, = line_box.children
     assert text_box.text == 'first assignment'
 
-@assert_no_logs
-def test_margin_box_string_set_after():
-    """
-    Test string-set / string() in margin boxes
-     using ::after
-    """
-    page_1, page_2 = render_pages('''
-        <style>
-            @page {
-                @top-center { content: string(header); }
-            }
-            p{
-                -weasy-string-set: header content(after);
-            }
-            .page{
-                page-break-before: always;
-            }
-            p:after{
-                content: "empire";
-            }
-        </style>
-        <p>first assignment</p>
-        <div class="page"></div>
-    ''')
-
-    html, top_center = page_2.children[:2]
-    assert len(top_center.children) >= 1
-    line_box, = top_center.children
-    text_box, = line_box.children
-    assert text_box.text == 'empire'
-
-@assert_no_logs
-def test_margin_box_string_set_except_first():
-    """
-    Test string-set / string() first-except in margin boxes
-     ie. exclude from page on which value is assigned
-    """
+    # test `first-except` ie. exclude from page on which value is assigned
     page_1, page_2 = render_pages('''
         <style>
             @page {
@@ -1341,12 +1303,7 @@ def test_margin_box_string_set_except_first():
     text_box, = line_box.children
     assert text_box.text == "first_excepted"
 
-@assert_no_logs
-def test_margin_box_string_set_last():
-    """
-    Test string-set / string() last in margin boxes
-     ie. use the most-recent assignment
-    """
+    #Test `last` ie. use the most-recent assignment
     page_1, = render_pages('''
         <style>
             @page {

--- a/weasyprint/tests/test_boxes.py
+++ b/weasyprint/tests/test_boxes.py
@@ -1228,6 +1228,116 @@ def test_margin_boxes():
     text_box, = line_box.children
     assert text_box.text == 'Title'
 
+@assert_no_logs
+def test_margin_box_string_set():
+    """
+    Test string-set / string() in margin boxes
+    """
+    page_1, page_2 = render_pages('''
+        <style>
+            @page {
+                @top-center { content: string(header); }
+            }
+            p{
+                -weasy-string-set: header content(text);
+            }
+            .page{
+                page-break-before: always;
+            }
+        </style>
+        <p>first assignment</p>
+        <div class="page"></div>
+    ''')
+
+    html, top_center = page_2.children[:2]
+    line_box, = top_center.children
+    text_box, = line_box.children
+    assert text_box.text == 'first assignment'
+
+@assert_no_logs
+def test_margin_box_string_set_after():
+    """
+    Test string-set / string() in margin boxes
+     using after
+    """
+    page_1, page_2 = render_pages('''
+        <style>
+            @page {
+                @top-center { content: string(header); }
+            }
+            p{
+                -weasy-string-set: header content(after);
+            }
+            .page{
+                page-break-before: always;
+            }
+            .page:after{
+                content: "empire";
+            }
+        </style>
+        <p>first assignment</p>
+        <div class="page"></div>
+    ''')
+
+    html, top_center = page_2.children[:2]
+    assert len(top_center.children) >= 1
+    line_box, = top_center.children
+    text_box, = line_box.children
+    assert text_box.text == 'empire'
+
+@assert_no_logs
+def test_margin_box_string_set_except_first():
+    """
+    Test string-set / string() first-except in margin boxes
+     - exclude from page on which value is assigned
+    """
+    page_1, page_2 = render_pages('''
+        <style>
+            @page {
+                @top-center { content: string(header_nofirst, first-except); }
+            }
+            p{
+                -weasy-string-set: header_nofirst content(text);
+            }
+            .page{
+                page-break-before: always;
+            }
+        </style>
+        <p>first_excepted</p>
+        <div class="page"></div>
+    ''')
+    html, top_center = page_1.children
+    assert len(top_center.children) == 0
+
+    html, top_center = page_2.children
+    line_box, = top_center.children
+    text_box, = line_box.children
+    assert text_box.text == "first_excepted"
+
+@assert_no_logs
+def test_margin_box_string_set_last():
+    """
+    Test string-set / string() last in margin boxes
+     - use the last assignment
+    """
+    page_1, = render_pages('''
+        <style>
+            @page {
+                @top-center { content: string(header_last, last); }
+            }
+            p{
+                -weasy-string-set: header_last content(text);
+            }
+        </style>
+        <p>String set</p>
+        <p>Second assignment</p>
+    ''')
+
+    html, top_center = page_1.children[:2]
+    line_box, = top_center.children
+
+    text_box, = line_box.children
+    assert text_box.text == "Second assignment"
 
 @assert_no_logs
 def test_page_counters():

--- a/weasyprint/tests/test_boxes.py
+++ b/weasyprint/tests/test_boxes.py
@@ -1233,14 +1233,14 @@ def test_margin_box_string_set():
     """
     Test string-set / string() in margin boxes
     """
-    # Test that both pages get string
+    # Test that both pages get string in the `bottom-center` margin box
     page_1, page_2 = render_pages('''
         <style>
             @page {
-                @top-center { content: string(header); }
+                @bottom-center { content: string(text_header); }
             }
             p{
-                -weasy-string-set: header content();
+                -weasy-string-set: text_header content();
             }
             .page{
                 page-break-before: always;
@@ -1250,28 +1250,28 @@ def test_margin_box_string_set():
         <div class="page"></div>
     ''')
 
-    html, top_center = page_2.children
-    line_box, = top_center.children
+    html, bottom_center = page_2.children
+    line_box, = bottom_center.children
     text_box, = line_box.children
     assert text_box.text == 'first assignment'
 
-    html, top_center = page_1.children
-    line_box, = top_center.children
+    html, bottom_center = page_1.children
+    line_box, = bottom_center.children
     text_box, = line_box.children
     assert text_box.text == 'first assignment'
 
-    # Test `text` (default value)
+    # Test `first` (default value) ie. use the first assignment on the page
     page_1, = render_pages('''
         <style>
             @page {
-                @top-center { content: string(text_header); }
+                @top-center { content: string(text_header, first); }
             }
             p{
                 -weasy-string-set: text_header content(text);
             }
         </style>
         <p>first assignment</p>
-        <div class="page"></div>
+        <p>Second assignment</p>
     ''')
 
     html, top_center = page_1.children
@@ -1345,7 +1345,6 @@ def test_page_counters():
         line_box, = bottom_center.children
         text_box, = line_box.children
         assert text_box.text == 'Page {0} of 3.'.format(page_number)
-
 
 @assert_no_logs
 def test_border_collapse():

--- a/weasyprint/tests/test_boxes.py
+++ b/weasyprint/tests/test_boxes.py
@@ -1261,6 +1261,36 @@ def test_margin_box_string_set():
     text_box, = line_box.children
     assert text_box.text == 'first assignment'
 
+    def simple_string_set_test(content_val, extra_style=""):
+        page_1, = render_pages('''
+            <style>
+                @page {
+                    @top-center { content: string(text_header); }
+                }
+                p{
+                    -weasy-string-set: text_header content(%(content_val)s);
+                }
+                %(extra_style)s
+            </style>
+            <p>first assignment</p>
+        '''% dict(content_val=content_val, extra_style=extra_style))
+
+        html, top_center = page_1.children
+        line_box, = top_center.children
+        text_box, = line_box.children
+        if content_val in ('before','after'):
+            assert text_box.text == 'psuedo'
+        else:
+            assert text_box.text == 'first assignment'
+
+    # Test each accepted value of `content()` as an arguemnt to `string-set`
+    for value in ('', 'text', 'before', 'after'):
+        if value in ('before','after'):
+            extra_style = "p:%s{content:'psuedo'}" % value
+            simple_string_set_test(value, extra_style)
+        else:
+            simple_string_set_test(value)
+
     # Test `first` (default value) ie. use the first assignment on the page
     page_1, = render_pages('''
         <style>
@@ -1268,7 +1298,7 @@ def test_margin_box_string_set():
                 @top-center { content: string(text_header, first); }
             }
             p{
-                -weasy-string-set: text_header content(text);
+                -weasy-string-set: text_header content();
             }
         </style>
         <p>first assignment</p>
@@ -1287,7 +1317,7 @@ def test_margin_box_string_set():
                 @top-center { content: string(header_nofirst, first-except); }
             }
             p{
-                -weasy-string-set: header_nofirst content(text);
+                -weasy-string-set: header_nofirst content();
             }
             .page{
                 page-break-before: always;
@@ -1311,7 +1341,7 @@ def test_margin_box_string_set():
                 @top-center { content: string(header_last, last); }
             }
             p{
-                -weasy-string-set: header_last content(text);
+                -weasy-string-set: header_last content();
             }
         </style>
         <p>String set</p>

--- a/weasyprint/tests/test_boxes.py
+++ b/weasyprint/tests/test_boxes.py
@@ -1273,7 +1273,7 @@ def test_margin_box_string_set():
                 %(extra_style)s
             </style>
             <p>first assignment</p>
-        '''% dict(content_val = content_val, extra_style = extra_style))
+        ''' % dict(content_val=content_val, extra_style=extra_style))
 
         html, top_center = page_1.children
         line_box, = top_center.children

--- a/weasyprint/tests/test_boxes.py
+++ b/weasyprint/tests/test_boxes.py
@@ -1273,19 +1273,19 @@ def test_margin_box_string_set():
                 %(extra_style)s
             </style>
             <p>first assignment</p>
-        '''% dict(content_val=content_val, extra_style=extra_style))
+        '''% dict(content_val = content_val, extra_style = extra_style))
 
         html, top_center = page_1.children
         line_box, = top_center.children
         text_box, = line_box.children
-        if content_val in ('before','after'):
+        if content_val in ('before', 'after'):
             assert text_box.text == 'psuedo'
         else:
             assert text_box.text == 'first assignment'
 
     # Test each accepted value of `content()` as an arguemnt to `string-set`
     for value in ('', 'text', 'before', 'after'):
-        if value in ('before','after'):
+        if value in ('before', 'after'):
             extra_style = "p:%s{content:'psuedo'}" % value
             simple_string_set_test(value, extra_style)
         else:

--- a/weasyprint/tests/test_boxes.py
+++ b/weasyprint/tests/test_boxes.py
@@ -1228,6 +1228,7 @@ def test_margin_boxes():
     text_box, = line_box.children
     assert text_box.text == 'Title'
 
+
 @assert_no_logs
 def test_margin_box_string_set():
     """
@@ -1303,7 +1304,7 @@ def test_margin_box_string_set():
     text_box, = line_box.children
     assert text_box.text == "first_excepted"
 
-    #Test `last` ie. use the most-recent assignment
+    # Test `last` ie. use the most-recent assignment
     page_1, = render_pages('''
         <style>
             @page {
@@ -1322,6 +1323,7 @@ def test_margin_box_string_set():
 
     text_box, = line_box.children
     assert text_box.text == "Second assignment"
+
 
 @assert_no_logs
 def test_page_counters():
@@ -1345,6 +1347,7 @@ def test_page_counters():
         line_box, = bottom_center.children
         text_box, = line_box.children
         assert text_box.text == 'Page {0} of 3.'.format(page_number)
+
 
 @assert_no_logs
 def test_border_collapse():

--- a/weasyprint/tests/test_boxes.py
+++ b/weasyprint/tests/test_boxes.py
@@ -1239,7 +1239,7 @@ def test_margin_box_string_set():
                 @top-center { content: string(header); }
             }
             p{
-                -weasy-string-set: header content(text);
+                -weasy-string-set: header content();
             }
             .page{
                 page-break-before: always;
@@ -1255,10 +1255,37 @@ def test_margin_box_string_set():
     assert text_box.text == 'first assignment'
 
 @assert_no_logs
+def test_margin_box_string_set_text():
+    """
+    Test string-set / string() in margin boxes with 'text' (default value)
+    """
+    page_1, page_2 = render_pages('''
+        <style>
+            @page {
+                @top-center { content: string(header); }
+            }
+            p{
+                -weasy-string-set: header content(text);
+            }
+            .page{
+                page-break-before: always;
+            }
+        </style>
+        <p>first assignment</p>
+        <div class="page"></div>
+    ''')
+
+    html, top_center = page_2.children[:2]
+    print top_center.children
+    line_box, = top_center.children
+    text_box, = line_box.children
+    assert text_box.text == 'first assignment'
+
+@assert_no_logs
 def test_margin_box_string_set_after():
     """
     Test string-set / string() in margin boxes
-     using after
+     using ::after
     """
     page_1, page_2 = render_pages('''
         <style>
@@ -1271,7 +1298,7 @@ def test_margin_box_string_set_after():
             .page{
                 page-break-before: always;
             }
-            .page:after{
+            p:after{
                 content: "empire";
             }
         </style>
@@ -1289,7 +1316,7 @@ def test_margin_box_string_set_after():
 def test_margin_box_string_set_except_first():
     """
     Test string-set / string() first-except in margin boxes
-     - exclude from page on which value is assigned
+     ie. exclude from page on which value is assigned
     """
     page_1, page_2 = render_pages('''
         <style>
@@ -1318,7 +1345,7 @@ def test_margin_box_string_set_except_first():
 def test_margin_box_string_set_last():
     """
     Test string-set / string() last in margin boxes
-     - use the last assignment
+     ie. use the most-recent assignment
     """
     page_1, = render_pages('''
         <style>


### PR DESCRIPTION
Named strings using the `-weasy-string-set` style and the CSS `string` function passed to `content()`.
http://dev.w3.org/csswg/css-gcpm/#named-strings
![named_strings](https://cloud.githubusercontent.com/assets/2049558/6745711/b3f9caaa-ce91-11e4-8974-60ed1d4f2d5e.png)

More discussion in feature request - issue https://github.com/Kozea/WeasyPrint/issues/174

Below is a simple example (more in tests/test_boxes.py).

``` html
<html>
<head>
<style>
body{
     counter-reset: header_counter; 
}
@page:first{
    @top-center { content: string(header)}
}
@page{
    @top-center { content: string(header, first-except)}
}
.page{
      page-break-before: always;
}

h1{
    counter-increment: header_counter;
	string-set: header content(after);
	-weasy-string-set: header content(text);
}
h1:before{
	content: "Chapter " counter(header_counter) " ";
}
</style>
</head>
<body>
    <div class="page"><h1>First</h1>This demonstrates named strings using the `string-set` style and the CSS `string` function passed to `content()`.<br>There are two assignments "First" and "Second" plus the psuedo ::before element. The numbers are produced using CSS `counter`.</div>
    <div class="page">CONTENT</div>
    <div class="page" ><h1 >Second</h1>Pages after the first have `first-except` set, meaning the page on which the assignment is made is excluded. Proceeding pages will have the value set here ("Second").</div>
    <div class="page">CONTENT</div>
</body>
</html>
```