### PR TITLE
Support 'q', 'vh', 'vw', 'vmin', 'vmax', 'rem' units

### DIFF
--- a/weasyprint/css/computed_values.py
+++ b/weasyprint/css/computed_values.py
@@ -30,6 +30,7 @@ LENGTHS_TO_PIXELS = {
     'in': 96.,  # LENGTHS_TO_PIXELS['pt'] * 72
     'cm': 96. / 2.54,  # LENGTHS_TO_PIXELS['in'] / 2.54
     'mm': 96. / 25.4,  # LENGTHS_TO_PIXELS['in'] / 25.4
+    'q': 96. / 25.4 / 4.,  # LENGTHS_TO_PIXELS['mm'] / 4
 }
 
 

--- a/weasyprint/css/computed_values.py
+++ b/weasyprint/css/computed_values.py
@@ -296,6 +296,13 @@ def length(computer, name, value, font_size=None, pixels_only=False):
             result = value.value * logical_width
         elif unit == 'em':
             result = value.value * font_size
+    elif unit in ('vh', 'vw', 'vmin', 'vmax'):
+        if pixels_only:
+            # TODO: remove the pixels_only attribute from this function and
+            # resolve these values during layout as it's done for percentages
+            return 0
+        else:
+            return value
     else:
         # A percentage or 'auto': no conversion needed.
         return value

--- a/weasyprint/css/validation.py
+++ b/weasyprint/css/validation.py
@@ -32,7 +32,9 @@ from . import computed_values
 
 
 # get the sets of keys
-LENGTH_UNITS = set(computed_values.LENGTHS_TO_PIXELS) | set(['ex', 'em', 'ch'])
+LENGTH_UNITS = (
+    set(computed_values.LENGTHS_TO_PIXELS) |
+    set(['ex', 'em', 'ch', 'vw', 'vh', 'vmin', 'vmax']))
 
 
 # keyword -> (open, insert)

--- a/weasyprint/layout/__init__.py
+++ b/weasyprint/layout/__init__.py
@@ -61,7 +61,7 @@ def layout_document(enable_hinting, style_for, get_image_from_uri, root_box):
         context.current_page = page_counter[0]
         page.children = (root,) + tuple(
             make_margin_boxes(context, page, counter_values))
-        layout_backgrounds(page, get_image_from_uri)
+        layout_backgrounds(page, get_image_from_uri, context)
         yield page
         page_counter[0] += 1
 
@@ -75,6 +75,7 @@ class LayoutContext(object):
         self.excluded_shapes = None  # Not initialized yet
         self.string_set = defaultdict(lambda: defaultdict(lambda: list()))
         self.current_page = None
+        self.viewport_size = None
 
     def create_block_formatting_context(self):
         self.excluded_shapes = []

--- a/weasyprint/layout/absolute.py
+++ b/weasyprint/layout/absolute.py
@@ -254,8 +254,8 @@ def absolute_box_layout(context, box, containing_block, fixed_boxes):
         cb_height = cb.padding_height()
     containing_block = cb_x, cb_y, cb_width, cb_height
 
-    resolve_percentages(box, (cb_width, cb_height))
-    resolve_position_percentages(box, (cb_width, cb_height))
+    resolve_percentages(box, (cb_width, cb_height), context)
+    resolve_position_percentages(box, (cb_width, cb_height), context)
 
     context.create_block_formatting_context()
     # Absolute tables are wrapped into block boxes

--- a/weasyprint/layout/backgrounds.py
+++ b/weasyprint/layout/backgrounds.py
@@ -50,13 +50,13 @@ def box_rectangle(box, which_rectangle):
         )
 
 
-def layout_box_backgrounds(page, box, get_image_from_uri):
+def layout_box_backgrounds(page, box, get_image_from_uri, context):
     """Fetch and position background images."""
     # Resolve percentages in border-radius properties
-    resolve_radii_percentages(box)
+    resolve_radii_percentages(box, context)
 
     for child in box.all_children():
-        layout_box_backgrounds(page, child, get_image_from_uri)
+        layout_box_backgrounds(page, child, get_image_from_uri, context)
 
     style = box.style
     if style.visibility == 'hidden':
@@ -209,6 +209,6 @@ def set_canvas_background(page):
         page.canvas_background = None
 
 
-def layout_backgrounds(page, get_image_from_uri):
-    layout_box_backgrounds(page, page, get_image_from_uri)
+def layout_backgrounds(page, get_image_from_uri, context):
+    layout_box_backgrounds(page, page, get_image_from_uri, context)
     set_canvas_background(page)

--- a/weasyprint/layout/blocks.py
+++ b/weasyprint/layout/blocks.py
@@ -39,7 +39,7 @@ def block_level_layout(context, box, max_position_y, skip_stack,
             context, box, max_position_y, skip_stack, containing_block,
             device_size, page_is_empty, absolute_boxes, fixed_boxes)
 
-    resolve_percentages(box, containing_block)
+    resolve_percentages(box, containing_block, context)
 
     if box.margin_top == 'auto':
         box.margin_top = 0
@@ -178,10 +178,10 @@ def block_level_width(box, containing_block):
         box.margin_right = margin_sum - margin_l
 
 
-def relative_positioning(box, containing_block):
+def relative_positioning(box, containing_block, context):
     """Translate the ``box`` if it is relatively positioned."""
     if box.style.position == 'relative':
-        resolve_position_percentages(box, containing_block)
+        resolve_position_percentages(box, containing_block, context)
 
         if box.left != 'auto' and box.right != 'auto':
             if box.style.direction == 'ltr':
@@ -206,7 +206,7 @@ def relative_positioning(box, containing_block):
 
     if isinstance(box, (boxes.InlineBox, boxes.LineBox)):
         for child in box.children:
-            relative_positioning(child, containing_block)
+            relative_positioning(child, containing_block, context)
 
 
 def block_container_layout(context, box, max_position_y, skip_stack,
@@ -390,7 +390,7 @@ def block_container_layout(context, box, max_position_y, skip_stack,
 
             if not new_containing_block.is_table_wrapper:
                 # TODO: there's no collapsing margins inside tables, right?
-                resolve_percentages(child, new_containing_block)
+                resolve_percentages(child, new_containing_block, context)
                 if (child.is_in_normal_flow() and last_in_flow_child is None
                         and collapsing_with_children):
                     # TODO: add the adjoining descendants' margin top to
@@ -563,7 +563,7 @@ def block_container_layout(context, box, max_position_y, skip_stack,
             absolute_layout(context, absolute_box, new_box, fixed_boxes)
 
     for child in new_box.children:
-        relative_positioning(child, (new_box.width, new_box.height))
+        relative_positioning(child, (new_box.width, new_box.height), context)
 
     if not isinstance(new_box, boxes.BlockBox):
         context.finish_block_formatting_context(new_box)

--- a/weasyprint/layout/float.py
+++ b/weasyprint/layout/float.py
@@ -32,9 +32,10 @@ def float_layout(context, box, containing_block, absolute_boxes, fixed_boxes):
     from .blocks import block_container_layout
     from .inlines import inline_replaced_box_width_height
 
-    resolve_percentages(box, (containing_block.width, containing_block.height))
+    resolve_percentages(
+        box, (containing_block.width, containing_block.height), context)
     resolve_position_percentages(
-        box, (containing_block.width, containing_block.height))
+        box, (containing_block.width, containing_block.height), context)
 
     if box.margin_left == 'auto':
         box.margin_left = 0

--- a/weasyprint/layout/inlines.py
+++ b/weasyprint/layout/inlines.py
@@ -60,11 +60,12 @@ def get_next_linebox(context, linebox, position_y, skip_stack,
                      containing_block, device_size, absolute_boxes,
                      fixed_boxes):
     """Return ``(line, resume_at)``."""
-    resolve_percentages(linebox, containing_block)
+    resolve_percentages(linebox, containing_block, context)
     if skip_stack is None:
         # text-indent only at the start of the first line
         # Other percentages (margins, width, ...) do not apply.
-        resolve_one_percentage(linebox, 'text_indent', containing_block.width)
+        resolve_one_percentage(
+            linebox, 'text_indent', containing_block.width, context)
     else:
         linebox.text_indent = 0
 
@@ -433,7 +434,7 @@ def inline_block_box_layout(context, box, position_x, skip_stack,
     # Avoid a circular import
     from .blocks import block_container_layout
 
-    resolve_percentages(box, containing_block)
+    resolve_percentages(box, containing_block, context)
 
     # http://www.w3.org/TR/CSS21/visudet.html#inlineblock-width
     if box.margin_left == 'auto':
@@ -488,7 +489,7 @@ def split_inline_level(context, box, position_x, max_x, skip_stack,
     is no split is possible.)
 
     """
-    resolve_percentages(box, containing_block)
+    resolve_percentages(box, containing_block, context)
     if isinstance(box, boxes.TextBox):
         box.position_x = position_x
         if skip_stack is None:

--- a/weasyprint/layout/markers.py
+++ b/weasyprint/layout/markers.py
@@ -27,7 +27,7 @@ def list_marker_layout(context, box):
     # see CSS3 lists.
     marker = getattr(box, 'outside_list_marker', None)
     if marker:
-        resolve_percentages(marker, containing_block=box)
+        resolve_percentages(marker, box, context)
         if isinstance(marker, boxes.TextBox):
             (marker.pango_layout, _, _, marker.width, marker.height,
                 marker.baseline) = split_first_line(

--- a/weasyprint/layout/pages.py
+++ b/weasyprint/layout/pages.py
@@ -302,7 +302,7 @@ def make_margin_boxes(context, page, counter_values):
             # run other post-processors from build.build_formatting_structure()
             box = build.inline_in_block(box)
             build.process_whitespace(box)
-        resolve_percentages(box, containing_block)
+        resolve_percentages(box, containing_block, context)
         if not box.is_generated:
             box.width = box.height = 0
             for side in ('top', 'right', 'bottom', 'left'):
@@ -475,13 +475,16 @@ def make_page(context, root_box, page_type, resume_at, content_empty,
 
     device_size = page.style.size
 
-    resolve_percentages(page, device_size)
+    resolve_percentages(page, device_size, context)
 
     page.position_x = 0
     page.position_y = 0
     cb_width, cb_height = device_size
     page_width(page, context, cb_width)
     page_height(page, context, cb_height)
+
+    if page_number == 1:
+        context.viewport_size = (page.width, page.height)
 
     root_box.position_x = page.content_box_x()
     root_box.position_y = page.content_box_y()

--- a/weasyprint/layout/percentages.py
+++ b/weasyprint/layout/percentages.py
@@ -3,7 +3,7 @@
     weasyprint.layout.percentages
     -----------------------------
 
-    Resolve percentages into fixed values.
+, context    Resolve percentages into fixed values.
 
     :copyright: Copyright 2011-2014 Simon Sapin and contributors, see AUTHORS.
     :license: BSD, see LICENSE for details.
@@ -15,45 +15,63 @@ from __future__ import division, unicode_literals
 from ..formatting_structure import boxes
 
 
-def _percentage(value, refer_to):
-    """Get the value corresponding to the value/percentage and the reference
+def _viewport_percentage(value, context):
+    """Get the value corresponding a the viewport percentage."""
+    if context.viewport_size is None:
+        raise ValueError(
+            'Relying on viewport-percentage units for elements '
+            'needed to define the size of the viewport')
+    print(context.viewport_size)
+    if value.unit == 'vw':
+        result = context.viewport_size[0]
+    elif value.unit == 'vh':
+        result = context.viewport_size[1]
+    elif value.unit == 'vmin':
+        result = min(*context.viewport_size)
+    elif value.unit == 'vmax':
+        result = max(*context.viewport_size)
+    return value.value * result
 
-    ``refer_to`` is the length for 100%. If ``refer_to`` is not a number, it
-    just replaces percentages.
+
+def _percentage(value, refer_to, context):
+    """Get the value corresponding to the value/percentage and the reference.
+
+    ``refer_to`` is the length for 100%.
 
     """
     if value == 'auto':
         result = value
     elif value.unit == 'px':
         result = value.value
+    elif value.unit in ('vw', 'vh', 'vmin', 'vmax'):
+        result = _viewport_percentage(value, context)
     else:
         assert value.unit == '%'
         result = value.value * refer_to / 100.
     return result
 
 
-def resolve_one_percentage(box, property_name, refer_to):
+def resolve_one_percentage(box, property_name, refer_to, context):
     """Set a used length value from a computed length value.
 
-    ``refer_to`` is the length for 100%. If ``refer_to`` is not a number, it
-    just replaces percentages.
+    ``refer_to`` is the length for 100%.
 
     """
     # box.style has computed values
     value = box.style[property_name]
     # box attributes are used values
-    setattr(box, property_name, _percentage(value, refer_to))
+    setattr(box, property_name, _percentage(value, refer_to, context))
 
 
-def resolve_position_percentages(box, containing_block):
+def resolve_position_percentages(box, containing_block, context):
     cb_width, cb_height = containing_block
-    resolve_one_percentage(box, 'left', cb_width)
-    resolve_one_percentage(box, 'right', cb_width)
-    resolve_one_percentage(box, 'top', cb_height)
-    resolve_one_percentage(box, 'bottom', cb_height)
+    resolve_one_percentage(box, 'left', cb_width, context)
+    resolve_one_percentage(box, 'right', cb_width, context)
+    resolve_one_percentage(box, 'top', cb_height, context)
+    resolve_one_percentage(box, 'bottom', cb_height, context)
 
 
-def resolve_percentages(box, containing_block):
+def resolve_percentages(box, containing_block, context):
     """Set used values as attributes of the box object."""
     if isinstance(containing_block, boxes.Box):
         # cb is short for containing block
@@ -65,17 +83,17 @@ def resolve_percentages(box, containing_block):
         maybe_height = cb_height
     else:
         maybe_height = cb_width
-    resolve_one_percentage(box, 'margin_left', cb_width)
-    resolve_one_percentage(box, 'margin_right', cb_width)
-    resolve_one_percentage(box, 'margin_top', maybe_height)
-    resolve_one_percentage(box, 'margin_bottom', maybe_height)
-    resolve_one_percentage(box, 'padding_left', cb_width)
-    resolve_one_percentage(box, 'padding_right', cb_width)
-    resolve_one_percentage(box, 'padding_top', maybe_height)
-    resolve_one_percentage(box, 'padding_bottom', maybe_height)
-    resolve_one_percentage(box, 'width', cb_width)
-    resolve_one_percentage(box, 'min_width', cb_width)
-    resolve_one_percentage(box, 'max_width', cb_width)
+    resolve_one_percentage(box, 'margin_left', cb_width, context)
+    resolve_one_percentage(box, 'margin_right', cb_width, context)
+    resolve_one_percentage(box, 'margin_top', maybe_height, context)
+    resolve_one_percentage(box, 'margin_bottom', maybe_height, context)
+    resolve_one_percentage(box, 'padding_left', cb_width, context)
+    resolve_one_percentage(box, 'padding_right', cb_width, context)
+    resolve_one_percentage(box, 'padding_top', maybe_height, context)
+    resolve_one_percentage(box, 'padding_bottom', maybe_height, context)
+    resolve_one_percentage(box, 'width', cb_width, context)
+    resolve_one_percentage(box, 'min_width', cb_width, context)
+    resolve_one_percentage(box, 'max_width', cb_width, context)
 
     # XXX later: top, bottom, left and right on positioned elements
 
@@ -85,17 +103,19 @@ def resolve_percentages(box, containing_block):
         height = box.style.height
         if height == 'auto' or height.unit == '%':
             box.height = 'auto'
+        elif height.unit in ('vw', 'vh', 'vmin', 'vmax'):
+            box.height = _viewport_percentage(height, context)
         else:
             assert height.unit == 'px'
             box.height = height.value
-        resolve_one_percentage(box, 'min_height', 0)
-        resolve_one_percentage(box, 'max_height', float('inf'))
+        resolve_one_percentage(box, 'min_height', 0, context)
+        resolve_one_percentage(box, 'max_height', float('inf'), context)
     else:
-        resolve_one_percentage(box, 'height', cb_height)
-        resolve_one_percentage(box, 'min_height', cb_height)
-        resolve_one_percentage(box, 'max_height', cb_height)
+        resolve_one_percentage(box, 'height', cb_height, context)
+        resolve_one_percentage(box, 'min_height', cb_height, context)
+        resolve_one_percentage(box, 'max_height', cb_height, context)
 
-    # Used value == computed value
+    # Used value == computed value or viewport-perccentage
     for side in ['top', 'right', 'bottom', 'left']:
         prop = 'border_{0}_width'.format(side)
         setattr(box, prop, box.style[prop])
@@ -116,11 +136,11 @@ def resolve_percentages(box, containing_block):
         assert box.style.box_sizing == 'content-box'
 
 
-def resolve_radii_percentages(box):
+def resolve_radii_percentages(box, context):
     corners = ('top_left', 'top_right', 'bottom_right', 'bottom_left')
     for corner in corners:
         property_name = 'border_%s_radius' % corner
         rx, ry = box.style[property_name]
-        rx = _percentage(rx, box.border_width())
-        ry = _percentage(ry, box.border_height())
+        rx = _percentage(rx, box.border_width(), context)
+        ry = _percentage(ry, box.border_height(), context)
         setattr(box, property_name, (rx, ry))

--- a/weasyprint/layout/percentages.py
+++ b/weasyprint/layout/percentages.py
@@ -3,7 +3,7 @@
     weasyprint.layout.percentages
     -----------------------------
 
-, context    Resolve percentages into fixed values.
+    Resolve percentages into fixed values.
 
     :copyright: Copyright 2011-2014 Simon Sapin and contributors, see AUTHORS.
     :license: BSD, see LICENSE for details.

--- a/weasyprint/layout/tables.py
+++ b/weasyprint/layout/tables.py
@@ -71,7 +71,7 @@ def table_layout(context, table, max_position_y, skip_stack,
     def group_layout(group, position_y, max_position_y,
                      page_is_empty, skip_stack):
         resume_at = None
-        resolve_percentages(group, containing_block=table)
+        resolve_percentages(group, table, context)
         group.position_x = rows_x
         group.position_y = position_y
         group.width = rows_width
@@ -86,7 +86,7 @@ def table_layout(context, table, max_position_y, skip_stack,
             skip, skip_stack = skip_stack
             assert not skip_stack  # No breaks inside rows for now
         for index_row, row in group.enumerate_skip(skip):
-            resolve_percentages(row, containing_block=table)
+            resolve_percentages(row, table, context)
             row.position_x = rows_x
             row.position_y = position_y
             row.width = rows_width
@@ -109,7 +109,7 @@ def table_layout(context, table, max_position_y, skip_stack,
                                    'the table, ignored %i cells: %r',
                                    len(ignored_cells), ignored_cells)
                     break
-                resolve_percentages(cell, containing_block=table)
+                resolve_percentages(cell, table, context)
                 cell.position_x = column_positions[cell.grid_x]
                 cell.position_y = row.position_y
                 cell.margin_top = 0
@@ -371,12 +371,12 @@ def table_layout(context, table, max_position_y, skip_stack,
         columns_height -= border_spacing_y
     for group in table.column_groups:
         for column in group.children:
-            resolve_percentages(column, containing_block=table)
+            resolve_percentages(column, table, context)
             column.position_x = column_positions[column.grid_x]
             column.position_y = initial_position_y
             column.width = column_widths[column.grid_x]
             column.height = columns_height
-        resolve_percentages(group, containing_block=table)
+        resolve_percentages(group, table, context)
         first = group.children[0]
         last = group.children[-1]
         group.position_x = first.position_x
@@ -403,7 +403,7 @@ def add_top_padding(box, extra_padding):
         child.translate(dy=extra_padding)
 
 
-def fixed_table_layout(box):
+def fixed_table_layout(context, box):
     """Run the fixed table layout and return a list of column widths
 
     http://www.w3.org/TR/CSS21/tables.html#fixed-table-layout
@@ -428,7 +428,7 @@ def fixed_table_layout(box):
 
     # `width` on column boxes
     for i, column in enumerate(all_columns):
-        resolve_one_percentage(column, 'width', table.width)
+        resolve_one_percentage(column, 'width', table.width, context)
         if column.width != 'auto':
             column_widths[i] = column.width
 
@@ -440,7 +440,7 @@ def fixed_table_layout(box):
     # `width` on cells of the first row.
     i = 0
     for cell in first_row_cells:
-        resolve_percentages(cell, table)
+        resolve_percentages(cell, table, context)
         if cell.width != 'auto':
             width = cell.border_width()
             width -= border_spacing_x * (cell.colspan - 1)
@@ -559,10 +559,10 @@ def auto_table_layout(context, box, containing_block):
 def table_wrapper_width(context, wrapper, containing_block):
     """Find the width of each column and derive the wrapper width."""
     table = wrapper.get_wrapped_table()
-    resolve_percentages(table, containing_block)
+    resolve_percentages(table, containing_block, context)
 
     if table.style.table_layout == 'fixed' and table.width != 'auto':
-        fixed_table_layout(wrapper)
+        fixed_table_layout(context, wrapper)
     else:
         auto_table_layout(context, wrapper, containing_block)
 

--- a/weasyprint/tests/test_css.py
+++ b/weasyprint/tests/test_css.py
@@ -401,3 +401,23 @@ def test_units():
     # Ahem: 1ex is 0.8em, 1ch is 1em
     assert margins == [96, 96, 96, 96, 96, 96, 96, 17.6, 15.4, 12]
     assert 4 < default_font_ch < 12  # for 1em = 16px
+
+
+@assert_no_logs
+def test_viewport_units():
+    document = TestHTML(string='''
+        <style>
+          @page {
+            size: 520px 240px;
+            margin: 30px 20px 10px 0;
+          }
+        </style>
+        <p style="width: 0.2vw"></p>
+        <p style="width: 0.6vh"></p>
+        <p style="width: 1vmin"></p>
+        <p style="width: 2vmax"></p>
+    ''')
+    page, = document.render().pages
+    html, = page._page_box.children
+    body, = html.children
+    assert [p.width for p in body.children] == [100, 120, 200, 1000]

--- a/weasyprint/tests/test_css.py
+++ b/weasyprint/tests/test_css.py
@@ -387,6 +387,7 @@ def test_units():
         <p style="margin-left: 6pc"></p>
         <p style="margin-left: 2.54cm"></p>
         <p style="margin-left: 25.4mm"></p>
+        <p style="margin-left: 101.6q"></p>
         <p style="margin-left: 1.1em"></p>
         <p style="margin-left: 1.1ch; font: 14px Ahem"></p>
         <p style="margin-left: 1.5ex; font: 10px Ahem"></p>
@@ -398,5 +399,5 @@ def test_units():
     margins = [round(p.margin_left, 6) for p in body.children]
     default_font_ch = margins.pop()
     # Ahem: 1ex is 0.8em, 1ch is 1em
-    assert margins == [96, 96, 96, 96, 96, 96, 17.6, 15.4, 12]
+    assert margins == [96, 96, 96, 96, 96, 96, 96, 17.6, 15.4, 12]
     assert 4 < default_font_ch < 12  # for 1em = 16px


### PR DESCRIPTION
'q' is a quarter millimeter and is easy to support.

Viewport-percentage lengths are related to the size of the initial containing block, which is the size of the first page area for paged media. Many ways exist to solve them in WeasyPrint, but none is simple as the size of the first page needs to be known (the layout has started) before solving.

The functions solving percentages are already doing this, so I've tried to merge the viewport-percentage and percentage solving functions. The size of the viewport is stored in the layout context and set as soon as the size is known.

This implementation works for most cases, but some problems need to be solved:
- these units may not work yet for properties that don't rely on the `length` computer (quite easy to fix, but may be long to test),
- these units don't work yet for properties relying on the `pixels_only` attribute of the `length` computer (easy but boring to fix),
- these units don't work yet for properties that don't allow percentages (seems easy, but I'm not sure),
- WeasyPrint refuses to render the document when these units are used in properties needed before defining the viewport size. I don't know what to do with that. Moreover, some corner cases are not even solved in the spec. I think that we can safely ignore these cases.

@SimonSapin are you OK with this implementation, or do you have a better idea?

Storing the font size of the root element in the context should be enough to support 'rem' once the first three problems listed above are solved.