### PR TITLE
Replace utf8 with utf-8 for gettext/django compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     WeasyPrint
     ==========

--- a/weasyprint/__init__.py
+++ b/weasyprint/__init__.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     WeasyPrint
     ==========

--- a/weasyprint/__main__.py
+++ b/weasyprint/__main__.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     weasyprint.__main__
     -------------------

--- a/weasyprint/compat.py
+++ b/weasyprint/compat.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     weasyprint.compat
     -----------------

--- a/weasyprint/css/__init__.py
+++ b/weasyprint/css/__init__.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     weasyprint.css
     --------------

--- a/weasyprint/css/computed_values.py
+++ b/weasyprint/css/computed_values.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     weasyprint.css.computed_values
     ------------------------------

--- a/weasyprint/css/properties.py
+++ b/weasyprint/css/properties.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     weasyprint.css.properties
     -------------------------

--- a/weasyprint/css/validation.py
+++ b/weasyprint/css/validation.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     weasyprint.css.validation
     -------------------------

--- a/weasyprint/document.py
+++ b/weasyprint/document.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     weasyprint.document
     -------------------

--- a/weasyprint/draw.py
+++ b/weasyprint/draw.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     weasyprint.draw
     ---------------

--- a/weasyprint/formatting_structure/__init__.py
+++ b/weasyprint/formatting_structure/__init__.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     weasyprint.formatting_structure
     -------------------------------

--- a/weasyprint/formatting_structure/boxes.py
+++ b/weasyprint/formatting_structure/boxes.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     weasyprint.formatting_structure.boxes
     -------------------------------------

--- a/weasyprint/formatting_structure/build.py
+++ b/weasyprint/formatting_structure/build.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     weasyprint.formatting_structure.build
     -------------------------------------

--- a/weasyprint/formatting_structure/counters.py
+++ b/weasyprint/formatting_structure/counters.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     weasyprint.formatting_structure.counters
     ----------------------------------------

--- a/weasyprint/html.py
+++ b/weasyprint/html.py
@@ -1,5 +1,5 @@
 
-# coding: utf8
+# coding: utf-8
 """
     weasyprint.html
     ---------------

--- a/weasyprint/images.py
+++ b/weasyprint/images.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     weasyprint.images
     -----------------

--- a/weasyprint/layout/__init__.py
+++ b/weasyprint/layout/__init__.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     weasyprint.layout
     -----------------

--- a/weasyprint/layout/absolute.py
+++ b/weasyprint/layout/absolute.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     weasyprint.absolute
     -------------------

--- a/weasyprint/layout/backgrounds.py
+++ b/weasyprint/layout/backgrounds.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     weasyprint.backgrounds
     ----------------------

--- a/weasyprint/layout/blocks.py
+++ b/weasyprint/layout/blocks.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     weasyprint.layout.blocks
     ------------------------

--- a/weasyprint/layout/float.py
+++ b/weasyprint/layout/float.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     weasyprint.float
     ----------------

--- a/weasyprint/layout/inlines.py
+++ b/weasyprint/layout/inlines.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     weasyprint.layout.inline
     ------------------------

--- a/weasyprint/layout/markers.py
+++ b/weasyprint/layout/markers.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     weasyprint.layout.markers
     -------------------------

--- a/weasyprint/layout/min_max.py
+++ b/weasyprint/layout/min_max.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     weasyprint.layout.min_max
     -------------------------

--- a/weasyprint/layout/pages.py
+++ b/weasyprint/layout/pages.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     weasyprint.layout.pages
     -----------------------

--- a/weasyprint/layout/percentages.py
+++ b/weasyprint/layout/percentages.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     weasyprint.layout.percentages
     -----------------------------

--- a/weasyprint/layout/preferred.py
+++ b/weasyprint/layout/preferred.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     weasyprint.layout.preferred
     ---------------------------

--- a/weasyprint/layout/replaced.py
+++ b/weasyprint/layout/replaced.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     weasyprint.layout.replaced
     --------------------------

--- a/weasyprint/layout/tables.py
+++ b/weasyprint/layout/tables.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     weasyprint.layout.tables
     ------------------------

--- a/weasyprint/logger.py
+++ b/weasyprint/logger.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     weasyprint.logging
     ------------------

--- a/weasyprint/navigator.py
+++ b/weasyprint/navigator.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     weasyprint.navigator
     --------------------

--- a/weasyprint/pdf.py
+++ b/weasyprint/pdf.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 r"""
     weasyprint.pdf
     --------------

--- a/weasyprint/stacking.py
+++ b/weasyprint/stacking.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     weasyprint.stacking
     -------------------

--- a/weasyprint/tests/__init__.py
+++ b/weasyprint/tests/__init__.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     weasyprint.tests
     ----------------

--- a/weasyprint/tests/test_api.py
+++ b/weasyprint/tests/test_api.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     weasyprint.tests.test_api
     -------------------------

--- a/weasyprint/tests/test_boxes.py
+++ b/weasyprint/tests/test_boxes.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     weasyprint.tests.test_boxes
     ---------------------------

--- a/weasyprint/tests/test_css.py
+++ b/weasyprint/tests/test_css.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     weasyprint.tests.test_css
     -------------------------

--- a/weasyprint/tests/test_css_validation.py
+++ b/weasyprint/tests/test_css_validation.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     weasyprint.tests.test_css_properties
     ------------------------------------

--- a/weasyprint/tests/test_draw.py
+++ b/weasyprint/tests/test_draw.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     weasyprint.tests.test_draw
     --------------------------

--- a/weasyprint/tests/test_layout.py
+++ b/weasyprint/tests/test_layout.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     weasyprint.tests.layout
     -----------------------

--- a/weasyprint/tests/test_pdf.py
+++ b/weasyprint/tests/test_pdf.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     weasyprint.tests.test_pdf
     -------------------------

--- a/weasyprint/tests/test_stacking.py
+++ b/weasyprint/tests/test_stacking.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     weasyprint.tests.stacking
     -------------------------

--- a/weasyprint/tests/test_text.py
+++ b/weasyprint/tests/test_text.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     weasyprint.tests.test_text
     --------------------------

--- a/weasyprint/tests/test_web/__init__.py
+++ b/weasyprint/tests/test_web/__init__.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     weasyprint.tests.test_web
     -------------------------

--- a/weasyprint/tests/test_web/run.py
+++ b/weasyprint/tests/test_web/run.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# coding: utf8
+# coding: utf-8
 """
     weasyprint.tests.test_web.run
     -----------------------------

--- a/weasyprint/tests/testing_utils.py
+++ b/weasyprint/tests/testing_utils.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     weasyprint.tests.testing_utils
     ------------------------------

--- a/weasyprint/text.py
+++ b/weasyprint/text.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     weasyprint.text
     ---------------

--- a/weasyprint/urls.py
+++ b/weasyprint/urls.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     weasyprint.utils
     ----------------


### PR DESCRIPTION
See: http://stackoverflow.com/questions/4370035/django-makemessages-errors-unknown-encoding-utf8

This will fix:
<pre>
CommandError: errors happened while running xgettext on __init__.py
xgettext: ./venv/lib/python3.4/site-packages/weasyprint/__init__.py:1: Unknown encoding "utf8".    Proceeding with ASCII instead.
xgettext: Non-ASCII string at ./venv/lib/python3.4/site-packages/weasyprint/__init__.py:145.
          Please specify the source encoding through --from-code or through a comment
          as specified in http://www.python.org/peps/pep-0263.html.
</pre>