### PR TITLE
Add 'rem' support

### DIFF
--- a/weasyprint/css/__init__.py
+++ b/weasyprint/css/__init__.py
@@ -264,8 +264,8 @@ def add_declaration(cascaded_styles, prop_name, prop_values, weight, element,
         style[prop_name] = prop_values, weight
 
 
-def set_computed_styles(cascaded_styles, computed_styles,
-                        element, parent, pseudo_type=None):
+def set_computed_styles(cascaded_styles, computed_styles, element, parent,
+                        root=None, pseudo_type=None):
     """Set the computed values of styles to ``element``.
 
     Take the properties left by ``apply_style_rule`` on an element or
@@ -495,9 +495,12 @@ def get_all_computed_styles(html, user_stylesheets=None):
     # their children, for inheritance.
 
     # Iterate on all elements, even if there is no cascaded style for them.
+    root = None
     for element in element_tree.iter():
+        if element.tag == 'body':
+            root = element
         set_computed_styles(cascaded_styles, computed_styles, element,
-                            parent=element.getparent())
+                            root=root, parent=element.getparent())
 
     # Then computed styles for @page.
 

--- a/weasyprint/css/__init__.py
+++ b/weasyprint/css/__init__.py
@@ -274,11 +274,12 @@ def set_computed_styles(cascaded_styles, computed_styles, element, parent,
 
     """
     parent_style = computed_styles[parent, None] if parent is not None else None
+    root_style = computed_styles.get((root, None), {})
     cascaded = cascaded_styles.get((element, pseudo_type), {})
-    style = computed_from_cascaded(
-        element, cascaded, parent_style, pseudo_type)
-    computed_styles[element, pseudo_type] = style
 
+    computed_styles[element, pseudo_type] = computed_from_cascaded(
+        element, cascaded, parent_style, pseudo_type, root_style
+    )
 
 
 def computed_from_cascaded(element, cascaded, parent_style, pseudo_type=None, root_style=None):

--- a/weasyprint/css/__init__.py
+++ b/weasyprint/css/__init__.py
@@ -500,12 +500,9 @@ def get_all_computed_styles(html, user_stylesheets=None):
     # their children, for inheritance.
 
     # Iterate on all elements, even if there is no cascaded style for them.
-    root = None
     for element in element_tree.iter():
-        if element.tag == 'body':
-            root = element
         set_computed_styles(cascaded_styles, computed_styles, element,
-                            root=root, parent=element.getparent())
+                            root=element_tree, parent=element.getparent())
 
     # Then computed styles for @page.
 

--- a/weasyprint/css/__init__.py
+++ b/weasyprint/css/__init__.py
@@ -273,11 +273,7 @@ def set_computed_styles(cascaded_styles, computed_styles,
     declaration priority (ie. ``!important``) and selector specificity.
 
     """
-    if parent is None:
-        parent_style = None
-    else:
-        parent_style = computed_styles[parent, None]
-
+    parent_style = computed_styles[parent, None] if parent is not None else None
     cascaded = cascaded_styles.get((element, pseudo_type), {})
     style = computed_from_cascaded(
         element, cascaded, parent_style, pseudo_type)

--- a/weasyprint/css/__init__.py
+++ b/weasyprint/css/__init__.py
@@ -516,7 +516,7 @@ def get_all_computed_styles(html, user_stylesheets=None):
             cascaded_styles, computed_styles, page_type,
             # @page inherits from the root element:
             # http://lists.w3.org/Archives/Public/www-style/2012Jan/1164.html
-            parent=element_tree)
+            root=element_tree, parent=element_tree)
 
     # Then computed styles for pseudo elements, in any order.
     # Pseudo-elements inherit from their associated element so they come
@@ -531,7 +531,7 @@ def get_all_computed_styles(html, user_stylesheets=None):
             set_computed_styles(cascaded_styles, computed_styles,
                                 element, pseudo_type=pseudo_type,
                                 # The pseudo-element inherits from the element.
-                                parent=element)
+                                root=element_tree, parent=element)
 
     # This is mostly useful to make pseudo_type optional.
     def style_for(element, pseudo_type=None, __get=computed_styles.get):

--- a/weasyprint/css/__init__.py
+++ b/weasyprint/css/__init__.py
@@ -275,7 +275,10 @@ def set_computed_styles(cascaded_styles, computed_styles, element, parent,
     """
     parent_style = computed_styles[parent, None] \
         if parent is not None else None
-    root_style = computed_styles.get((root, None), {})
+    # When specified on the font-size property of the root element, the rem
+    # units refer to the property’s initial value.
+    root_style = {'font_size': properties.INITIAL_VALUES['font_size']} \
+        if element is root else computed_styles[root, None]
     cascaded = cascaded_styles.get((element, pseudo_type), {})
 
     computed_styles[element, pseudo_type] = computed_from_cascaded(

--- a/weasyprint/css/__init__.py
+++ b/weasyprint/css/__init__.py
@@ -273,7 +273,8 @@ def set_computed_styles(cascaded_styles, computed_styles, element, parent,
     declaration priority (ie. ``!important``) and selector specificity.
 
     """
-    parent_style = computed_styles[parent, None] if parent is not None else None
+    parent_style = computed_styles[parent, None] \
+        if parent is not None else None
     root_style = computed_styles.get((root, None), {})
     cascaded = cascaded_styles.get((element, pseudo_type), {})
 
@@ -282,7 +283,8 @@ def set_computed_styles(cascaded_styles, computed_styles, element, parent,
     )
 
 
-def computed_from_cascaded(element, cascaded, parent_style, pseudo_type=None, root_style=None):
+def computed_from_cascaded(element, cascaded, parent_style, pseudo_type=None,
+                           root_style=None):
     """Get a dict of computed style mixed from parent and cascaded styles."""
     if not cascaded and parent_style is not None:
         # Fast path for anonymous boxes:

--- a/weasyprint/css/__init__.py
+++ b/weasyprint/css/__init__.py
@@ -280,7 +280,8 @@ def set_computed_styles(cascaded_styles, computed_styles, element, parent,
     computed_styles[element, pseudo_type] = style
 
 
-def computed_from_cascaded(element, cascaded, parent_style, pseudo_type=None):
+
+def computed_from_cascaded(element, cascaded, parent_style, pseudo_type=None, root_style=None):
     """Get a dict of computed style mixed from parent and cascaded styles."""
     if not cascaded and parent_style is not None:
         # Fast path for anonymous boxes:
@@ -326,7 +327,8 @@ def computed_from_cascaded(element, cascaded, parent_style, pseudo_type=None):
         specified[name] = value
 
     return computed_values.compute(
-        element, pseudo_type, specified, computed, parent_style)
+        element, pseudo_type, specified, computed, parent_style, root_style
+    )
 
 
 class Selector(object):

--- a/weasyprint/css/computed_values.py
+++ b/weasyprint/css/computed_values.py
@@ -158,7 +158,7 @@ def register_computer(name):
     return decorator
 
 
-def compute(element, pseudo_type, specified, computed, parent_style):
+def compute(element, pseudo_type, specified, computed, parent_style, root_style):
     """
     Return a StyleDict of computed values.
 
@@ -184,6 +184,7 @@ def compute(element, pseudo_type, specified, computed, parent_style):
     computer.specified = specified
     computer.computed = computed
     computer.parent_style = parent_style
+    computer.root_style = root_style
 
     getter = COMPUTER_FUNCTIONS.get
 

--- a/weasyprint/css/computed_values.py
+++ b/weasyprint/css/computed_values.py
@@ -283,7 +283,7 @@ def length(computer, name, value, font_size=None, pixels_only=False):
     elif unit in LENGTHS_TO_PIXELS:
         # Convert absolute lengths to pixels
         result = value.value * LENGTHS_TO_PIXELS[unit]
-    elif unit in ('em', 'ex', 'ch'):
+    elif unit in ('em', 'ex', 'ch', 'rem'):
         if font_size is None:
             font_size = computer.computed.font_size
         if unit == 'ex':
@@ -300,6 +300,8 @@ def length(computer, name, value, font_size=None, pixels_only=False):
             result = value.value * logical_width
         elif unit == 'em':
             result = value.value * font_size
+        elif unit == 'rem':
+            result = value.value * computer.root_style.font_size
     else:
         # A percentage or 'auto': no conversion needed.
         return value

--- a/weasyprint/css/computed_values.py
+++ b/weasyprint/css/computed_values.py
@@ -158,7 +158,8 @@ def register_computer(name):
     return decorator
 
 
-def compute(element, pseudo_type, specified, computed, parent_style, root_style):
+def compute(element, pseudo_type, specified, computed, parent_style,
+            root_style):
     """
     Return a StyleDict of computed values.
 

--- a/weasyprint/css/validation.py
+++ b/weasyprint/css/validation.py
@@ -33,7 +33,7 @@ from . import computed_values
 
 # get the sets of keys
 LENGTH_UNITS = set(computed_values.LENGTHS_TO_PIXELS) | \
-               {'ex', 'em', 'ch', 'rem'}
+               set(['ex', 'em', 'ch', 'rem'])
 
 
 # keyword -> (open, insert)

--- a/weasyprint/css/validation.py
+++ b/weasyprint/css/validation.py
@@ -32,7 +32,8 @@ from . import computed_values
 
 
 # get the sets of keys
-LENGTH_UNITS = set(computed_values.LENGTHS_TO_PIXELS) | set(['ex', 'em', 'ch'])
+LENGTH_UNITS = set(computed_values.LENGTHS_TO_PIXELS) | \
+               {'ex', 'em', 'ch', 'rem'}
 
 
 # keyword -> (open, insert)


### PR DESCRIPTION
I am using Foundation, that uses the 'rem' unit a lot.

I am not sure about what i am doing here is correctly implementing the spec and the implementation follows "weasyprint conventions". Is there documentation on how weasy works? sequence of operations, what happens where etc?

I read through https://github.com/Kozea/WeasyPrint/pull/264 to maybe figure this out, but I don't need all the viewport related relative units, so I attempted to just solve 'rem' for now.

It's based on the 'font-size' of the root element, so I am passing on the computed style of the 'body' element to `compute()` and use it in `length()`.

My pdf output now works as I'd expect it.