### PR TITLE
Enhance the support of SVG images

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -12,7 +12,7 @@ WeasyPrint |version| depends on:
 * cairocffi_ ≥ 0.3
 * tinycss_ = 0.3
 * cssselect_ ≥ 0.6
-* CairoSVG_ ≥ 0.5
+* CairoSVG_ ≥ 1.0.20
 * Pyphen_ ≥ 0.8
 * Optional: GDK-PixBuf_ [#]_
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ REQUIREMENTS = [
     'html5lib>=0.999',
     'tinycss==0.3',
     'cssselect>=0.6',
-    'CairoSVG>=0.4.1',
+    'CairoSVG>=1.0.20',
     'cffi>=0.6',
     'cairocffi>=0.5',
     'Pyphen>=0.8'

--- a/weasyprint/images.py
+++ b/weasyprint/images.py
@@ -158,7 +158,8 @@ class SVGImage(object):
     def draw(self, context, concrete_width, concrete_height, _image_rendering):
         svg = self._render(concrete_width, concrete_height)
         if svg.width and svg.height:
-            context.scale(concrete_width / svg.width, concrete_height / svg.height)
+            context.scale(
+                concrete_width / svg.width, concrete_height / svg.height)
             context.set_source_surface(svg.cairo)
             context.paint()
 

--- a/weasyprint/images.py
+++ b/weasyprint/images.py
@@ -13,6 +13,7 @@
 from __future__ import division, unicode_literals
 
 from io import BytesIO
+from xml.etree import ElementTree
 import math
 
 import cairocffi
@@ -67,7 +68,7 @@ class RasterImage(object):
             self._intrinsic_width / self._intrinsic_height
             if self._intrinsic_height != 0 else float('inf'))
 
-    def get_intrinsic_size(self, image_resolution):
+    def get_intrinsic_size(self, image_resolution, _font_size):
         # Raster images are affected by the 'image-resolution' property.
         return (self._intrinsic_width / image_resolution,
                 self._intrinsic_height / image_resolution)
@@ -96,6 +97,14 @@ class ScaledSVGSurface(cairosvg.surface.SVGSurface):
         return scale / 0.75
 
 
+class FakeSurface(object):
+    """Fake CairoSVG surface used to get SVG attributes."""
+    context_height = 0
+    context_width = 0
+    font_size = 12
+    dpi = 96
+
+
 class SVGImage(object):
     def __init__(self, svg_data, base_url):
         # Don’t pass data URIs to CairoSVG.
@@ -104,41 +113,54 @@ class SVGImage(object):
             base_url if not base_url.lower().startswith('data:') else None)
         self._svg_data = svg_data
 
-        # TODO: find a way of not doing twice the whole rendering.
         try:
-            svg = self._render()
+            self._tree = ElementTree.fromstring(self._svg_data)
         except Exception as e:
             raise ImageLoadingError.from_exception(e)
-        # TODO: support SVG images with none or only one of intrinsic
-        #       width, height and ratio.
-        if not (svg.width > 0 and svg.height > 0):
-            raise ImageLoadingError(
-                'SVG images without an intrinsic size are not supported.')
-        self._intrinsic_width = svg.width
-        self._intrinsic_height = svg.height
-        self.intrinsic_ratio = self._intrinsic_width / self._intrinsic_height
 
-    def get_intrinsic_size(self, _image_resolution):
-        # Vector images are affected by the 'image-resolution' property.
+    def get_intrinsic_size(self, _image_resolution, font_size):
+        # Vector images may be affected by the font size.
+        fake_surface = FakeSurface()
+        fake_surface.font_size = font_size
+        # Percentages don't provide an intrinsic size, we transform percentages
+        # into 0 using a (0, 0) context size:
+        # http://www.w3.org/TR/SVG/coords.html#IntrinsicSizing
+        self._width = cairosvg.surface.size(
+            fake_surface, self._tree.get('width'))
+        self._height = cairosvg.surface.size(
+            fake_surface, self._tree.get('height'))
+        _, _, viewbox = cairosvg.surface.node_format(fake_surface, self._tree)
+        self._intrinsic_width = self._width or None
+        self._intrinsic_height = self._height or None
+        self.intrinsic_ratio = None
+        if viewbox:
+            if self._width and self._height:
+                self.intrinsic_ratio = self._width / self._height
+            else:
+                self.intrinsic_ratio = (
+                    (viewbox[2] - viewbox[0]) / (viewbox[3] - viewbox[1]))
+                if self._width:
+                    self._intrinsic_height = self._width / self.intrinsic_ratio
+                elif self._height:
+                    self._intrinsic_width = self._height * self.intrinsic_ratio
+        elif self._width and self._height:
+            self.intrinsic_ratio = self._width / self._height
         return self._intrinsic_width, self._intrinsic_height
 
-    def _render(self):
+    def _render(self, width=None, height=None):
         # Draw to a cairo surface but do not write to a file.
         # This is a CairoSVG surface, not a cairo surface.
         return ScaledSVGSurface(
             cairosvg.parser.Tree(
                 bytestring=self._svg_data, url=self._base_url),
-            output=None, dpi=96)
+            output=None, dpi=96, parent_width=width, parent_height=height)
 
     def draw(self, context, concrete_width, concrete_height, _image_rendering):
-        # Do not re-use the rendered Surface object,
-        # but regenerate it as needed.
-        # If a surface for a SVG image is still alive by the time we call
-        # show_page(), cairo will rasterize the image instead writing vectors.
-        svg = self._render()
-        context.scale(concrete_width / svg.width, concrete_height / svg.height)
-        context.set_source_surface(svg.cairo)
-        context.paint()
+        svg = self._render(concrete_width, concrete_height)
+        if svg.width and svg.height:
+            context.scale(concrete_width / svg.width, concrete_height / svg.height)
+            context.set_source_surface(svg.cairo)
+            context.paint()
 
 
 def get_image_from_uri(cache, url_fetcher, url, forced_mime_type=None):
@@ -291,8 +313,8 @@ class Gradient(object):
         #: bool
         self.repeating = repeating
 
-    def get_intrinsic_size(self, _image_resolution):
-        # Raster images are affected by the 'image-resolution' property.
+    def get_intrinsic_size(self, _image_resolution, _font_size):
+        # Gradients are not affected by image resolution, parent or font size.
         return None, None
 
     intrinsic_ratio = None

--- a/weasyprint/images.py
+++ b/weasyprint/images.py
@@ -161,10 +161,6 @@ class SVGImage(object):
                     concrete_width / svg.width, concrete_height / svg.height)
                 context.set_source_surface(svg.cairo)
                 context.paint()
-            else:
-                LOGGER.warning(
-                    'Trying to draw an SVG image at %s'
-                    'with width or height equal to 0' % self._base_url)
         except Exception as e:
             LOGGER.warning(
                 'Failed to draw an SVG image at %s : %s', self._base_url, e)

--- a/weasyprint/images.py
+++ b/weasyprint/images.py
@@ -137,12 +137,14 @@ class SVGImage(object):
             if self._width and self._height:
                 self.intrinsic_ratio = self._width / self._height
             else:
-                self.intrinsic_ratio = (
-                    (viewbox[2] - viewbox[0]) / (viewbox[3] - viewbox[1]))
-                if self._width:
-                    self._intrinsic_height = self._width / self.intrinsic_ratio
-                elif self._height:
-                    self._intrinsic_width = self._height * self.intrinsic_ratio
+                if viewbox[2] and viewbox[3]:
+                    self.intrinsic_ratio = viewbox[2] / viewbox[3]
+                    if self._width:
+                        self._intrinsic_height = (
+                            self._width / self.intrinsic_ratio)
+                    elif self._height:
+                        self._intrinsic_width = (
+                            self._height * self.intrinsic_ratio)
         elif self._width and self._height:
             self.intrinsic_ratio = self._width / self._height
         return self._intrinsic_width, self._intrinsic_height

--- a/weasyprint/layout/backgrounds.py
+++ b/weasyprint/layout/backgrounds.py
@@ -147,7 +147,7 @@ def layout_background_layer(box, page, resolution, image, size, clip, repeat,
             assert clip == 'content-box', clip
             clipped_boxes = [box.rounded_content_box()]
 
-    if image is None or 0 in image.get_intrinsic_size(1):
+    if image is None or 0 in image.get_intrinsic_size(1, 1):
         return BackgroundLayer(
             image=None, unbounded=(box is page), painting_area=painting_area,
             size='unused', position='unused', repeat='unused',
@@ -172,7 +172,8 @@ def layout_background_layer(box, page, resolution, image, size, clip, repeat,
             positioning_width, positioning_height, image.intrinsic_ratio)
     else:
         size_width, size_height = size
-        iwidth, iheight = image.get_intrinsic_size(resolution)
+        iwidth, iheight = image.get_intrinsic_size(
+            resolution, box.style.font_size)
         image_width, image_height = replaced.default_image_sizing(
             iwidth, iheight, image.intrinsic_ratio,
             percentage(size_width, positioning_width),

--- a/weasyprint/layout/preferred.py
+++ b/weasyprint/layout/preferred.py
@@ -554,7 +554,8 @@ def replaced_min_content_width(box, outer=True):
             assert height.unit == 'px'
             height = height.value
         image = box.replacement
-        iwidth, iheight = image.get_intrinsic_size(box.style.image_resolution)
+        iwidth, iheight = image.get_intrinsic_size(
+            box.style.image_resolution, box.style.font_size)
         width, _ = default_image_sizing(
             iwidth, iheight, image.intrinsic_ratio, 'auto', height,
             default_width=300, default_height=150)

--- a/weasyprint/layout/replaced.py
+++ b/weasyprint/layout/replaced.py
@@ -23,7 +23,8 @@ def image_marker_layout(box):
     """
     image = box.replacement
     one_em = box.style.font_size
-    iwidth, iheight = image.get_intrinsic_size(box.style.image_resolution)
+    iwidth, iheight = image.get_intrinsic_size(
+        box.style.image_resolution, one_em)
     box.width, box.height = default_image_sizing(
         iwidth, iheight, image.intrinsic_ratio, box.width, box.height,
         default_width=one_em, default_height=one_em)
@@ -57,10 +58,14 @@ def default_image_sizing(intrinsic_width, intrinsic_height, intrinsic_ratio,
             else default_width
         ), specified_height
     else:
-        return (intrinsic_width if intrinsic_width is not None
-                else default_width,
-                intrinsic_height if intrinsic_height is not None
-                else default_height)
+        if intrinsic_width is not None or intrinsic_height is not None:
+            return default_image_sizing(
+                intrinsic_width, intrinsic_height, intrinsic_ratio,
+                intrinsic_width, intrinsic_height, default_width,
+                default_height)
+        else:
+            return contain_constraint_image_sizing(
+                default_width, default_height, intrinsic_ratio)
 
 
 def contain_constraint_image_sizing(

--- a/weasyprint/tests/test_draw.py
+++ b/weasyprint/tests/test_draw.py
@@ -1328,11 +1328,9 @@ def test_images():
                             alt="Hello, world!">'''),
             ]
         ])
-    assert len(logs) == 2
+    assert len(logs) == 1
     assert 'WARNING: Failed to load image' in logs[0]
     assert 'inexistent2.png' in logs[0]
-    assert 'WARNING: Failed to load image at data:image/svg+xml' in logs[1]
-    assert 'intrinsic size' in logs[1]
 
     assert_pixels('image_0x1', 8, 8, no_image, '''
         <style>


### PR DESCRIPTION
This commit adds two features:
- don't render SVG files twice anymore; and
- support SVG images with no intrinsic ratio.

This PR is useful for these two features (mainly the SVG rendered only once for me), but also for the tests: the W3C test suite relies on SVG files with no intrinsic size even for some tests unrelated to this feature, we won't be polluted anymore on these tests by this missing feature.

The related W3C tests pass (except one pathological case) with the latest git master version of CairoSVG. The current PyPI version of CairoSVG (1.0.20) has the needed API but has a poor support of SVG files with no intrinsic size.