### PR TITLE
Fix CairoSVG 2.0 pre-release dependency in Python 2.x

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,17 @@
 WeasyPrint changelog
 ====================
 
+
+Version 0.29
+------------
+
+*Not released yet.*
+
+Bug fixes:
+* `#323: <https://github.com/Kozea/WeasyPrint/pull/323>`_:
+  Fix CairoSVG 2.0 pre-release dependency in Python 2.x.
+
+
 Version 0.28
 ------------
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ REQUIREMENTS = [
     'html5lib>=0.999',
     'tinycss==0.3',
     'cssselect>=0.6',
-    'CairoSVG>=1.0.20',
     'cffi>=0.6',
     'cairocffi>=0.5',
     'Pyphen>=0.8'
@@ -39,6 +38,11 @@ REQUIREMENTS = [
 if sys.version_info < (2, 7) or (3,) <= sys.version_info < (3, 2):
     # In the stdlib from 2.7 and 3.2:
     REQUIREMENTS.append('argparse')
+
+if sys.version_info < (3,):
+    REQUIREMENTS.append('CairoSVG >= 1.0.20, < 2')
+else:
+    REQUIREMENTS.append('CairoSVG >= 1.0.20')
 
 setup(
     name='WeasyPrint',


### PR DESCRIPTION
CairoSVG 2.0 drop Python 2.x support. See:
* https://github.com/Kozea/CairoSVG/blob/2.0.0rc2/NEWS.rst#version-20-not-released-yet
* https://github.com/Kozea/CairoSVG/issues/106

While the final revision of CairoSVG 2.0 hasn't been released yet, there is a `CairoSVG-2.0.0rc2` pre-released package available in PyPi. As a result, WeasyPrint deployments on Python 2.x environment with the `pip --pre` parameter fails.