### PR TITLE
Fix the Windows support

### DIFF
--- a/weasyprint/compat.py
+++ b/weasyprint/compat.py
@@ -12,6 +12,7 @@
 
 from __future__ import division, unicode_literals
 
+import codecs
 import sys
 import email
 
@@ -22,6 +23,15 @@ __all__ = ['Request', 'base64_decode', 'base64_encode', 'basestring',
            'urlencode', 'urljoin', 'urlopen', 'urllib_get_content_type',
            'urllib_get_charset', 'urllib_get_filename',
            'urlparse_uses_relative', 'urlsplit', 'xrange']
+
+
+# getfilesystemencoding() on Linux is sometimes stupid...
+FILESYSTEM_ENCODING = sys.getfilesystemencoding() or 'utf-8'
+try:
+    if codecs.lookup(FILESYSTEM_ENCODING).name == 'ascii':
+        FILESYSTEM_ENCODING = 'utf-8'
+except LookupError:
+    FILESYSTEM_ENCODING = 'utf-8'
 
 
 if sys.version_info[0] >= 3:
@@ -63,7 +73,7 @@ else:
     from urlparse import (urljoin, urlsplit, parse_qs,
                           uses_relative as urlparse_uses_relative)
     from urllib2 import urlopen, Request
-    from urllib import pathname2url, quote, unquote, urlencode
+    from urllib import pathname2url as _pathname2url, quote, unquote, urlencode
     from array import array as _array
     from itertools import izip, imap
     from base64 import (decodestring as base64_decode,
@@ -76,6 +86,11 @@ else:
 
     def array(typecode, initializer):
         return _array(typecode.encode('ascii'), initializer)
+
+    def pathname2url(path):
+        if isinstance(path, unicode):
+            path = path.encode(FILESYSTEM_ENCODING)
+        return _pathname2url(path)
 
     def urllib_get_content_type(urlobj):
         return urlobj.info().gettype()

--- a/weasyprint/document.py
+++ b/weasyprint/document.py
@@ -11,7 +11,6 @@
 from __future__ import division, unicode_literals
 
 import io
-import sys
 import math
 import shutil
 import functools
@@ -28,8 +27,7 @@ from .layout import layout_document
 from .layout.backgrounds import percentage
 from .draw import draw_page, stacked
 from .pdf import write_pdf_metadata
-from .compat import izip, iteritems, unicode
-from .urls import FILESYSTEM_ENCODING
+from .compat import izip, iteritems
 
 
 def _get_matrix(box):
@@ -551,9 +549,6 @@ class Document(object):
             surface.write_to_png(target)
             png_bytes = target.getvalue()
         else:
-            if sys.version_info[0] < 3 and isinstance(target, unicode):
-                # py2cairo 1.8 does not support unicode filenames.
-                target = target.encode(FILESYSTEM_ENCODING)
             surface.write_to_png(target)
             png_bytes = None
         return png_bytes, max_width, sum_heights

--- a/weasyprint/urls.py
+++ b/weasyprint/urls.py
@@ -27,7 +27,8 @@ from .logger import LOGGER
 from .compat import (
     urljoin, urlsplit, quote, unquote, unquote_to_bytes, urlopen,
     urllib_get_content_type, urllib_get_charset, urllib_get_filename, Request,
-    parse_email, pathname2url, unicode, base64_decode, StreamingGzipFile)
+    parse_email, pathname2url, unicode, base64_decode, StreamingGzipFile,
+    FILESYSTEM_ENCODING)
 
 
 # Unlinke HTML, CSS and PNG, the SVG MIME type is not always builtin
@@ -54,7 +55,8 @@ def iri_to_uri(url):
         # Data URIs can be huge, but don’t need this anyway.
         return url
     # Use UTF-8 as per RFC 3987 (IRI), except for file://
-    url = url.encode('utf-8')
+    url = url.encode(FILESYSTEM_ENCODING
+                     if url.startswith('file:') else 'utf-8')
     # This is a full URI, not just a component. Only %-encode characters
     # that are not allowed at all in URIs. Everthing else is "safe":
     # * Reserved characters: /:?#[]@!$&'()*+,;=

--- a/weasyprint/urls.py
+++ b/weasyprint/urls.py
@@ -258,12 +258,6 @@ def default_url_fetcher(url):
     """
     if url.lower().startswith('data:'):
         return open_data_url(url)
-    elif url.lower().startswith('file:'):
-        filename = unquote(url[7:])  # len('file://') == 7
-        mime_type = mimetypes.guess_type(filename)[0]
-        with open(filename, 'rb') as fd:
-            return dict(filename=filename, string=fd.read(),
-                        mime_type=mime_type, redirected_url=url)
     elif UNICODE_SCHEME_RE.match(url):
         url = iri_to_uri(url)
         response = urlopen(Request(url, headers=HTTP_HEADERS))


### PR DESCRIPTION
I've tried many little things to make WeasyPrint work with both Python 2 and 3, and here's the best solution I've found.

- As explained in #132, the problem is that `pathname2url` doesn't accept bytestrings with Python 3 on Windows. As Python 2 allows bytes and Python 3 allows unicode with all OSes, I've added the `encode` in the `compat` module's `pathname2url` implementation.
- Contrary to what I've said, there's no need to be afraid of returning unicode strings in `path2url`: unicode is actually already returned because of the implicit cast due to `u'abc' + b'abc'` at the end of the function.
- @SimonSapin's idea to use `open` instead of `urlopen` is a good idea, but it's not related to this problem. For the record, I've tried to use `open`, but URIs for Windows filenames have an extra slash before the volume (something like `/C:/path`). This leading path is explained by the RFC and it's handled correctly by `urlopen`, duplicating code to handle it (and other needed features such as guessing mimetypes) in WP may be useless. We can do this later if we want.
- I've put the `FILESYSTEM_ENCODING` variable in the `compat` module: it's not a bad place and avoids a circular import.

Finally, this PR is pretty equivalent to #132, but a bit cleaner :smile:.

It's been tested with Python 2.7 and 3.5, on Windows 10 and Linux. Some tests launched with `py.test` even work on Windows (but some tests make Python crash, fun fun fun).