### PR TITLE
Support presentational hints

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -33,8 +33,11 @@ Some elements need special treatment:
   or in SVG with CairoSVG_. SVG images are not rasterized but rendered
   as vectors in the PDF output.
 
-HTML `presentational hints`_ (like the ``width`` attribute on an ``img``
-element) are **not** supported. Use CSS in the ``style`` attribute instead.
+HTML `presentational hints`_ are not supported by default, but can be supported:
+
+* by using the ``--presentational-hints`` CLI parameter, or
+* by setting the ``presentational_hints`` parameter of the ``HTML.render`` or
+  ``HTML.write_*`` methods to ``True``.
 
 .. _CairoSVG: http://cairosvg.org/
 .. _GdkPixbuf: https://live.gnome.org/GdkPixbuf

--- a/weasyprint/__init__.py
+++ b/weasyprint/__init__.py
@@ -107,6 +107,9 @@ class HTML(object):
     def _ua_stylesheets(self):
         return [HTML5_UA_STYLESHEET]
 
+    def _ph_stylesheets(self):
+        return [HTML5_PH_STYLESHEET]
+
     def _get_metadata(self):
         return get_html_metadata(self.root_element)
 
@@ -352,5 +355,7 @@ def _select_source(guess=None, filename=None, url=None, file_obj=None,
 
 # Work around circular imports.
 from .css import PARSER, preprocess_stylesheet  # noqa
-from .html import find_base_url, HTML5_UA_STYLESHEET, get_html_metadata  # noqa
+from .html import (
+    find_base_url, HTML5_UA_STYLESHEET, HTML5_PH_STYLESHEET,
+    get_html_metadata)  # noqa
 from .document import Document, Page  # noqa

--- a/weasyprint/__init__.py
+++ b/weasyprint/__init__.py
@@ -110,7 +110,8 @@ class HTML(object):
     def _get_metadata(self):
         return get_html_metadata(self.root_element)
 
-    def render(self, stylesheets=None, enable_hinting=False):
+    def render(self, stylesheets=None, enable_hinting=False,
+               presentational_hints=False):
         """Lay out and paginate the document, but do not (yet) export it
         to PDF or another format.
 
@@ -129,10 +130,14 @@ class HTML(object):
             Whether text, borders and background should be *hinted* to fall
             at device pixel boundaries. Should be enabled for pixel-based
             output (like PNG) but not vector based output (like PDF).
+        :type presentational_hints: bool
+        :param presentational_hints: Whether HTML presentational hints are
+            followed.
         :returns: A :class:`~document.Document` object.
 
         """
-        return Document._render(self, stylesheets, enable_hinting)
+        return Document._render(
+            self, stylesheets, enable_hinting, presentational_hints)
 
     def write_pdf(self, target=None, stylesheets=None, zoom=1,
                   attachments=None):

--- a/weasyprint/__init__.py
+++ b/weasyprint/__init__.py
@@ -140,7 +140,7 @@ class HTML(object):
             self, stylesheets, enable_hinting, presentational_hints)
 
     def write_pdf(self, target=None, stylesheets=None, zoom=1,
-                  attachments=None):
+                  attachments=None, presentational_hints=False):
         """Render the document to a PDF file.
 
         This is a shortcut for calling :meth:`render`, then
@@ -163,21 +163,28 @@ class HTML(object):
         :param attachments: A list of additional file attachments for the
             generated PDF document or :obj:`None`. The list's elements are
             :class:`Attachment` objects, filenames, URLs or file-like objects.
+        :type presentational_hints: bool
+        :param presentational_hints: Whether HTML presentational hints are
+            followed.
         :returns:
             The PDF as byte string if :obj:`target` is not provided or
             :obj:`None`, otherwise :obj:`None` (the PDF is written to
             :obj:`target`.)
 
         """
-        return self.render(stylesheets).write_pdf(target, zoom, attachments)
+        return self.render(stylesheets, presentational_hints).write_pdf(
+            target, zoom, attachments)
 
-    def write_image_surface(self, stylesheets=None, resolution=96):
+    def write_image_surface(self, stylesheets=None, resolution=96,
+                            presentational_hints=False):
         surface, _width, _height = (
-            self.render(stylesheets, enable_hinting=True)
+            self.render(stylesheets, enable_hinting=True,
+                        presentational_hints=presentational_hints)
             .write_image_surface(resolution))
         return surface
 
-    def write_png(self, target=None, stylesheets=None, resolution=96):
+    def write_png(self, target=None, stylesheets=None, resolution=96,
+                  presentational_hints=False):
         """Paint the pages vertically to a single PNG image.
 
         There is no decoration around pages other than those specified in CSS
@@ -197,6 +204,9 @@ class HTML(object):
         :param resolution:
             The output resolution in PNG pixels per CSS inch. At 96 dpi
             (the default), PNG pixels match the CSS ``px`` unit.
+        :type presentational_hints: bool
+        :param presentational_hints: Whether HTML presentational hints are
+            followed.
         :returns:
             The image as byte string if :obj:`target` is not provided or
             :obj:`None`, otherwise :obj:`None` (the image is written to
@@ -204,7 +214,8 @@ class HTML(object):
 
         """
         png_bytes, _width, _height = (
-            self.render(stylesheets, enable_hinting=True)
+            self.render(stylesheets, enable_hinting=True,
+                        presentational_hints=presentational_hints)
             .write_png(target, resolution))
         return png_bytes
 

--- a/weasyprint/__main__.py
+++ b/weasyprint/__main__.py
@@ -66,6 +66,10 @@ def main(argv=None, stdout=None, stdin=None):
         Adds an attachment to the document which is included in the PDF output.
         This option can be added multiple times to attach more files.
 
+    .. option:: -p, --presentational-hints
+
+        Follow HTML presentational hints.
+
     .. option:: --version
 
         Show the version number. Other options and arguments are ignored.
@@ -100,6 +104,8 @@ def main(argv=None, stdout=None, stdin=None):
     parser.add_argument('-a', '--attachment', action='append',
                         help='URL or filename of a file '
                              'to attach to the PDF document')
+    parser.add_argument('-p', '--presentational-hints', action='store_true',
+                        help='Follow HTML presentational hints.')
     parser.add_argument(
         'input', help='URL or filename of the HTML input, or - for stdin')
     parser.add_argument(
@@ -152,7 +158,8 @@ def main(argv=None, stdout=None, stdin=None):
             parser.error('--attachment only applies for the PDF format.')
 
     html = HTML(source, base_url=args.base_url, encoding=args.encoding,
-                media_type=args.media_type)
+                media_type=args.media_type,
+                presentational_hints=args.presentational_hints)
     getattr(html, 'write_' + format_)(output, **kwargs)
 
 

--- a/weasyprint/__main__.py
+++ b/weasyprint/__main__.py
@@ -144,7 +144,9 @@ def main(argv=None, stdout=None, stdin=None):
     else:
         output = args.output
 
-    kwargs = {'stylesheets': args.stylesheet}
+    kwargs = {
+        'stylesheets': args.stylesheet,
+        'presentational_hints': args.presentational_hints}
     if args.resolution:
         if format_ == 'png':
             kwargs['resolution'] = args.resolution
@@ -158,8 +160,7 @@ def main(argv=None, stdout=None, stdin=None):
             parser.error('--attachment only applies for the PDF format.')
 
     html = HTML(source, base_url=args.base_url, encoding=args.encoding,
-                media_type=args.media_type,
-                presentational_hints=args.presentational_hints)
+                media_type=args.media_type)
     getattr(html, 'write_' + format_)(output, **kwargs)
 
 

--- a/weasyprint/css/__init__.py
+++ b/weasyprint/css/__init__.py
@@ -209,25 +209,26 @@ def check_style_attribute(parser, element, style_attribute):
     return element, declarations, element_base_url(element)
 
 
-def find_style_attributes(element_tree):
-    """
-    Yield ``element, declaration, base_url`` for elements with
-    a "style" attribute.
+def find_style_attributes(element_tree, presentational_hints=False):
+    """Yield ``specificity, (element, declaration, base_url)`` rules.
+
+    Rules from "style" attribute are returned with specificity
+    ``(1, 0, 0, 0)``.
+
+    If ``presentational_hints`` is ``True``, rules from presentational hints
+    are returned with specificity ``(0, 0, 0, 0)``.
+
     """
     parser = PARSER
     for element in element_tree.iter():
+        specificity = (1, 0, 0, 0)
         style_attribute = element.get('style')
         if style_attribute:
-            yield check_style_attribute(parser, element, style_attribute)
-
-
-def find_presentational_hints(element_tree):
-    """
-    Yield ``element, declaration, base_url`` for elements with
-    presentational hints.
-    """
-    parser = PARSER
-    for element in element_tree.iter():
+            yield specificity, check_style_attribute(
+                parser, element, style_attribute)
+        if not presentational_hints:
+            continue
+        specificity = (0, 0, 0, 0)
         if element.tag == 'body':
             for prop, position in (
                     ('height', 'top'), ('height', 'bottom'),
@@ -239,48 +240,55 @@ def find_presentational_hints(element_tree):
                             position, element.get('margin%r' % prop))
                         break
                 if style_attribute:
-                    yield check_style_attribute(
+                    yield specificity, check_style_attribute(
                         parser, element, style_attribute)
             if element.get('background'):
                 style_attribute = 'background-image:%s' % (
                     element.get('background'))
-                yield check_style_attribute(parser, element, style_attribute)
+                yield specificity, check_style_attribute(
+                    parser, element, style_attribute)
             if element.get('bgcolor'):
                 style_attribute = 'background-color:%s' % (
                     element.get('bgcolor'))
-                yield check_style_attribute(parser, element, style_attribute)
+                yield specificity, check_style_attribute(
+                    parser, element, style_attribute)
             if element.get('text'):
                 style_attribute = 'color:%s' % element.get('text')
-                yield check_style_attribute(parser, element, style_attribute)
+                yield check_style_attribute(
+                    parser, element, style_attribute)
         elif element.tag == 'pre':
             if 'wrap' in element:
-                yield check_style_attribute(
+                yield specificity, check_style_attribute(
                     parser, element, 'white-space:pre-wrap')
         elif element.tag == 'center':
-            yield check_style_attribute(parser, element, 'text-align:center')
+            yield specificity, check_style_attribute(
+                parser, element, 'text-align:center')
         elif element.tag == 'div':
             align = element.get('align', '').lower()
             if align == 'middle':
-                yield check_style_attribute(
+                yield specificity, check_style_attribute(
                     parser, element, 'text-align:center')
             elif align in ('center', 'left', 'right', 'justify'):
-                yield check_style_attribute(
+                yield specificity, check_style_attribute(
                     parser, element, 'text-align:%s' % align)
         elif element.tag == 'br':
             clear = element.get('clear', '').lower()
             if clear:
                 if clear == 'left':
-                    yield check_style_attribute(parser, element, 'clear:left')
+                    yield specificity, check_style_attribute(
+                        parser, element, 'clear:left')
                 elif clear == 'right':
-                    yield check_style_attribute(parser, element, 'clear:right')
+                    yield specificity, check_style_attribute(
+                        parser, element, 'clear:right')
                 elif clear in ('all', 'both'):
-                    yield check_style_attribute(parser, element, 'clear:both')
+                    yield specificity, check_style_attribute(
+                        parser, element, 'clear:both')
         elif element.tag == 'font':
             if element.get('color'):
-                yield check_style_attribute(
+                yield specificity, check_style_attribute(
                     parser, element, 'color:%s' % element.get('color'))
             if element.get('face'):
-                yield check_style_attribute(
+                yield specificity, check_style_attribute(
                     parser, element, 'font-family:%s' % element.get('face'))
             if element.get('size'):
                 size = element.get('size').strip()
@@ -307,195 +315,206 @@ def find_presentational_hints(element_tree):
                     elif relative_minus:
                         size -= 3
                     size = min(1, max(7, size))
-                    yield check_style_attribute(
+                    yield specificity, check_style_attribute(
                         parser, element, 'font-size:%s' % font_sizes[size])
         elif element.tag in ('ol', 'ul', 'li'):
             if element.get('type'):
                 if element.tag in ('ol', 'li'):
                     if element.get('type') == '1':
-                        yield check_style_attribute(
+                        yield specificity, check_style_attribute(
                             parser, element, 'list-style-type:decimal')
                     elif element.get('type') == 'a':
-                        yield check_style_attribute(
+                        yield specificity, check_style_attribute(
                             parser, element, 'list-style-type:lower-alpha')
                     elif element.get('type') == 'A':
-                        yield check_style_attribute(
+                        yield specificity, check_style_attribute(
                             parser, element, 'list-style-type:upper-alpha')
                     elif element.get('type') == 'i':
-                        yield check_style_attribute(
+                        yield specificity, check_style_attribute(
                             parser, element, 'list-style-type:lower-roman')
                     elif element.get('type') == 'I':
-                        yield check_style_attribute(
+                        yield specificity, check_style_attribute(
                             parser, element, 'list-style-type:upper-roman')
                 elif element.tag in ('ul', 'li'):
                     if element.get('type').lower() in (
                             'disc', 'circle', 'square'):
-                        yield check_style_attribute(
+                        yield specificity, check_style_attribute(
                             parser, element,
                             'list-style-type:%s' % element.get('type').lower())
         elif element.tag == 'table':
             # TODO: Rules for children are not handled
             align = element.get('align', '').lower()
             if align == 'left':
-                yield check_style_attribute(parser, element, 'float:left')
+                yield specificity, check_style_attribute(
+                    parser, element, 'float:left')
             elif align == 'right':
-                yield check_style_attribute(parser, element, 'float:right')
+                yield specificity, check_style_attribute(
+                    parser, element, 'float:right')
             elif align == 'center':
-                yield check_style_attribute(
+                yield specificity, check_style_attribute(
                     parser, element, 'margin-left:auto;margin-right:auto')
             rules = element.get('rules', '').lower()
             if rules in ('none', 'groups', 'rows', 'cols', 'all'):
-                yield check_style_attribute(
+                yield specificity, check_style_attribute(
                     parser, element,
                     'border-style:hidden;border-collapse:collapse')
             if 'border' in element:
-                yield check_style_attribute(
+                yield specificity, check_style_attribute(
                     parser, element, 'border-style:outset')
             frame = element.get('frame', '').lower()
             if frame == 'void':
-                yield check_style_attribute(
+                yield specificity, check_style_attribute(
                     parser, element, 'border-style:hidden')
             elif frame == 'above':
-                yield check_style_attribute(
+                yield specificity, check_style_attribute(
                     parser, element,
                     'border-style:outset hidden hidden hidden')
             elif frame == 'below':
-                yield check_style_attribute(
+                yield specificity, check_style_attribute(
                     parser, element,
                     'border-style:hidden hidden outset hidden')
             elif frame == 'hsides':
-                yield check_style_attribute(
+                yield specificity, check_style_attribute(
                     parser, element,
                     'border-style:outset hidden outset hidden')
             elif frame == 'lhs':
-                yield check_style_attribute(
+                yield specificity, check_style_attribute(
                     parser, element,
                     'border-style:hidden hidden hidden outset')
             elif frame == 'rhs':
-                yield check_style_attribute(
+                yield specificity, check_style_attribute(
                     parser, element,
                     'border-style:hidden outset hidden hidden')
             elif frame == 'vslides':
-                yield check_style_attribute(
+                yield specificity, check_style_attribute(
                     parser, element,
                     'border-style:hidden outset')
             elif frame in ('box', 'border'):
-                yield check_style_attribute(
+                yield specificity, check_style_attribute(
                     parser, element, 'border-style:outset')
             if element.get('cellspacing'):
-                yield check_style_attribute(
+                yield specificity, check_style_attribute(
                     parser, element,
                     'border-spacing:%spx' % element.get('cellspacing'))
             if element.get('hspace'):
                 hspace = element.get('hspace')
                 if hspace.isdigit():
                     hspace += 'px'
-                yield check_style_attribute(
+                yield specificity, check_style_attribute(
                     parser, element,
                     'margin-left:%s;margin-right:%s' % (hspace, hspace))
             if element.get('vspace'):
                 vspace = element.get('vspace')
                 if vspace.isdigit():
                     vspace += 'px'
-                yield check_style_attribute(
+                yield specificity, check_style_attribute(
                     parser, element,
                     'margin-top:%s;margin-bottom:%s' % (vspace, vspace))
             if element.get('width'):
                 style_attribute = 'width:%s' % element.get('width')
                 if element.get('width').isdigit():
                     style_attribute += 'px'
-                yield check_style_attribute(parser, element, style_attribute)
+                yield specificity, check_style_attribute(
+                    parser, element, style_attribute)
             if element.get('height'):
                 style_attribute = 'height:%s' % element.get('height')
                 if element.get('height').isdigit():
                     style_attribute += 'px'
-                yield check_style_attribute(parser, element, style_attribute)
+                yield specificity, check_style_attribute(
+                    parser, element, style_attribute)
             if element.get('background'):
                 style_attribute = 'background-image:%s' % (
                     element.get('background'))
-                yield check_style_attribute(parser, element, style_attribute)
+                yield specificity, check_style_attribute(
+                    parser, element, style_attribute)
             if element.get('bgcolor'):
                 style_attribute = 'background-color:%s' % (
                     element.get('bgcolor'))
-                yield check_style_attribute(parser, element, style_attribute)
+                yield specificity, check_style_attribute(
+                    parser, element, style_attribute)
             if element.get('bordercolor'):
                 style_attribute = 'border-color:%s' % (
                     element.get('bordercolor'))
-                yield check_style_attribute(parser, element, style_attribute)
+                yield specificity, check_style_attribute(
+                    parser, element, style_attribute)
             if element.get('border'):
                 style_attribute = 'border-width:%spx' % (
                     element.get('border'))
-                yield check_style_attribute(parser, element, style_attribute)
+                yield specificity, check_style_attribute(
+                    parser, element, style_attribute)
         elif element.tag in ('tr', 'td', 'th', 'thead', 'tbody', 'tfoot'):
             align = element.get('align', '').lower()
             if align == 'absmiddle':
-                yield check_style_attribute(
+                yield specificity, check_style_attribute(
                     parser, element, 'text-align:center')
             if align in ('left', 'right', 'justify'):
-                yield check_style_attribute(
+                yield specificity, check_style_attribute(
                     parser, element, 'text-align:%s' % align)
             valign = element.get('valign', '').lower()
             if valign in ('top', 'middle', 'bottom', 'baseline'):
-                yield check_style_attribute(
+                yield specificity, check_style_attribute(
                     parser, element, 'vertical-align:%s' % valign)
             if element.tag in ('td', 'th'):
                 if 'nowrap' in element:
-                    yield check_style_attribute(
+                    yield specificity, check_style_attribute(
                         parser, element, 'white-space:nowrap')
                 if element.get('cellpadding'):
-                    yield check_style_attribute(
+                    yield specificity, check_style_attribute(
                         parser, element,
                         'padding:%spx' % element.get('cellpadding'))
                 if element.get('width'):
                     style_attribute = 'width:%s' % element.get('width')
                     if element.get('width').isdigit():
                         style_attribute += 'px'
-                    yield check_style_attribute(
+                    yield specificity, check_style_attribute(
                         parser, element, style_attribute)
             if element.tag in ('tr', 'td', 'th'):
                 if element.get('height'):
                     style_attribute = 'height:%s' % element.get('height')
                     if element.get('height').isdigit():
                         style_attribute += 'px'
-                    yield check_style_attribute(
+                    yield specificity, check_style_attribute(
                         parser, element, style_attribute)
             if element.get('background'):
                 style_attribute = 'background-image:%s' % (
                     element.get('background'))
-                yield check_style_attribute(parser, element, style_attribute)
+                yield specificity, check_style_attribute(
+                    parser, element, style_attribute)
             if element.get('bgcolor'):
                 style_attribute = 'background-color:%s' % (
                     element.get('bgcolor'))
-                yield check_style_attribute(parser, element, style_attribute)
+                yield specificity, check_style_attribute(
+                    parser, element, style_attribute)
         elif element.tag == 'caption':
             align = element.get('align', '').lower()
             if align == 'bottom':
-                yield check_style_attribute(
+                yield specificity, check_style_attribute(
                     parser, element, 'caption-side:bottom')
             if align in ('left', 'right', 'justify'):
-                yield check_style_attribute(
+                yield specificity, check_style_attribute(
                     parser, element, 'text-align:%s' % align)
         elif element.tag == 'col':
             if element.get('width'):
                 style_attribute = 'width:%s' % element.get('width')
                 if element.get('width').isdigit():
                     style_attribute += 'px'
-                yield check_style_attribute(parser, element, style_attribute)
+                yield specificity, check_style_attribute(
+                    parser, element, style_attribute)
         elif element.tag in ('p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'):
             align = element.get('align', '').lower()
             if align in ('center', 'left', 'right', 'justify'):
-                yield check_style_attribute(
+                yield specificity, check_style_attribute(
                     parser, element, 'text-align:%s' % align)
         elif element.tag == 'hr':
             align = element.get('align', '').lower()
             if align == 'left':
-                yield check_style_attribute(
+                yield specificity, check_style_attribute(
                     parser, element, 'margin-left:0;margin-right:auto')
             elif align == 'right':
-                yield check_style_attribute(
+                yield specificity, check_style_attribute(
                     parser, element, 'margin-left:auto;margin-right:0')
             elif align == 'center':
-                yield check_style_attribute(
+                yield specificity, check_style_attribute(
                     parser, element, 'margin-left:auto;margin-right:auto')
             size = 0
             if element.get('size'):
@@ -504,24 +523,25 @@ def find_presentational_hints(element_tree):
                 except ValueError:
                     LOGGER.warning('Invalid value for size: %s' % size)
             if 'color' in element or 'noshade' in element:
-                yield check_style_attribute(
+                yield specificity, check_style_attribute(
                     parser, element, 'border-style:solid')
                 if size >= 1:
-                    yield check_style_attribute(
+                    yield specificity, check_style_attribute(
                         parser, element, 'border-width:%spx' % size / 2)
             elif size == 1:
-                yield check_style_attribute(
+                yield specificity, check_style_attribute(
                     parser, element, 'border-bottom-width:0')
             elif size > 1:
-                yield check_style_attribute(
+                yield specificity, check_style_attribute(
                     parser, element, 'height:%spx' % (size - 2))
             if element.get('width'):
                 style_attribute = 'width:%s' % element.get('width')
                 if element.get('width').isdigit():
                     style_attribute += 'px'
-                yield check_style_attribute(parser, element, style_attribute)
+                yield specificity, check_style_attribute(
+                    parser, element, style_attribute)
             if element.get('color'):
-                yield check_style_attribute(
+                yield specificity, check_style_attribute(
                     parser, element, 'color:%s' % element.get('color'))
         elif element.tag in (
                 'iframe', 'applet', 'embed', 'img', 'input', 'object'):
@@ -529,30 +549,30 @@ def find_presentational_hints(element_tree):
                     element.get('type', '').lower() == 'image'):
                 align = element.get('align', '').lower()
                 if align in ('left', 'right'):
-                    yield check_style_attribute(
+                    yield specificity, check_style_attribute(
                         parser, element, 'float:%s' % align)
                 elif align in ('top', 'baseline', 'bottom'):
-                    yield check_style_attribute(
+                    yield specificity, check_style_attribute(
                         parser, element, 'vertical-align:%s' % align)
                 elif align == 'texttop':
-                    yield check_style_attribute(
+                    yield specificity, check_style_attribute(
                         parser, element, 'vertical-align:text-top')
                 elif align in ('absmiddle', 'abscenter', 'middle', 'center'):
                     # TODO: middle and center values are wrong
-                    yield check_style_attribute(
+                    yield specificity, check_style_attribute(
                         parser, element, 'vertical-align:middle')
                 if element.get('hspace'):
                     hspace = element.get('hspace')
                     if hspace.isdigit():
                         hspace += 'px'
-                    yield check_style_attribute(
+                    yield specificity, check_style_attribute(
                         parser, element,
                         'margin-left:%s;margin-right:%s' % (hspace, hspace))
                 if element.get('vspace'):
                     vspace = element.get('vspace')
                     if vspace.isdigit():
                         vspace += 'px'
-                    yield check_style_attribute(
+                    yield specificity, check_style_attribute(
                         parser, element,
                         'margin-top:%s;margin-bottom:%s' % (vspace, vspace))
                 # TODO: img seems to be excluded for width and height, but a
@@ -561,23 +581,24 @@ def find_presentational_hints(element_tree):
                     style_attribute = 'width:%s' % element.get('width')
                     if element.get('width').isdigit():
                         style_attribute += 'px'
-                    yield check_style_attribute(
+                    yield specificity, check_style_attribute(
                         parser, element, style_attribute)
                 if element.get('height'):
                     style_attribute = 'height:%s' % element.get('height')
                     if element.get('height').isdigit():
                         style_attribute += 'px'
-                    yield check_style_attribute(
+                    yield specificity, check_style_attribute(
                         parser, element, style_attribute)
                 if element.tag in ('img', 'object', 'input'):
                     if element.get('border'):
-                        yield check_style_attribute(
+                        yield specificity, check_style_attribute(
                             parser, element,
                             'border-width:%spx;border-style:solid' %
                             element.get('border'))
             if element.tag == 'iframe':
                 if element.get('frameborder', '').lower() in ('0', 'no'):
-                    yield check_style_attribute(parser, element, 'border:none')
+                    yield specificity, check_style_attribute(
+                        parser, element, 'border:none')
 
 
 def evaluate_media_query(query_list, device_media_type):
@@ -848,18 +869,9 @@ def get_all_computed_styles(html, user_stylesheets=None,
                                 cascaded_styles, name, values, weight,
                                 element, pseudo_type)
 
-    if presentational_hints:
-        specificity = (0, 0, 0, 0)
-        for element, declarations, base_url in find_presentational_hints(
-                element_tree):
-            for name, values, importance in preprocess_declarations(
-                    base_url, declarations):
-                precedence = declaration_precedence('author', importance)
-                weight = (precedence, specificity)
-                add_declaration(cascaded_styles, name, values, weight, element)
-
-    specificity = (1, 0, 0, 0)
-    for element, declarations, base_url in find_style_attributes(element_tree):
+    for specificity, attributes in find_style_attributes(
+            element_tree, presentational_hints):
+        element, declarations, base_url = attributes
         for name, values, importance in preprocess_declarations(
                 base_url, declarations):
             precedence = declaration_precedence('author', importance)

--- a/weasyprint/css/__init__.py
+++ b/weasyprint/css/__init__.py
@@ -242,10 +242,12 @@ def find_presentational_hints(element_tree):
                     yield check_style_attribute(
                         parser, element, style_attribute)
             if element.get('background'):
-                style_attribute = 'background-image:%s' % element.get('background')
+                style_attribute = 'background-image:%s' % (
+                    element.get('background'))
                 yield check_style_attribute(parser, element, style_attribute)
             if element.get('bgcolor'):
-                style_attribute = 'background-color:%s' % element.get('bgcolor')
+                style_attribute = 'background-color:%s' % (
+                    element.get('bgcolor'))
                 yield check_style_attribute(parser, element, style_attribute)
             if element.get('text'):
                 style_attribute = 'color:%s' % element.get('text')
@@ -326,7 +328,8 @@ def find_presentational_hints(element_tree):
                         yield check_style_attribute(
                             parser, element, 'list-style-type:upper-roman')
                 elif element.tag in ('ul', 'li'):
-                    if element.get('type').lower() in ('disc', 'circle', 'square'):
+                    if element.get('type').lower() in (
+                            'disc', 'circle', 'square'):
                         yield check_style_attribute(
                             parser, element,
                             'list-style-type:%s' % element.get('type').lower())

--- a/weasyprint/css/__init__.py
+++ b/weasyprint/css/__init__.py
@@ -798,9 +798,9 @@ def preprocess_stylesheet(device_media_type, base_url, rules, url_fetcher):
                     yield margin_rule, selector_list, declarations
 
 
-def get_all_computed_styles(html, user_stylesheets=None):
-    """Compute all the computed styles of all elements
-    in the given ``html`` document.
+def get_all_computed_styles(html, user_stylesheets=None,
+                            presentational_hints=False):
+    """Compute all the computed styles of all elements in ``html`` document.
 
     Do everything from finding author stylesheets to parsing and applying them.
 
@@ -848,14 +848,15 @@ def get_all_computed_styles(html, user_stylesheets=None):
                                 cascaded_styles, name, values, weight,
                                 element, pseudo_type)
 
-    specificity = (0, 0, 0, 0)
-    for element, declarations, base_url in find_presentational_hints(
-            element_tree):
-        for name, values, importance in preprocess_declarations(
-                base_url, declarations):
-            precedence = declaration_precedence('author', importance)
-            weight = (precedence, specificity)
-            add_declaration(cascaded_styles, name, values, weight, element)
+    if presentational_hints:
+        specificity = (0, 0, 0, 0)
+        for element, declarations, base_url in find_presentational_hints(
+                element_tree):
+            for name, values, importance in preprocess_declarations(
+                    base_url, declarations):
+                precedence = declaration_precedence('author', importance)
+                weight = (precedence, specificity)
+                add_declaration(cascaded_styles, name, values, weight, element)
 
     specificity = (1, 0, 0, 0)
     for element, declarations, base_url in find_style_attributes(element_tree):

--- a/weasyprint/css/__init__.py
+++ b/weasyprint/css/__init__.py
@@ -237,7 +237,7 @@ def find_style_attributes(element_tree, presentational_hints=False):
                 for prop in ('margin%s' % prop, '%smargin' % prop):
                     if element.get(prop):
                         style_attribute = 'margin-%s:%spx' % (
-                            position, element.get('margin%r' % prop))
+                            position, element.get('margin%s' % prop))
                         break
                 if style_attribute:
                     yield specificity, check_style_attribute(
@@ -256,10 +256,6 @@ def find_style_attributes(element_tree, presentational_hints=False):
                 style_attribute = 'color:%s' % element.get('text')
                 yield check_style_attribute(
                     parser, element, style_attribute)
-        elif element.tag == 'pre':
-            if 'wrap' in element:
-                yield specificity, check_style_attribute(
-                    parser, element, 'white-space:pre-wrap')
         elif element.tag == 'center':
             yield specificity, check_style_attribute(
                 parser, element, 'text-align:center')
@@ -271,18 +267,6 @@ def find_style_attributes(element_tree, presentational_hints=False):
             elif align in ('center', 'left', 'right', 'justify'):
                 yield specificity, check_style_attribute(
                     parser, element, 'text-align:%s' % align)
-        elif element.tag == 'br':
-            clear = element.get('clear', '').lower()
-            if clear:
-                if clear == 'left':
-                    yield specificity, check_style_attribute(
-                        parser, element, 'clear:left')
-                elif clear == 'right':
-                    yield specificity, check_style_attribute(
-                        parser, element, 'clear:right')
-                elif clear in ('all', 'both'):
-                    yield specificity, check_style_attribute(
-                        parser, element, 'clear:both')
         elif element.tag == 'font':
             if element.get('color'):
                 yield specificity, check_style_attribute(
@@ -317,81 +301,7 @@ def find_style_attributes(element_tree, presentational_hints=False):
                     size = min(1, max(7, size))
                     yield specificity, check_style_attribute(
                         parser, element, 'font-size:%s' % font_sizes[size])
-        elif element.tag in ('ol', 'ul', 'li'):
-            if element.get('type'):
-                if element.tag in ('ol', 'li'):
-                    if element.get('type') == '1':
-                        yield specificity, check_style_attribute(
-                            parser, element, 'list-style-type:decimal')
-                    elif element.get('type') == 'a':
-                        yield specificity, check_style_attribute(
-                            parser, element, 'list-style-type:lower-alpha')
-                    elif element.get('type') == 'A':
-                        yield specificity, check_style_attribute(
-                            parser, element, 'list-style-type:upper-alpha')
-                    elif element.get('type') == 'i':
-                        yield specificity, check_style_attribute(
-                            parser, element, 'list-style-type:lower-roman')
-                    elif element.get('type') == 'I':
-                        yield specificity, check_style_attribute(
-                            parser, element, 'list-style-type:upper-roman')
-                elif element.tag in ('ul', 'li'):
-                    if element.get('type').lower() in (
-                            'disc', 'circle', 'square'):
-                        yield specificity, check_style_attribute(
-                            parser, element,
-                            'list-style-type:%s' % element.get('type').lower())
         elif element.tag == 'table':
-            # TODO: Rules for children are not handled
-            align = element.get('align', '').lower()
-            if align == 'left':
-                yield specificity, check_style_attribute(
-                    parser, element, 'float:left')
-            elif align == 'right':
-                yield specificity, check_style_attribute(
-                    parser, element, 'float:right')
-            elif align == 'center':
-                yield specificity, check_style_attribute(
-                    parser, element, 'margin-left:auto;margin-right:auto')
-            rules = element.get('rules', '').lower()
-            if rules in ('none', 'groups', 'rows', 'cols', 'all'):
-                yield specificity, check_style_attribute(
-                    parser, element,
-                    'border-style:hidden;border-collapse:collapse')
-            if 'border' in element:
-                yield specificity, check_style_attribute(
-                    parser, element, 'border-style:outset')
-            frame = element.get('frame', '').lower()
-            if frame == 'void':
-                yield specificity, check_style_attribute(
-                    parser, element, 'border-style:hidden')
-            elif frame == 'above':
-                yield specificity, check_style_attribute(
-                    parser, element,
-                    'border-style:outset hidden hidden hidden')
-            elif frame == 'below':
-                yield specificity, check_style_attribute(
-                    parser, element,
-                    'border-style:hidden hidden outset hidden')
-            elif frame == 'hsides':
-                yield specificity, check_style_attribute(
-                    parser, element,
-                    'border-style:outset hidden outset hidden')
-            elif frame == 'lhs':
-                yield specificity, check_style_attribute(
-                    parser, element,
-                    'border-style:hidden hidden hidden outset')
-            elif frame == 'rhs':
-                yield specificity, check_style_attribute(
-                    parser, element,
-                    'border-style:hidden outset hidden hidden')
-            elif frame == 'vslides':
-                yield specificity, check_style_attribute(
-                    parser, element,
-                    'border-style:hidden outset')
-            elif frame in ('box', 'border'):
-                yield specificity, check_style_attribute(
-                    parser, element, 'border-style:outset')
             if element.get('cellspacing'):
                 yield specificity, check_style_attribute(
                     parser, element,
@@ -444,37 +354,10 @@ def find_style_attributes(element_tree, presentational_hints=False):
                     parser, element, style_attribute)
         elif element.tag in ('tr', 'td', 'th', 'thead', 'tbody', 'tfoot'):
             align = element.get('align', '').lower()
-            if align == 'absmiddle':
-                yield specificity, check_style_attribute(
-                    parser, element, 'text-align:center')
             if align in ('left', 'right', 'justify'):
+                # TODO: we should align descendants too
                 yield specificity, check_style_attribute(
                     parser, element, 'text-align:%s' % align)
-            valign = element.get('valign', '').lower()
-            if valign in ('top', 'middle', 'bottom', 'baseline'):
-                yield specificity, check_style_attribute(
-                    parser, element, 'vertical-align:%s' % valign)
-            if element.tag in ('td', 'th'):
-                if 'nowrap' in element:
-                    yield specificity, check_style_attribute(
-                        parser, element, 'white-space:nowrap')
-                if element.get('cellpadding'):
-                    yield specificity, check_style_attribute(
-                        parser, element,
-                        'padding:%spx' % element.get('cellpadding'))
-                if element.get('width'):
-                    style_attribute = 'width:%s' % element.get('width')
-                    if element.get('width').isdigit():
-                        style_attribute += 'px'
-                    yield specificity, check_style_attribute(
-                        parser, element, style_attribute)
-            if element.tag in ('tr', 'td', 'th'):
-                if element.get('height'):
-                    style_attribute = 'height:%s' % element.get('height')
-                    if element.get('height').isdigit():
-                        style_attribute += 'px'
-                    yield specificity, check_style_attribute(
-                        parser, element, style_attribute)
             if element.get('background'):
                 style_attribute = 'background-image:%s' % (
                     element.get('background'))
@@ -485,11 +368,27 @@ def find_style_attributes(element_tree, presentational_hints=False):
                     element.get('bgcolor'))
                 yield specificity, check_style_attribute(
                     parser, element, style_attribute)
+            if element.tag in ('tr', 'td', 'th'):
+                if element.get('height'):
+                    style_attribute = 'height:%s' % element.get('height')
+                    if element.get('height').isdigit():
+                        style_attribute += 'px'
+                    yield specificity, check_style_attribute(
+                        parser, element, style_attribute)
+                if element.tag in ('td', 'th'):
+                    if element.get('cellpadding'):
+                        yield specificity, check_style_attribute(
+                            parser, element,
+                            'padding:%spx' % element.get('cellpadding'))
+                    if element.get('width'):
+                        style_attribute = 'width:%s' % element.get('width')
+                        if element.get('width').isdigit():
+                            style_attribute += 'px'
+                        yield specificity, check_style_attribute(
+                            parser, element, style_attribute)
         elif element.tag == 'caption':
             align = element.get('align', '').lower()
-            if align == 'bottom':
-                yield specificity, check_style_attribute(
-                    parser, element, 'caption-side:bottom')
+            # TODO: we should align descendants too
             if align in ('left', 'right', 'justify'):
                 yield specificity, check_style_attribute(
                     parser, element, 'text-align:%s' % align)
@@ -500,22 +399,7 @@ def find_style_attributes(element_tree, presentational_hints=False):
                     style_attribute += 'px'
                 yield specificity, check_style_attribute(
                     parser, element, style_attribute)
-        elif element.tag in ('p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'):
-            align = element.get('align', '').lower()
-            if align in ('center', 'left', 'right', 'justify'):
-                yield specificity, check_style_attribute(
-                    parser, element, 'text-align:%s' % align)
         elif element.tag == 'hr':
-            align = element.get('align', '').lower()
-            if align == 'left':
-                yield specificity, check_style_attribute(
-                    parser, element, 'margin-left:0;margin-right:auto')
-            elif align == 'right':
-                yield specificity, check_style_attribute(
-                    parser, element, 'margin-left:auto;margin-right:0')
-            elif align == 'center':
-                yield specificity, check_style_attribute(
-                    parser, element, 'margin-left:auto;margin-right:auto')
             size = 0
             if element.get('size'):
                 try:
@@ -523,8 +407,6 @@ def find_style_attributes(element_tree, presentational_hints=False):
                 except ValueError:
                     LOGGER.warning('Invalid value for size: %s' % size)
             if 'color' in element or 'noshade' in element:
-                yield specificity, check_style_attribute(
-                    parser, element, 'border-style:solid')
                 if size >= 1:
                     yield specificity, check_style_attribute(
                         parser, element, 'border-width:%spx' % size / 2)
@@ -548,16 +430,7 @@ def find_style_attributes(element_tree, presentational_hints=False):
             if (element.tag != 'input' or
                     element.get('type', '').lower() == 'image'):
                 align = element.get('align', '').lower()
-                if align in ('left', 'right'):
-                    yield specificity, check_style_attribute(
-                        parser, element, 'float:%s' % align)
-                elif align in ('top', 'baseline', 'bottom'):
-                    yield specificity, check_style_attribute(
-                        parser, element, 'vertical-align:%s' % align)
-                elif align == 'texttop':
-                    yield specificity, check_style_attribute(
-                        parser, element, 'vertical-align:text-top')
-                elif align in ('absmiddle', 'abscenter', 'middle', 'center'):
+                if align in ('middle', 'center'):
                     # TODO: middle and center values are wrong
                     yield specificity, check_style_attribute(
                         parser, element, 'vertical-align:middle')
@@ -595,10 +468,6 @@ def find_style_attributes(element_tree, presentational_hints=False):
                             parser, element,
                             'border-width:%spx;border-style:solid' %
                             element.get('border'))
-            if element.tag == 'iframe':
-                if element.get('frameborder', '').lower() in ('0', 'no'):
-                    yield specificity, check_style_attribute(
-                        parser, element, 'border:none')
 
 
 def evaluate_media_query(query_list, device_media_type):
@@ -835,6 +704,10 @@ def get_all_computed_styles(html, user_stylesheets=None,
     ua_stylesheets = html._ua_stylesheets()
     author_stylesheets = list(find_stylesheets(
         element_tree, device_media_type, url_fetcher))
+    if presentational_hints:
+        ph_stylesheets = html._ph_stylesheets()
+    else:
+        ph_stylesheets = []
 
     # keys: (element, pseudo_element_type)
     #    element: a lxml element object or the '@page' string for @page styles
@@ -848,17 +721,18 @@ def get_all_computed_styles(html, user_stylesheets=None,
     #             http://www.w3.org/TR/CSS21/cascade.html#cascading-order
     cascaded_styles = {}
 
-    for sheets, origin in (
+    for sheets, origin, sheet_specificity in (
         # Order here is not important ('origin' is).
         # Use this order for a regression test
-        (ua_stylesheets or [], 'user agent'),
-        (author_stylesheets, 'author'),
-        (user_stylesheets or [], 'user'),
+        (ua_stylesheets or [], 'user agent', None),
+        (ph_stylesheets, 'author', (0, 0, 0, 0)),
+        (author_stylesheets, 'author', None),
+        (user_stylesheets or [], 'user', None),
     ):
         for sheet in sheets:
             for _rule, selector_list, declarations in sheet.rules:
                 for selector in selector_list:
-                    specificity = selector.specificity
+                    specificity = sheet_specificity or selector.specificity
                     pseudo_type = selector.pseudo_element
                     for element in selector.match(element_tree):
                         for name, values, importance in declarations:

--- a/weasyprint/css/html5_ph.css
+++ b/weasyprint/css/html5_ph.css
@@ -7,81 +7,84 @@ expressed as CSS.
 
 See https://www.w3.org/TR/html5/rendering.html#rendering
 
+TODO: Attribute values are not case-insensitive, but they should be. We can add
+a "i" flag when CSS Selectors Level 4 is supported.
+
 */
 
 pre[wrap] { white-space: pre-wrap; }
 
-br[clear=left i] { clear: left; }
-br[clear=right i] { clear: right; }
-br[clear=all i], br[clear=both i] { clear: both; }
+br[clear=left] { clear: left; }
+br[clear=right] { clear: right; }
+br[clear=all], br[clear=both] { clear: both; }
 
 ol[type=1], li[type=1] { list-style-type: decimal; }
 ol[type=a], li[type=a] { list-style-type: lower-alpha; }
 ol[type=A], li[type=A] { list-style-type: upper-alpha; }
 ol[type=i], li[type=i] { list-style-type: lower-roman; }
 ol[type=I], li[type=I] { list-style-type: upper-roman; }
-ul[type=disc i], li[type=disc i] { list-style-type: disc; }
-ul[type=circle i], li[type=circle i] { list-style-type: circle; }
-ul[type=square i], li[type=square i] { list-style-type: square; }
+ul[type=disc], li[type=disc] { list-style-type: disc; }
+ul[type=circle], li[type=circle] { list-style-type: circle; }
+ul[type=square], li[type=square] { list-style-type: square; }
 
-table[align=left i] { float: left; }
-table[align=right i] { float: right; }
-table[align=center i] { margin-left: auto; margin-right: auto; }
-thead[align=absmiddle i], tbody[align=absmiddle i], tfoot[align=absmiddle i],
-tr[align=absmiddle i], td[align=absmiddle i], th[align=absmiddle i] {
+table[align=left] { float: left; }
+table[align=right] { float: right; }
+table[align=center] { margin-left: auto; margin-right: auto; }
+thead[align=absmiddle], tbody[align=absmiddle], tfoot[align=absmiddle],
+tr[align=absmiddle], td[align=absmiddle], th[align=absmiddle] {
   text-align: center;
 }
 
-caption[align=bottom i] { caption-side: bottom; }
-p[align=left i], h1[align=left i], h2[align=left i], h3[align=left i],
-h4[align=left i], h5[align=left i], h6[align=left i] {
+caption[align=bottom] { caption-side: bottom; }
+p[align=left], h1[align=left], h2[align=left], h3[align=left],
+h4[align=left], h5[align=left], h6[align=left] {
   text-align: left;
 }
-p[align=right i], h1[align=right i], h2[align=right i], h3[align=right i],
-h4[align=right i], h5[align=right i], h6[align=right i] {
+p[align=right], h1[align=right], h2[align=right], h3[align=right],
+h4[align=right], h5[align=right], h6[align=right] {
   text-align: right;
 }
-p[align=center i], h1[align=center i], h2[align=center i], h3[align=center i],
-h4[align=center i], h5[align=center i], h6[align=center i] {
+p[align=center], h1[align=center], h2[align=center], h3[align=center],
+h4[align=center], h5[align=center], h6[align=center] {
   text-align: center;
 }
-p[align=justify i], h1[align=justify i], h2[align=justify i], h3[align=justify i],
-h4[align=justify i], h5[align=justify i], h6[align=justify i] {
+p[align=justify], h1[align=justify], h2[align=justify], h3[align=justify],
+h4[align=justify], h5[align=justify], h6[align=justify] {
   text-align: justify;
 }
-thead[valign=top i], tbody[valign=top i], tfoot[valign=top i],
-tr[valign=top i], td[valign=top i], th[valign=top i] {
+thead[valign=top], tbody[valign=top], tfoot[valign=top],
+tr[valign=top], td[valign=top], th[valign=top] {
   vertical-align: top;
 }
-thead[valign=middle i], tbody[valign=middle i], tfoot[valign=middle i],
-tr[valign=middle i], td[valign=middle i], th[valign=middle i] {
+thead[valign=middle], tbody[valign=middle], tfoot[valign=middle],
+tr[valign=middle], td[valign=middle], th[valign=middle] {
   vertical-align: middle;
 }
-thead[valign=bottom i], tbody[valign=bottom i], tfoot[valign=bottom i],
-tr[valign=bottom i], td[valign=bottom i], th[valign=bottom i] {
+thead[valign=bottom], tbody[valign=bottom], tfoot[valign=bottom],
+tr[valign=bottom], td[valign=bottom], th[valign=bottom] {
   vertical-align: bottom;
 }
-thead[valign=baseline i], tbody[valign=baseline i], tfoot[valign=baseline i],
-tr[valign=baseline i], td[valign=baseline i], th[valign=baseline i] {
+thead[valign=baseline], tbody[valign=baseline], tfoot[valign=baseline],
+tr[valign=baseline], td[valign=baseline], th[valign=baseline] {
   vertical-align: baseline;
 }
 
 td[nowrap], th[nowrap] { white-space: nowrap; }
 
-table[rules=none i], table[rules=groups i], table[rules=rows i],
-table[rules=cols i], table[rules=all i] {
+table[rules=none], table[rules=groups], table[rules=rows],
+table[rules=cols], table[rules=all] {
   border-style: hidden;
   border-collapse: collapse;
 }
 table[border] { border-style: outset; } /* only if border is not equivalent to zero */
-table[frame=void i] { border-style: hidden; }
-table[frame=above i] { border-style: outset hidden hidden hidden; }
-table[frame=below i] { border-style: hidden hidden outset hidden; }
-table[frame=hsides i] { border-style: outset hidden outset hidden; }
-table[frame=lhs i] { border-style: hidden hidden hidden outset; }
-table[frame=rhs i] { border-style: hidden outset hidden hidden; }
-table[frame=vsides i] { border-style: hidden outset; }
-table[frame=box i], table[frame=border i] { border-style: outset; }
+table[frame=void] { border-style: hidden; }
+table[frame=above] { border-style: outset hidden hidden hidden; }
+table[frame=below] { border-style: hidden hidden outset hidden; }
+table[frame=hsides] { border-style: outset hidden outset hidden; }
+table[frame=lhs] { border-style: hidden hidden hidden outset; }
+table[frame=rhs] { border-style: hidden outset hidden hidden; }
+table[frame=vsides] { border-style: hidden outset; }
+table[frame=box], table[frame=border] { border-style: outset; }
 
 table[border] > tr > td, table[border] > tr > th,
 table[border] > thead > tr > td, table[border] > thead > tr > th,
@@ -91,53 +94,53 @@ table[border] > tfoot > tr > td, table[border] > tfoot > tr > th {
   border-width: 1px;
   border-style: inset;
 }
-table[rules=none i] > tr > td, table[rules=none i] > tr > th,
-table[rules=none i] > thead > tr > td, table[rules=none i] > thead > tr > th,
-table[rules=none i] > tbody > tr > td, table[rules=none i] > tbody > tr > th,
-table[rules=none i] > tfoot > tr > td, table[rules=none i] > tfoot > tr > th,
-table[rules=groups i] > tr > td, table[rules=groups i] > tr > th,
-table[rules=groups i] > thead > tr > td, table[rules=groups i] > thead > tr > th,
-table[rules=groups i] > tbody > tr > td, table[rules=groups i] > tbody > tr > th,
-table[rules=groups i] > tfoot > tr > td, table[rules=groups i] > tfoot > tr > th,
-table[rules=rows i] > tr > td, table[rules=rows i] > tr > th,
-table[rules=rows i] > thead > tr > td, table[rules=rows i] > thead > tr > th,
-table[rules=rows i] > tbody > tr > td, table[rules=rows i] > tbody > tr > th,
-table[rules=rows i] > tfoot > tr > td, table[rules=rows i] > tfoot > tr > th {
+table[rules=none] > tr > td, table[rules=none] > tr > th,
+table[rules=none] > thead > tr > td, table[rules=none] > thead > tr > th,
+table[rules=none] > tbody > tr > td, table[rules=none] > tbody > tr > th,
+table[rules=none] > tfoot > tr > td, table[rules=none] > tfoot > tr > th,
+table[rules=groups] > tr > td, table[rules=groups] > tr > th,
+table[rules=groups] > thead > tr > td, table[rules=groups] > thead > tr > th,
+table[rules=groups] > tbody > tr > td, table[rules=groups] > tbody > tr > th,
+table[rules=groups] > tfoot > tr > td, table[rules=groups] > tfoot > tr > th,
+table[rules=rows] > tr > td, table[rules=rows] > tr > th,
+table[rules=rows] > thead > tr > td, table[rules=rows] > thead > tr > th,
+table[rules=rows] > tbody > tr > td, table[rules=rows] > tbody > tr > th,
+table[rules=rows] > tfoot > tr > td, table[rules=rows] > tfoot > tr > th {
   border-width: 1px;
   border-style: none;
 }
-table[rules=cols i] > tr > td, table[rules=cols i] > tr > th,
-table[rules=cols i] > thead > tr > td, table[rules=cols i] > thead > tr > th,
-table[rules=cols i] > tbody > tr > td, table[rules=cols i] > tbody > tr > th,
-table[rules=cols i] > tfoot > tr > td, table[rules=cols i] > tfoot > tr > th {
+table[rules=cols] > tr > td, table[rules=cols] > tr > th,
+table[rules=cols] > thead > tr > td, table[rules=cols] > thead > tr > th,
+table[rules=cols] > tbody > tr > td, table[rules=cols] > tbody > tr > th,
+table[rules=cols] > tfoot > tr > td, table[rules=cols] > tfoot > tr > th {
   border-width: 1px;
   border-style: none solid;
 }
-table[rules=all i] > tr > td, table[rules=all i] > tr > th,
-table[rules=all i] > thead > tr > td, table[rules=all i] > thead > tr > th,
-table[rules=all i] > tbody > tr > td, table[rules=all i] > tbody > tr > th,
-table[rules=all i] > tfoot > tr > td, table[rules=all i] > tfoot > tr > th {
+table[rules=all] > tr > td, table[rules=all] > tr > th,
+table[rules=all] > thead > tr > td, table[rules=all] > thead > tr > th,
+table[rules=all] > tbody > tr > td, table[rules=all] > tbody > tr > th,
+table[rules=all] > tfoot > tr > td, table[rules=all] > tfoot > tr > th {
   border-width: 1px;
   border-style: solid;
 }
 
-table[rules=groups i] > colgroup {
+table[rules=groups] > colgroup {
   border-left-width: 1px;
   border-left-style: solid;
   border-right-width: 1px;
   border-right-style: solid;
 }
-table[rules=groups i] > thead,
-table[rules=groups i] > tbody,
-table[rules=groups i] > tfoot {
+table[rules=groups] > thead,
+table[rules=groups] > tbody,
+table[rules=groups] > tfoot {
   border-top-width: 1px;
   border-top-style: solid;
   border-bottom-width: 1px;
   border-bottom-style: solid;
 }
 
-table[rules=rows i] > tr, table[rules=rows i] > thead > tr,
-table[rules=rows i] > tbody > tr, table[rules=rows i] > tfoot > tr {
+table[rules=rows] > tr, table[rules=rows] > thead > tr,
+table[rules=rows] > tbody > tr, table[rules=rows] > tfoot > tr {
   border-top-width: 1px;
   border-top-style: solid;
   border-bottom-width: 1px;
@@ -149,42 +152,42 @@ hr[align=right] { margin-left: auto; margin-right: 0; }
 hr[align=center] { margin-left: auto; margin-right: auto; }
 hr[color], hr[noshade] { border-style: solid; }
 
-iframe[frameborder=0], iframe[frameborder=no i] { border: none; }
+iframe[frameborder=0], iframe[frameborder=no] { border: none; }
 
-applet[align=left i], embed[align=left i], iframe[align=left i],
-img[align=left i], input[type=image i][align=left i], object[align=left i] {
+applet[align=left], embed[align=left], iframe[align=left],
+img[align=left], input[type=image][align=left], object[align=left] {
   float: left;
 }
 
-applet[align=right i], embed[align=right i], iframe[align=right i],
-img[align=right i], input[type=image i][align=right i], object[align=right i] {
+applet[align=right], embed[align=right], iframe[align=right],
+img[align=right], input[type=image][align=right], object[align=right] {
   float: right;
 }
 
-applet[align=top i], embed[align=top i], iframe[align=top i],
-img[align=top i], input[type=image i][align=top i], object[align=top i] {
+applet[align=top], embed[align=top], iframe[align=top],
+img[align=top], input[type=image][align=top], object[align=top] {
   vertical-align: top;
 }
 
-applet[align=baseline i], embed[align=baseline i], iframe[align=baseline i],
-img[align=baseline i], input[type=image i][align=baseline i], object[align=baseline i] {
+applet[align=baseline], embed[align=baseline], iframe[align=baseline],
+img[align=baseline], input[type=image][align=baseline], object[align=baseline] {
   vertical-align: baseline;
 }
 
-applet[align=texttop i], embed[align=texttop i], iframe[align=texttop i],
-img[align=texttop i], input[type=image i][align=texttop i], object[align=texttop i] {
+applet[align=texttop], embed[align=texttop], iframe[align=texttop],
+img[align=texttop], input[type=image][align=texttop], object[align=texttop] {
   vertical-align: text-top;
 }
 
-applet[align=absmiddle i], embed[align=absmiddle i], iframe[align=absmiddle i],
-img[align=absmiddle i], input[type=image i][align=absmiddle i], object[align=absmiddle i],
-applet[align=abscenter i], embed[align=abscenter i], iframe[align=abscenter i],
-img[align=abscenter i], input[type=image i][align=abscenter i], object[align=abscenter i] {
+applet[align=absmiddle], embed[align=absmiddle], iframe[align=absmiddle],
+img[align=absmiddle], input[type=image][align=absmiddle], object[align=absmiddle],
+applet[align=abscenter], embed[align=abscenter], iframe[align=abscenter],
+img[align=abscenter], input[type=image][align=abscenter], object[align=abscenter] {
   vertical-align: middle;
 }
 
-applet[align=bottom i], embed[align=bottom i], iframe[align=bottom i],
-img[align=bottom i], input[type=image i][align=bottom i],
-object[align=bottom i] {
+applet[align=bottom], embed[align=bottom], iframe[align=bottom],
+img[align=bottom], input[type=image][align=bottom],
+object[align=bottom] {
   vertical-align: bottom;
 }

--- a/weasyprint/css/html5_ph.css
+++ b/weasyprint/css/html5_ph.css
@@ -1,0 +1,190 @@
+/*
+
+Presentational hints stylsheet for HTML.
+
+This stylesheet contains all the presentational hints rules that can be
+expressed as CSS.
+
+See https://www.w3.org/TR/html5/rendering.html#rendering
+
+*/
+
+pre[wrap] { white-space: pre-wrap; }
+
+br[clear=left i] { clear: left; }
+br[clear=right i] { clear: right; }
+br[clear=all i], br[clear=both i] { clear: both; }
+
+ol[type=1], li[type=1] { list-style-type: decimal; }
+ol[type=a], li[type=a] { list-style-type: lower-alpha; }
+ol[type=A], li[type=A] { list-style-type: upper-alpha; }
+ol[type=i], li[type=i] { list-style-type: lower-roman; }
+ol[type=I], li[type=I] { list-style-type: upper-roman; }
+ul[type=disc i], li[type=disc i] { list-style-type: disc; }
+ul[type=circle i], li[type=circle i] { list-style-type: circle; }
+ul[type=square i], li[type=square i] { list-style-type: square; }
+
+table[align=left i] { float: left; }
+table[align=right i] { float: right; }
+table[align=center i] { margin-left: auto; margin-right: auto; }
+thead[align=absmiddle i], tbody[align=absmiddle i], tfoot[align=absmiddle i],
+tr[align=absmiddle i], td[align=absmiddle i], th[align=absmiddle i] {
+  text-align: center;
+}
+
+caption[align=bottom i] { caption-side: bottom; }
+p[align=left i], h1[align=left i], h2[align=left i], h3[align=left i],
+h4[align=left i], h5[align=left i], h6[align=left i] {
+  text-align: left;
+}
+p[align=right i], h1[align=right i], h2[align=right i], h3[align=right i],
+h4[align=right i], h5[align=right i], h6[align=right i] {
+  text-align: right;
+}
+p[align=center i], h1[align=center i], h2[align=center i], h3[align=center i],
+h4[align=center i], h5[align=center i], h6[align=center i] {
+  text-align: center;
+}
+p[align=justify i], h1[align=justify i], h2[align=justify i], h3[align=justify i],
+h4[align=justify i], h5[align=justify i], h6[align=justify i] {
+  text-align: justify;
+}
+thead[valign=top i], tbody[valign=top i], tfoot[valign=top i],
+tr[valign=top i], td[valign=top i], th[valign=top i] {
+  vertical-align: top;
+}
+thead[valign=middle i], tbody[valign=middle i], tfoot[valign=middle i],
+tr[valign=middle i], td[valign=middle i], th[valign=middle i] {
+  vertical-align: middle;
+}
+thead[valign=bottom i], tbody[valign=bottom i], tfoot[valign=bottom i],
+tr[valign=bottom i], td[valign=bottom i], th[valign=bottom i] {
+  vertical-align: bottom;
+}
+thead[valign=baseline i], tbody[valign=baseline i], tfoot[valign=baseline i],
+tr[valign=baseline i], td[valign=baseline i], th[valign=baseline i] {
+  vertical-align: baseline;
+}
+
+td[nowrap], th[nowrap] { white-space: nowrap; }
+
+table[rules=none i], table[rules=groups i], table[rules=rows i],
+table[rules=cols i], table[rules=all i] {
+  border-style: hidden;
+  border-collapse: collapse;
+}
+table[border] { border-style: outset; } /* only if border is not equivalent to zero */
+table[frame=void i] { border-style: hidden; }
+table[frame=above i] { border-style: outset hidden hidden hidden; }
+table[frame=below i] { border-style: hidden hidden outset hidden; }
+table[frame=hsides i] { border-style: outset hidden outset hidden; }
+table[frame=lhs i] { border-style: hidden hidden hidden outset; }
+table[frame=rhs i] { border-style: hidden outset hidden hidden; }
+table[frame=vsides i] { border-style: hidden outset; }
+table[frame=box i], table[frame=border i] { border-style: outset; }
+
+table[border] > tr > td, table[border] > tr > th,
+table[border] > thead > tr > td, table[border] > thead > tr > th,
+table[border] > tbody > tr > td, table[border] > tbody > tr > th,
+table[border] > tfoot > tr > td, table[border] > tfoot > tr > th {
+  /* only if border is not equivalent to zero */
+  border-width: 1px;
+  border-style: inset;
+}
+table[rules=none i] > tr > td, table[rules=none i] > tr > th,
+table[rules=none i] > thead > tr > td, table[rules=none i] > thead > tr > th,
+table[rules=none i] > tbody > tr > td, table[rules=none i] > tbody > tr > th,
+table[rules=none i] > tfoot > tr > td, table[rules=none i] > tfoot > tr > th,
+table[rules=groups i] > tr > td, table[rules=groups i] > tr > th,
+table[rules=groups i] > thead > tr > td, table[rules=groups i] > thead > tr > th,
+table[rules=groups i] > tbody > tr > td, table[rules=groups i] > tbody > tr > th,
+table[rules=groups i] > tfoot > tr > td, table[rules=groups i] > tfoot > tr > th,
+table[rules=rows i] > tr > td, table[rules=rows i] > tr > th,
+table[rules=rows i] > thead > tr > td, table[rules=rows i] > thead > tr > th,
+table[rules=rows i] > tbody > tr > td, table[rules=rows i] > tbody > tr > th,
+table[rules=rows i] > tfoot > tr > td, table[rules=rows i] > tfoot > tr > th {
+  border-width: 1px;
+  border-style: none;
+}
+table[rules=cols i] > tr > td, table[rules=cols i] > tr > th,
+table[rules=cols i] > thead > tr > td, table[rules=cols i] > thead > tr > th,
+table[rules=cols i] > tbody > tr > td, table[rules=cols i] > tbody > tr > th,
+table[rules=cols i] > tfoot > tr > td, table[rules=cols i] > tfoot > tr > th {
+  border-width: 1px;
+  border-style: none solid;
+}
+table[rules=all i] > tr > td, table[rules=all i] > tr > th,
+table[rules=all i] > thead > tr > td, table[rules=all i] > thead > tr > th,
+table[rules=all i] > tbody > tr > td, table[rules=all i] > tbody > tr > th,
+table[rules=all i] > tfoot > tr > td, table[rules=all i] > tfoot > tr > th {
+  border-width: 1px;
+  border-style: solid;
+}
+
+table[rules=groups i] > colgroup {
+  border-left-width: 1px;
+  border-left-style: solid;
+  border-right-width: 1px;
+  border-right-style: solid;
+}
+table[rules=groups i] > thead,
+table[rules=groups i] > tbody,
+table[rules=groups i] > tfoot {
+  border-top-width: 1px;
+  border-top-style: solid;
+  border-bottom-width: 1px;
+  border-bottom-style: solid;
+}
+
+table[rules=rows i] > tr, table[rules=rows i] > thead > tr,
+table[rules=rows i] > tbody > tr, table[rules=rows i] > tfoot > tr {
+  border-top-width: 1px;
+  border-top-style: solid;
+  border-bottom-width: 1px;
+  border-bottom-style: solid;
+}
+
+hr[align=left] { margin-left: 0; margin-right: auto; }
+hr[align=right] { margin-left: auto; margin-right: 0; }
+hr[align=center] { margin-left: auto; margin-right: auto; }
+hr[color], hr[noshade] { border-style: solid; }
+
+iframe[frameborder=0], iframe[frameborder=no i] { border: none; }
+
+applet[align=left i], embed[align=left i], iframe[align=left i],
+img[align=left i], input[type=image i][align=left i], object[align=left i] {
+  float: left;
+}
+
+applet[align=right i], embed[align=right i], iframe[align=right i],
+img[align=right i], input[type=image i][align=right i], object[align=right i] {
+  float: right;
+}
+
+applet[align=top i], embed[align=top i], iframe[align=top i],
+img[align=top i], input[type=image i][align=top i], object[align=top i] {
+  vertical-align: top;
+}
+
+applet[align=baseline i], embed[align=baseline i], iframe[align=baseline i],
+img[align=baseline i], input[type=image i][align=baseline i], object[align=baseline i] {
+  vertical-align: baseline;
+}
+
+applet[align=texttop i], embed[align=texttop i], iframe[align=texttop i],
+img[align=texttop i], input[type=image i][align=texttop i], object[align=texttop i] {
+  vertical-align: text-top;
+}
+
+applet[align=absmiddle i], embed[align=absmiddle i], iframe[align=absmiddle i],
+img[align=absmiddle i], input[type=image i][align=absmiddle i], object[align=absmiddle i],
+applet[align=abscenter i], embed[align=abscenter i], iframe[align=abscenter i],
+img[align=abscenter i], input[type=image i][align=abscenter i], object[align=abscenter i] {
+  vertical-align: middle;
+}
+
+applet[align=bottom i], embed[align=bottom i], iframe[align=bottom i],
+img[align=bottom i], input[type=image i][align=bottom i],
+object[align=bottom i] {
+  vertical-align: bottom;
+}

--- a/weasyprint/document.py
+++ b/weasyprint/document.py
@@ -313,11 +313,13 @@ class Document(object):
 
     """
     @classmethod
-    def _render(cls, html, stylesheets, enable_hinting):
-        style_for = get_all_computed_styles(html, user_stylesheets=[
-            css if hasattr(css, 'rules')
-            else CSS(guess=css, media_type=html.media_type)
-            for css in stylesheets or []])
+    def _render(cls, html, stylesheets, enable_hinting,
+                presentational_hints=False):
+        style_for = get_all_computed_styles(
+            html, presentational_hints=presentational_hints, user_stylesheets=[
+                css if hasattr(css, 'rules')
+                else CSS(guess=css, media_type=html.media_type)
+                for css in stylesheets or []])
         get_image_from_uri = functools.partial(
             images.get_image_from_uri, {}, html.url_fetcher)
         page_boxes = layout_document(

--- a/weasyprint/html.py
+++ b/weasyprint/html.py
@@ -39,6 +39,7 @@ if hasattr(sys, "frozen"):
 else:
     root = os.path.dirname(__file__)
 HTML5_UA_STYLESHEET = CSS(filename=os.path.join(root, 'css', 'html5_ua.css'))
+HTML5_PH_STYLESHEET = CSS(filename=os.path.join(root, 'css', 'html5_ph.css'))
 
 LOGGER.setLevel(level)
 

--- a/weasyprint/tests/test_presentational_hints.py
+++ b/weasyprint/tests/test_presentational_hints.py
@@ -1,0 +1,289 @@
+# coding: utf-8
+"""
+    weasyprint.tests.test_presentational_hints
+    ------------------------------------------
+
+    Test the HTML presentational hints.
+
+    :copyright: Copyright 2016 Simon Sapin and contributors, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+
+"""
+
+from __future__ import division, unicode_literals
+
+from .testing_utils import assert_no_logs
+from .. import HTML, CSS
+
+PH_TESTING_CSS = CSS(string='''
+@page {margin: 0; size: 1000px 1000px}
+body {margin: 0}
+''')
+
+
+@assert_no_logs
+def test_no_ph():
+    """Check that presentational hints are not applied when not requested."""
+    # Test both CSS and non-CSS rules
+    document = HTML(string='''
+        <hr size=100 />
+        <table align=right width=100><td>0</td></table>
+    ''').render(stylesheets=[PH_TESTING_CSS])
+    page, = document.pages
+    html, = page._page_box.children
+    body, = html.children
+    hr, table = body.children
+    assert hr.border_height() != 100
+    assert table.position_x == 0
+
+
+@assert_no_logs
+def test_ph_page():
+    """Check presentational hints on the page."""
+    document = HTML(string='''
+        <body marginheight=2 topmargin=3 leftmargin=5
+              bgcolor=red text=blue />
+    ''').render(stylesheets=[PH_TESTING_CSS], presentational_hints=True)
+    page, = document.pages
+    html, = page._page_box.children
+    body, = html.children
+    assert body.margin_top == 2
+    assert body.margin_bottom == 2
+    assert body.margin_left == 5
+    assert body.margin_right == 0
+    assert body.style.background_color == (1, 0, 0, 1)
+    assert body.style.color == (0, 0, 1, 1)
+
+
+@assert_no_logs
+def test_ph_flow():
+    """Check presentational hints on the flow content."""
+    document = HTML(string='''
+        <pre wrap></pre>
+        <center></center>
+        <div align=center></div>
+        <div align=middle></div>
+        <div align=left></div>
+        <div align=right></div>
+        <div align=justify></div>
+    ''').render(stylesheets=[PH_TESTING_CSS], presentational_hints=True)
+    page, = document.pages
+    html, = page._page_box.children
+    body, = html.children
+    pre, center, div1, div2, div3, div4, div5 = body.children
+    assert pre.style.white_space == 'pre-wrap'
+    assert center.style.text_align == 'center'
+    assert div1.style.text_align == 'center'
+    assert div2.style.text_align == 'center'
+    assert div3.style.text_align == 'left'
+    assert div4.style.text_align == 'right'
+    assert div5.style.text_align == 'justify'
+
+
+@assert_no_logs
+def test_ph_phrasing():
+    """Check presentational hints on the phrasing content."""
+    document = HTML(string='''
+        <br clear=left>
+        <br clear=right />
+        <br clear=both />
+        <br clear=all />
+        <font color=red face=ahem size=7></font>
+        <Font size=4></Font>
+        <font size=+5 ></font>
+        <font size=-5 ></font>
+    ''').render(stylesheets=[PH_TESTING_CSS], presentational_hints=True)
+    page, = document.pages
+    html, = page._page_box.children
+    body, = html.children
+    line1, line2, line3, line4, line5 = body.children
+    br1, = line1.children
+    br2, = line2.children
+    br3, = line3.children
+    br4, = line4.children
+    font1, font2, font3, font4 = line5.children
+    assert br1.style.clear == 'left'
+    assert br2.style.clear == 'right'
+    assert br3.style.clear == 'both'
+    assert br4.style.clear == 'both'
+    assert font1.style.color == (1, 0, 0, 1)
+    assert font1.style.font_family == ['ahem']
+    assert font1.style.font_size == 1.5 * 2 * 16
+    assert font2.style.font_size == 6 / 5 * 16
+    assert font3.style.font_size == 1.5 * 2 * 16
+    assert font4.style.font_size == 8 / 9 * 16
+
+
+@assert_no_logs
+def test_ph_lists():
+    """Check presentational hints on lists."""
+    document = HTML(string='''
+        <ol>
+          <li type=A></li>
+          <li type=1></li>
+          <li type=a></li>
+          <li type=i></li>
+          <li type=I></li>
+        </ol>
+        <ul>
+          <li type=circle></li>
+          <li type=disc></li>
+          <li type=square></li>
+        </ul>
+    ''').render(stylesheets=[PH_TESTING_CSS], presentational_hints=True)
+    page, = document.pages
+    html, = page._page_box.children
+    body, = html.children
+    ol, ul = body.children
+    oli1, oli2, oli3, oli4, oli5 = ol.children
+    uli1, uli2, uli3 = ul.children
+    assert oli1.style.list_style_type == 'upper-alpha'
+    assert oli2.style.list_style_type == 'decimal'
+    assert oli3.style.list_style_type == 'lower-alpha'
+    assert oli4.style.list_style_type == 'lower-roman'
+    assert oli5.style.list_style_type == 'upper-roman'
+    assert uli1.style.list_style_type == 'circle'
+    assert uli2.style.list_style_type == 'disc'
+    assert uli3.style.list_style_type == 'square'
+
+    document = HTML(string='''
+        <ol type=A></ol>
+        <ol type=1></ol>
+        <ol type=a></ol>
+        <ol type=i></ol>
+        <ol type=I></ol>
+        <ul type=circle></ul>
+        <ul type=disc></ul>
+        <ul type=square></ul>
+    ''').render(stylesheets=[PH_TESTING_CSS], presentational_hints=True)
+    page, = document.pages
+    html, = page._page_box.children
+    body, = html.children
+    ol1, ol2, ol3, ol4, ol5, ul1, ul2, ul3 = body.children
+    assert ol1.style.list_style_type == 'upper-alpha'
+    assert ol2.style.list_style_type == 'decimal'
+    assert ol3.style.list_style_type == 'lower-alpha'
+    assert ol4.style.list_style_type == 'lower-roman'
+    assert ol5.style.list_style_type == 'upper-roman'
+    assert ul1.style.list_style_type == 'circle'
+    assert ul2.style.list_style_type == 'disc'
+    assert ul3.style.list_style_type == 'square'
+
+
+@assert_no_logs
+def test_ph_tables():
+    """Check presentational hints on tables."""
+    document = HTML(string='''
+        <table align=left rules=none></table>
+        <table align=right rules=groups></table>
+        <table align=center rules=rows></table>
+        <table border=10 cellspacing=3 bordercolor=green>
+          <thead>
+            <tr>
+              <th valign=top></th>
+            </tr>
+          </thead>
+          <tr>
+            <td nowrap><h1 align=right></h1><p align=center></p></td>
+          </tr>
+          <tr>
+          </tr>
+          <tfoot align=justify>
+            <tr>
+              <td></td>
+            </tr>
+          </tfoot>
+        </table>
+    ''').render(stylesheets=[PH_TESTING_CSS], presentational_hints=True)
+    page, = document.pages
+    html, = page._page_box.children
+    body, = html.children
+    wrapper1, wrapper2, wrapper3, wrapper4, = body.children
+    assert wrapper1.style.float == 'left'
+    assert wrapper2.style.float == 'right'
+    assert wrapper3.style.margin_left == 'auto'
+    assert wrapper3.style.margin_right == 'auto'
+    assert wrapper1.children[0].style.border_left_style == 'hidden'
+    assert wrapper1.style.border_collapse == 'collapse'
+    assert wrapper2.children[0].style.border_left_style == 'hidden'
+    assert wrapper2.style.border_collapse == 'collapse'
+    assert wrapper3.children[0].style.border_left_style == 'hidden'
+    assert wrapper3.style.border_collapse == 'collapse'
+
+    table4, = wrapper4.children
+    assert table4.style.border_top_style == 'outset'
+    assert table4.style.border_top_width == 10
+    assert table4.style.border_spacing == (3, 3)
+    r, g, b, a = table4.style.border_left_color
+    assert g > r and g > b
+    head_group, rows_group, foot_group = table4.children
+    head, = head_group.children
+    th, = head.children
+    assert th.style.vertical_align == 'top'
+    line1, line2 = rows_group.children
+    td, = line1.children
+    assert td.style.white_space == 'nowrap'
+    assert td.style.border_top_width == 1
+    assert td.style.border_top_style == 'inset'
+    h1, p = td.children
+    assert h1.style.text_align == 'right'
+    assert p.style.text_align == 'center'
+    foot, = foot_group.children
+    tr, = foot.children
+    assert tr.style.text_align == 'justify'
+
+
+@assert_no_logs
+def test_ph_hr():
+    """Check presentational hints on horizontal rules."""
+    document = HTML(string='''
+        <hr align=left>
+        <hr align=right />
+        <hr align=both color=red />
+        <hr align=center noshade size=10 />
+        <hr align=all size=8 width=100 />
+    ''').render(stylesheets=[PH_TESTING_CSS], presentational_hints=True)
+    page, = document.pages
+    html, = page._page_box.children
+    body, = html.children
+    hr1, hr2, hr3, hr4, hr5 = body.children
+    assert hr1.margin_left == 0
+    assert hr1.style.margin_right == 'auto'
+    assert hr2.style.margin_left == 'auto'
+    assert hr2.margin_right == 0
+    assert hr3.style.margin_left == 'auto'
+    assert hr3.style.margin_right == 'auto'
+    assert hr3.style.color == (1, 0, 0, 1)
+    assert hr4.style.margin_left == 'auto'
+    assert hr4.style.margin_right == 'auto'
+    assert hr4.border_height() == 10
+    assert hr4.style.border_top_width == 5
+    assert hr5.border_height() == 8
+    assert hr5.height == 6
+    assert hr5.width == 100
+    assert hr5.style.border_top_width == 1
+
+
+@assert_no_logs
+def test_ph_embedded():
+    """Check presentational hints on embedded contents."""
+    document = HTML(string='''
+        <object data="data:image/svg+xml,<svg></svg>"
+                align=top hspace=10 vspace=20></object>
+        <img src="data:image/svg+xml,<svg></svg>" alt=text
+              align=right width=10 height=20 />
+        <embed src="data:image/svg+xml,<svg></svg>" align=texttop />
+    ''').render(stylesheets=[PH_TESTING_CSS], presentational_hints=True)
+    page, = document.pages
+    html, = page._page_box.children
+    body, = html.children
+    line, = body.children
+    object_, text1, img, embed, text2 = line.children
+    print(line.children)
+    assert embed.style.vertical_align == 'text-top'
+    assert object_.style.vertical_align == 'top'
+    assert object_.margin_top == 20
+    assert object_.margin_left == 10
+    assert img.style.float == 'right'
+    assert img.width == 10
+    assert img.height == 20

--- a/weasyprint/tests/test_presentational_hints.py
+++ b/weasyprint/tests/test_presentational_hints.py
@@ -279,7 +279,6 @@ def test_ph_embedded():
     body, = html.children
     line, = body.children
     object_, text1, img, embed, text2 = line.children
-    print(line.children)
     assert embed.style.vertical_align == 'text-top'
     assert object_.style.vertical_align == 'top'
     assert object_.margin_top == 20


### PR DESCRIPTION
See #253.

This feature has been implemented in a clean way.

Random thoughts:
- I've added this feature because it's useful for many W3C tests.
- The diff is big but really simple.
- Many hints are given in CSS in the spec, they could (should?) be added in another stylesheet in WP with priority set to 0 (instead of code).
- Merging `find_style_attributes` and `find_presetational_hints` is possible, it would avoid going through the whole tree twice.
- The code is not tested, but the test suites available on `test.weasyprint.org` pass without a crash.
- Calling `check_style_attribute` with constant strings is probably useless.
- This features makes the tests last ~5% more for me, and it's probably much worst on real cases. Should we allow the users to enable/disable it with an option?
- Some rules have not been implemented, mainly because they would be much easier to handle with CSS than with code (one more reason to use an extra stylesheet).
- Some parsing errors are logged, some aren't (who cares?).

Comments are welcome, as usual. I won't merge it right now, I'd like (at least):
- [x] a new option to activate this feature (and keep it deactivated by default),
- [x] a stylesheet for rules described in CSS in the spec,
- [x] tests.