### PR TITLE
Require libffi headers at Fedora

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -124,7 +124,7 @@ with pip after installing the following packages:
 
 .. code-block:: sh
 
-    sudo yum install redhat-rpm-config python-devel python-pip python-lxml python-cffi cairo pango gdk-pixbuf2
+    sudo yum install redhat-rpm-config python-devel python-pip python-lxml python-cffi libffi-devel cairo pango gdk-pixbuf2
 
 Archlinux
 ~~~~~~~~~


### PR DESCRIPTION
To be able to install this via pip at Fedora I had to install `libffi-devel`.

    Collecting cairocffi>=0.5 (from WeasyPrint==0.30)
      Downloading cairocffi-0.7.2.tar.gz (75kB)
        100% |████████████████████████████████| 81kB 5.3MB/s 
        Complete output from command python setup.py egg_info:
        Package libffi was not found in the pkg-config search path.
        Perhaps you should add the directory containing `libffi.pc'
        to the PKG_CONFIG_PATH environment variable
        No package 'libffi' found

I might have done something wrong. Please check if this package really is required.