### PR TITLE
check for font_config

### DIFF
--- a/weasyprint/css/__init__.py
+++ b/weasyprint/css/__init__.py
@@ -687,10 +687,11 @@ def preprocess_stylesheet(device_media_type, base_url, stylesheet_rules,
                         key.replace('_', '-'), rule.line, rule.column)
                     break
             else:
-                font_filename = font_config.add_font_face(
-                    rule_descriptors, url_fetcher)
-                if font_filename:
-                    fonts.append(font_filename)
+                if font_config is not None:
+                    font_filename = font_config.add_font_face(
+                        rule_descriptors, url_fetcher)
+                    if font_filename:
+                        fonts.append(font_filename)
 
 
 def get_all_computed_styles(html, user_stylesheets=None,


### PR DESCRIPTION
check for font_config before attempting to add_font_face
This is an attempt to resolve this error that I get from `css/__init__.py:690` upon upgrading to 0.32:
'NoneType' object has no attribute 'add_font_face'