### PR TITLE
Avoid CairoSVG-2.0.0rc* on Python 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ REQUIREMENTS = [
 ]
 
 if sys.version_info < (3,):
-    REQUIREMENTS.append('CairoSVG >= 1.0.20, < 2')
+    REQUIREMENTS.append('CairoSVG >= 1.0.20, < 2.0.0')
 else:
     REQUIREMENTS.append('CairoSVG >= 1.0.20')
 


### PR DESCRIPTION
It's funny but:
```
pip install --upgrade 'CairoSVG<2'
```
would pull CairoSVG-2.0.0rc6, while
```
pip install --upgrade 'CairoSVG<2.0.0'
```
would pull the 1.x branch (1.0.22 at time of writing).