### PR TITLE
Fix AssertionError in layout.inlines.split_text_box().

### DIFF
--- a/weasyprint/text.py
+++ b/weasyprint/text.py
@@ -1112,11 +1112,14 @@ def split_first_line(text, style, context, max_width, line_width):
         temp_second_line_index = (
             len(text.encode('utf-8')) if temp_second_line is None
             else temp_second_line.start_index)
-        resume_at = temp_second_line_index
         first_line_text = utf8_slice(text, slice(temp_second_line_index))
         layout.set_text(first_line_text)
         lines = layout.iter_lines()
         first_line = next(lines, None)
+        second_line = next(lines, None)
+        resume_at = (
+            first_line.length if second_line is None
+            else second_line.start_index)
 
     return first_line_metrics(
         first_line, text, layout, resume_at, space_collapse, style, hyphenated,


### PR DESCRIPTION
<pre>
Traceback (most recent call last):
  [...]
  File "/app/env/lib/python3.5/site-packages/weasyprint/layout/inlines.py", line 718, in split_text_box
    'Expected nothing or a preserved line break' % (between,))
AssertionError: Got '1,' between two lines. Expected nothing or a preserved line break
</pre>

The Assertion Error can be triggered with following minimal test case
(Adobe's Source Sans Pro font must be installed):

	<style type="text/css">
	    p {
		font-family: 'Source Sans Pro';
		font-size: 24pt;
		width: 275pt;
		overflow-wrap: break-word;
	    }
	</style>
	<p>W1D1,W1D7,W2D14,W3D21,W4D28</p>

With the Adobe Source Sans Font the pango line wrapping algorithm
sometimes produces sporadic results. The wrapping seems to be dependent
on the following text, so that a short text doesn't "fit" on a line, but
does if it is followed by more text. This can be worked around in the
split_first_line() function by computing the resume offset at a later
point, so it is in sync with the actual wrapping behaviour.

See https://bugzilla.gnome.org/show_bug.cgi?id=777093.