### PR TITLE
Let the logging module do the string interpolation

### DIFF
--- a/weasyprint/css/__init__.py
+++ b/weasyprint/css/__init__.py
@@ -248,7 +248,7 @@ def find_style_attributes(element_tree, presentational_hints=False):
                 try:
                     size = int(size)
                 except ValueError:
-                    LOGGER.warning('Invalid value for size: %s' % size)
+                    LOGGER.warning('Invalid value for size: %s', size)
                 else:
                     font_sizes = {
                         1: 'x-small',
@@ -379,7 +379,7 @@ def find_style_attributes(element_tree, presentational_hints=False):
                 try:
                     size = int(element.get('size'))
                 except ValueError:
-                    LOGGER.warning('Invalid value for size: %s' % size)
+                    LOGGER.warning('Invalid value for size: %s', size)
             if (element.get('color'), element.get('noshade')) != (None, None):
                 if size >= 1:
                     yield specificity, check_style_attribute(

--- a/weasyprint/document.py
+++ b/weasyprint/document.py
@@ -408,7 +408,7 @@ class Document(object):
                     if target is None:
                         LOGGER.warning(
                             'No anchor #%s for internal URI reference '
-                            'at line %s' % (anchor_name, link.sourceline))
+                            'at line %s', anchor_name, link.sourceline)
                     else:
                         page_links.append((link_type, target, rectangle))
                 else:

--- a/weasyprint/fonts.py
+++ b/weasyprint/fonts.py
@@ -285,7 +285,7 @@ else:
                     else:
                         LOGGER.warning('Failed to load font at "%s"', url)
             LOGGER.warning(
-                'Font-face "%s" cannot be loaded' %
+                'Font-face "%s" cannot be loaded',
                 rule_descriptors['font_family'])
 
         def clean(self):


### PR DESCRIPTION
Interpolating manually sometimes leads to UnicodeDecodeError when the argument is a unicode string. Better to let the logging module take care of the interpolation. 