### PR TITLE
Fix typos and awkward grammar on Tutorial and API pages.

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -174,7 +174,7 @@ See the :ref:`python-api` for details. A few random example:
 URL fetchers
 ............
 
-WeasyPrint goes through an *URL fetcher* to fetch external resources such as
+WeasyPrint goes through a *URL fetcher* to fetch external resources such as
 images or CSS stylesheets. The default fetcher can natively open file and
 HTTP URLs, but the HTTP client does not support advanced features like cookies
 or authentication. This can be worked-around by passing a custom

--- a/weasyprint/__init__.py
+++ b/weasyprint/__init__.py
@@ -49,22 +49,23 @@ class HTML(object):
 
     Alternatively, use **one** named argument so that no guessing is involved:
 
-    :param filename: A filename, relative to the current directory or absolute.
+    :param filename: A filename, relative to the current directory, or absolute.
     :param url: An absolute, fully qualified URL.
-    :param file_obj: a file-like: any object with a :meth:`~file.read` method.
-    :param string: a string of HTML source. (This argument must be named.)
-    :param tree: a parsed lxml tree. (This argument must be named.)
+    :param file_obj: A file-like: any object with a :meth:`~file.read` method.
+    :param string: A string of HTML source. (This argument must be named.)
+    :param tree: A parsed lxml tree. (This argument must be named.)
 
-    Specifying multiple inputs is an error: ``HTML(filename=foo, url=bar)``
-    will raise.
+    Specifying multiple inputs is an error:
+    ``HTML(filename="foo.html", url="localhost://bar.html")``
+    will raise a TypeError.
 
     You can also pass optional named arguments:
 
     :param encoding: Force the source character encoding.
     :param base_url: The base used to resolve relative URLs
-        (eg. in ``<img src="../foo.png">``). If not provided, try to use
+        (e.g. in ``<img src="../foo.png">``). If not provided, try to use
         the input filename, URL, or ``name`` attribute of file-like objects.
-    :param url_fetcher: a function or other callable
+    :param url_fetcher: A function or other callable
         with the same signature as :func:`default_url_fetcher` called to
         fetch external resources such as stylesheets and images.
         (See :ref:`url-fetchers`.)
@@ -126,14 +127,14 @@ class HTML(object):
         .. versionadded:: 0.15
 
         :param stylesheets:
-            An optional list of user stylesheets. (See
-            :ref:`stylesheet-origins`\.) List elements are :class:`CSS`
-            objects, filenames, URLs, or file-like objects.
+            An optional list of user stylesheets. List elements are
+            :class:`CSS` objects, filenames, URLs, or file-like
+            objects. (See :ref:`stylesheet-origins`.)
         :type enable_hinting: bool
         :param enable_hinting:
             Whether text, borders and background should be *hinted* to fall
             at device pixel boundaries. Should be enabled for pixel-based
-            output (like PNG) but not vector based output (like PDF).
+            output (like PNG) but not for vector-based output (like PDF).
         :type presentational_hints: bool
         :param presentational_hints: Whether HTML presentational hints are
             followed.
@@ -153,17 +154,15 @@ class HTML(object):
         :param target:
             A filename, file-like object, or :obj:`None`.
         :param stylesheets:
-            An optional list of user stylesheets. (See
-            :ref:`stylesheet-origins`\.) The list’s elements are
-            :class:`CSS` objects, filenames, URLs, or file-like objects.
+            An optional list of user stylesheets. The list’s elements
+            are :class:`CSS` objects, filenames, URLs, or file-like
+            objects.  (See :ref:`stylesheet-origins`.)
         :type zoom: float
         :param zoom:
-            The zoom factor in PDF units per CSS units.
-            **Warning**: All CSS units (even physical, like ``cm``)
-            are affected.
-            For values other than 1, physical CSS units will thus be “wrong”.
-            Page size declarations are affected too, even with keyword values
-            like ``@page { size: A3 landscape; }``
+            The zoom factor in PDF units per CSS units.  **Warning**:
+            All CSS units are affected, including physical units like
+            ``cm`` and named sizes like ``A4``.  For values other than
+            1, the physical CSS units will thus be “wrong”.
         :param attachments: A list of additional file attachments for the
             generated PDF document or :obj:`None`. The list's elements are
             :class:`Attachment` objects, filenames, URLs or file-like objects.
@@ -173,7 +172,7 @@ class HTML(object):
         :returns:
             The PDF as byte string if :obj:`target` is not provided or
             :obj:`None`, otherwise :obj:`None` (the PDF is written to
-            :obj:`target`.)
+            :obj:`target`).
 
         """
         return self.render(
@@ -203,9 +202,9 @@ class HTML(object):
         :param target:
             A filename, file-like object, or :obj:`None`.
         :param stylesheets:
-            An optional list of user stylesheets. (See
-            :ref:`stylesheet-origins`\.) The list’s elements are
-            :class:`CSS` objects, filenames, URLs, or file-like objects.
+            An optional list of user stylesheets.  The list’s elements
+            are :class:`CSS` objects, filenames, URLs, or file-like
+            objects. (See :ref:`stylesheet-origins`.)
         :type resolution: float
         :param resolution:
             The output resolution in PNG pixels per CSS inch. At 96 dpi
@@ -230,7 +229,7 @@ class CSS(object):
     """Represents a CSS stylesheet parsed by tinycss2.
 
     An instance is created in the same way as :class:`HTML`, except that
-    the ``tree`` parameter is not available. All other parameters are the same.
+    the ``tree`` argument is not available. All other arguments are the same.
 
     ``CSS`` objects have no public attribute or method. They are only meant to
     be used in the :meth:`~HTML.write_pdf`, :meth:`~HTML.write_png` and
@@ -268,8 +267,8 @@ class Attachment(object):
     """Represents a file attachment for a PDF document.
 
     An instance is created in the same way as :class:`HTML`, except that
-    the HTML specific parameters are not supported. An optional description can
-    be provided with the ``description`` parameter.
+    the HTML specific arguments are not supported. An optional description can
+    be provided with the ``description`` argument.
 
     :param description: A description of the attachment to be included in the
         PDF document. May be :obj:`None`

--- a/weasyprint/__main__.py
+++ b/weasyprint/__main__.py
@@ -30,23 +30,23 @@ def main(argv=None, stdout=None, stdin=None):
     The input is a filename or URL to an HTML document, or ``-`` to read
     HTML from stdin. The output is a filename, or ``-`` to write to stdout.
 
-    Options can be mixed anywhere before, between or after the input and
+    Options can be mixed anywhere before, between, or after the input and
     output:
 
     .. option:: -e <input_encoding>, --encoding <input_encoding>
 
-        Force the input character encoding (eg. ``-e utf8``).
+        Force the input character encoding (e.g. ``-e utf8``).
 
     .. option:: -f <output_format>, --format <output_format>
 
-        Choose the output file format among PDF and PNG (eg. ``-f png``).
+        Choose the output file format among PDF and PNG (e.g. ``-f png``).
         Required if the output is not a ``.pdf`` or ``.png`` filename.
 
     .. option:: -s <filename_or_URL>, --stylesheet <filename_or_URL>
 
         Filename or URL of a user CSS stylesheet (see
-        :ref:`stylesheet-origins`\.) to add to the document.
-        (eg. ``-s print.css``). Multiple stylesheets are allowed.
+        :ref:`stylesheet-origins`) to add to the document
+        (e.g. ``-s print.css``). Multiple stylesheets are allowed.
 
     .. option:: -r <dpi>, --resolution <dpi>
 
@@ -64,8 +64,9 @@ def main(argv=None, stdout=None, stdin=None):
 
     .. option:: -a <file>, --attachment <file>
 
-        Adds an attachment to the document which is included in the PDF output.
-        This option can be added multiple times to attach more files.
+        Adds an attachment to the document.  The attachment is
+        included in the PDF output.  This option can be used multiple
+        times.
 
     .. option:: -p, --presentational-hints
 

--- a/weasyprint/css/html5_ua.css
+++ b/weasyprint/css/html5_ua.css
@@ -3,8 +3,8 @@
 User agent stylsheet for HTML.
 
 Contributed by Peter Moulder.
-Based on suggested styles in the HTML5 specification and what various
-web browsers use.
+Based on suggested styles in the HTML5 specification, CSS 2.1, and
+what various web browsers use.
 
 */
 
@@ -515,7 +515,7 @@ video { object-fit: contain; }
 xmp { display: block; font-family: monospace; margin-bottom: 1em; margin-top: 1em; unicode-bidi: isolate; white-space: pre; }
 
 @page {
-    /* `size: auto` (the inital) is A4 portrait */
+    /* `size: auto` (the initial) is A4 portrait */
     margin: 75px;
     @top-left-corner     { text-align: right;  vertical-align:  middle }
     @top-left            { text-align: left;   vertical-align:  middle }

--- a/weasyprint/document.py
+++ b/weasyprint/document.py
@@ -167,8 +167,8 @@ class Page(object):
 
         #: A list of ``(bookmark_level, bookmark_label, target)`` tuples.
         #: :obj:`bookmark_level` and :obj:`bookmark_label` are respectively
-        #: an integer and an Unicode string, based on the CSS properties
-        #: of the same names. :obj:`target` is a ``(x, y)`` point
+        #: an integer and a Unicode string, based on the CSS properties
+        #: of the same names. :obj:`target` is an ``(x, y)`` point
         #: in CSS pixels from the top-left of the page.
         self.bookmarks = bookmarks = []
 
@@ -186,8 +186,8 @@ class Page(object):
         #:   to a resource to attach to the document.
         self.links = links = []
 
-        #: A dict mapping anchor names to their target, ``(x, y)`` points
-        #: in CSS pixels form the top-left of the page.)
+        #: A dict mapping each anchor name to its target, an ``(x, y)`` point
+        #: in CSS pixels from the top-left of the page.
         self.anchors = anchors = {}
 
         _gather_links_and_bookmarks(
@@ -203,10 +203,8 @@ class Page(object):
 
             .. note::
 
-                In case you get a :class:`cairo.Context` object
-                (eg. form PyGTK),
-                it is possible to :ref:`convert it to cairocffi
-                <converting_pycairo>`.
+                In case you get a :class:`cairo.Context` object (e.g. from PyGTK),
+                it is possible to :ref:`convert it to cairocffi <converting_pycairo>`.
         :param left_x:
             X coordinate of the left of the page, in cairo user units.
         :param top_y:
@@ -251,9 +249,9 @@ class Page(object):
 
 class DocumentMetadata(object):
     """Contains meta-information about a :class:`Document`
-    that do not belong to specific pages but to the whole document.
+    that belongs to the whole document rather than specific pages.
 
-    New attributes may be added in future versions of WeasyPrint.
+   New attributes may be added in future versions of WeasyPrint.
 
     .. _W3C’s profile of ISO 8601: http://www.w3.org/TR/NOTE-datetime
 
@@ -309,7 +307,7 @@ class Document(object):
     Typically obtained from :meth:`HTML.render() <weasyprint.HTML.render>`,
     but can also be instantiated directly
     with a list of :class:`pages <Page>`,
-    a set of :class:`metadata <DocumentMetadata>` and a ``url_fetcher``.
+    a set of :class:`metadata <DocumentMetadata>`, and a ``url_fetcher``.
 
     """
     @classmethod
@@ -391,8 +389,8 @@ class Document(object):
             A generator yielding lists (one per page) like :attr:`Page.links`,
             except that :obj:`target` for internal hyperlinks is
             ``(page_number, x, y)`` instead of an anchor name.
-            The page number is an index (0-based) in the :attr:`pages` list,
-            ``x, y`` are in CSS pixels from the top-left of the page.
+            The page number is a 0-based index into the :attr:`pages` list,
+            and ``x, y`` are in CSS pixels from the top-left of the page.
 
         """
         anchors = {}
@@ -422,14 +420,14 @@ class Document(object):
         :return: a list of bookmark subtrees.
             A subtree is ``(label, target, children)``. :obj:`label` is
             a string, :obj:`target` is ``(page_number, x, y)`` like in
-            :meth:`resolve_links`, and :obj:`children` is itself a (recursive)
-            list of subtrees.
+            :meth:`resolve_links`, and :obj:`children` is a
+            list of child subtrees.
 
         """
         root = []
         # At one point in the document, for each "output" depth, how much
         # to add to get the source level (CSS values of bookmark-level).
-        # Eg. with <h1> then <h3>, level_shifts == [0, 1]
+        # E.g. with <h1> then <h3>, level_shifts == [0, 1]
         # 1 means that <h3> has depth 3 - 1 = 2 in the output.
         skipped_levels = []
         last_by_depth = [root]
@@ -471,18 +469,16 @@ class Document(object):
             A filename, file-like object, or :obj:`None`.
         :type zoom: float
         :param zoom:
-            The zoom factor in PDF units per CSS units.
-            **Warning**: All CSS units (even physical, like ``cm``)
-            are affected.
-            For values other than 1, physical CSS units will thus be “wrong”.
-            Page size declarations are affected too, even with keyword values
-            like ``@page { size: A3 landscape; }``
+            The zoom factor in PDF units per CSS units.  **Warning**:
+            All CSS units are affected, including physical units like
+            ``cm`` and named sizes like ``A4``.  For values other than
+            1, the physical CSS units will thus be “wrong”.
         :param attachments: A list of additional file attachments for the
             generated PDF document or :obj:`None`. The list's elements are
-            :class:`Attachment` objects, filenames, URLs or file-like objects.
+            :class:`Attachment` objects, filenames, URLs, or file-like objects.
         :returns:
             The PDF as byte string if :obj:`target` is :obj:`None`, otherwise
-            :obj:`None` (the PDF is written to :obj:`target`.)
+            :obj:`None` (the PDF is written to :obj:`target`).
 
         """
         # 0.75 = 72 PDF point (cairo units) per inch / 96 CSS pixel per inch
@@ -553,7 +549,7 @@ class Document(object):
         :returns:
             A ``(png_bytes, png_width, png_height)`` tuple. :obj:`png_bytes`
             is a byte string if :obj:`target` is :obj:`None`, otherwise
-            :obj:`None` (the image is written to :obj:`target`.)
+            :obj:`None` (the image is written to :obj:`target`).
             :obj:`png_width` and :obj:`png_height` are the size of the
             final image, in PNG pixels.
 

--- a/weasyprint/urls.py
+++ b/weasyprint/urls.py
@@ -235,26 +235,24 @@ def default_url_fetcher(url):
     (See :ref:`url-fetchers`.)
 
     :type url: Unicode string
-    :param url: The URL of the resource to fetch
-    :raises: any exception to indicate failure. Failures are logged
-        as warnings, with the string representation of the exception
-        in the message.
-    :returns: In case of success, a dict with the following keys:
+    :param url: The URL of the resource to fetch.
+    :raises: An exception indicating failure, e.g. ``ValueError`` on syntactically invalid URL.
+    :returns: A dict with the following keys:
 
         * One of ``string`` (a byte string) or ``file_obj``
           (a file-like object)
-        * Optionally: ``mime_type``, a MIME type extracted eg. from a
+        * Optionally: ``mime_type``, a MIME type extracted e.g. from a
           *Content-Type* header. If not provided, the type is guessed from the
           file extension in the URL.
-        * Optionally: ``encoding``, a character encoding extracted eg. from a
+        * Optionally: ``encoding``, a character encoding extracted e.g. from a
           *charset* parameter in a *Content-Type* header
         * Optionally: ``redirected_url``, the actual URL of the resource
-          in case there were eg. HTTP redirects.
+          if there were e.g. HTTP redirects.
         * Optionally: ``filename``, the filename of the resource. Usually
           derived from the *filename* parameter in a *Content-Disposition*
           header
 
-        If a ``file_obj`` key is given, it is the caller’s responsability
+        If a ``file_obj`` key is given, it is the caller’s responsibility
         to call ``file_obj.close()``.
 
     """


### PR DESCRIPTION
Minor prose edits from a quick pass over the first couple of pages of documentation.
