### PR TITLE
Assert fail details

### DIFF
--- a/weasyprint/__init__.py
+++ b/weasyprint/__init__.py
@@ -95,7 +95,7 @@ class HTML(object):
                         source, treebuilder='lxml', override_encoding=encoding,
                         transport_encoding=protocol_encoding,
                         namespaceHTMLElements=False)
-                assert result
+                assert result, str((source_type, type(source)))
         base_url = find_base_url(result, base_url)
         if hasattr(result, 'getroot'):
             result.docinfo.URL = base_url

--- a/weasyprint/css/__init__.py
+++ b/weasyprint/css/__init__.py
@@ -485,7 +485,8 @@ def declaration_precedence(origin, importance):
     elif origin == 'author':  # and importance
         return 4
     else:
-        assert origin == 'user'  # and importance
+        # and importance
+        assert origin == 'user', str((origin, importance))
         return 5
 
 

--- a/weasyprint/css/computed_values.py
+++ b/weasyprint/css/computed_values.py
@@ -58,7 +58,8 @@ BORDER_WIDTH_KEYWORDS = {
     'medium': 3,
     'thick': 5,
 }
-assert INITIAL_VALUES['border_top_width'] == BORDER_WIDTH_KEYWORDS['medium']
+assert INITIAL_VALUES['border_top_width'] == BORDER_WIDTH_KEYWORDS['medium'], str((
+    INITIAL_VALUES['border_top_width'], BORDER_WIDTH_KEYWORDS['medium']))
 
 # http://www.w3.org/TR/CSS21/fonts.html#propdef-font-weight
 FONT_WEIGHT_RELATIVE = dict(
@@ -124,7 +125,7 @@ PAGE_SIZES = dict(
 )
 # In "portrait" orientation.
 for w, h in PAGE_SIZES.values():
-    assert w.value < h.value
+    assert w.value < h.value, str((w.value, h.value))
 
 INITIAL_PAGE_SIZE = PAGE_SIZES['a4']
 INITIAL_VALUES['size'] = tuple(

--- a/weasyprint/document.py
+++ b/weasyprint/document.py
@@ -66,7 +66,7 @@ def _get_matrix(box):
                 elif name == 'skewy':
                     args = (1, math.tan(args), 0, 1, 0, 0)
                 else:
-                    assert name == 'matrix'
+                    assert name == 'matrix', str((name, box))
                 matrix = cairo.Matrix(*args) * matrix
         matrix.translate(-origin_x, -origin_y)
         box.transformation_matrix = matrix
@@ -444,8 +444,8 @@ class Document(object):
 
                 previous_level = level
                 depth = level - sum(skipped_levels)
-                assert depth == len(skipped_levels)
-                assert depth >= 1
+                assert 1 <= depth == len(skipped_levels), str((
+                    depth, len(skipped_levels), level, label))
 
                 children = []
                 subtree = label, (page_number, point_x, point_y), children

--- a/weasyprint/layout/blocks.py
+++ b/weasyprint/layout/blocks.py
@@ -370,7 +370,7 @@ def block_container_layout(context, box, max_position_y, skip_stack,
                            device_size, page_is_empty, absolute_boxes,
                            fixed_boxes, adjoining_margins=None):
     """Set the ``box`` height."""
-    assert isinstance(box, boxes.BlockContainerBox)
+    assert isinstance(box, boxes.BlockContainerBox), str(type(box))
 
     # TODO: this should make a difference, but that is currently neglected.
     # See http://www.w3.org/TR/CSS21/visudet.html#normal-block
@@ -466,8 +466,8 @@ def block_container_layout(context, box, max_position_y, skip_stack,
             continue
 
         if isinstance(child, boxes.LineBox):
-            assert len(box.children) == 1, (
-                'line box with siblings before layout')
+            assert len(box.children) == 1, str((
+                'line box with siblings before layout:', len(box.children)))
             if adjoining_margins:
                 position_y += collapse_margin(adjoining_margins)
                 adjoining_margins = []

--- a/weasyprint/layout/inlines.py
+++ b/weasyprint/layout/inlines.py
@@ -180,7 +180,7 @@ def skip_first_whitespace(box, skip_stack):
         index, next_skip_stack = skip_stack
 
     if isinstance(box, boxes.TextBox):
-        assert next_skip_stack is None
+        assert next_skip_stack is None, str((box, next_skip_stack))
         white_space = box.style.white_space
         length = len(box.text)
         if index == length:
@@ -202,7 +202,7 @@ def skip_first_whitespace(box, skip_stack):
             result = skip_first_whitespace(box.children[index], None)
         return (index, result) if (index or result) else None
 
-    assert skip_stack is None, 'unexpected skip inside %s' % box
+    assert skip_stack is None, str((box, skip_stack))
     return None
 
 
@@ -227,8 +227,8 @@ def remove_last_whitespace(context, box):
             return
         box.text = new_text
         new_box, resume, _ = split_text_box(context, box, None, None, 0)
-        assert new_box is not None
-        assert resume is None
+        assert new_box is not None, str(box)
+        assert resume is None, str((box, resume))
         space_width = box.width - new_box.width
         box.width = new_box.width
     else:
@@ -567,7 +567,7 @@ def split_inline_level(context, box, position_x, max_x, skip_stack,
         else:
             skip, skip_stack = skip_stack
             skip = skip or 0
-            assert skip_stack is None
+            assert skip_stack is None, str((box, skip_stack))
 
         new_box, skip, preserved_line_break = split_text_box(
             context, box, max_x - position_x, max_x, skip)
@@ -602,7 +602,7 @@ def split_inline_box(context, box, position_x, max_x, skip_stack,
     """Same behavior as split_inline_level."""
     is_start = skip_stack is None
     initial_position_x = position_x
-    assert isinstance(box, (boxes.LineBox, boxes.InlineBox))
+    assert isinstance(box, (boxes.LineBox, boxes.InlineBox)), str(type(box))
     left_spacing = (box.padding_left + box.margin_left +
                     box.border_left_width)
 #    right_spacing = (box.padding_right + box.margin_right +
@@ -687,7 +687,7 @@ def split_inline_box(context, box, position_x, max_x, skip_stack,
 
         if new_child is None:
             # may be None where we would have an empty TextBox
-            assert isinstance(child, boxes.TextBox)
+            assert isinstance(child, boxes.TextBox), str(type(child))
         else:
             margin_width = new_child.margin_width()
             new_position_x = position_x + margin_width
@@ -745,7 +745,7 @@ def split_text_box(context, box, available_width, line_width, skip):
     Also break an preserved whitespace.
 
     """
-    assert isinstance(box, boxes.TextBox)
+    assert isinstance(box, boxes.TextBox), str(type(box))
     font_size = box.style.font_size
     text = box.text[skip:]
     if font_size == 0 or not text:
@@ -843,7 +843,8 @@ def line_box_verticality(box):
         elif subtree.style.vertical_align == 'top':
             dy = min_y - sub_min_y
         else:
-            assert subtree.style.vertical_align == 'bottom'
+            assert subtree.style.vertical_align == 'bottom', str((
+                box, subtree.style.vertical_align))
             dy = max_y - sub_max_y
         translate_subtree(subtree, dy)
     return max_y, min_y
@@ -977,7 +978,7 @@ def text_align(context, line, available_width, last):
     if align == 'center':
         offset /= 2.
     else:
-        assert align == 'right'
+        assert align == 'right', str(align)
     return offset
 
 
@@ -1008,7 +1009,7 @@ def add_word_spacing(context, box, extra_word_spacing, x_advance):
         if nb_spaces > 0:
             layout, _, resume_at, width, _, _ = split_first_line(
                 box.text, style, context, float('inf'), None)
-            assert resume_at is None
+            assert resume_at is None, str((box, resume_at))
             # XXX new_box.width - box.width is always 0???
             # x_advance +=  new_box.width - box.width
             x_advance += extra_word_spacing * nb_spaces

--- a/weasyprint/layout/pages.py
+++ b/weasyprint/layout/pages.py
@@ -173,9 +173,9 @@ def compute_fixed_dimension(context, box, outer, vertical, top_or_left):
         box.margin_a = box.margin_b = (
             outer - box.padding_plus_border - box.inner) / 2
 
-    assert 'auto' not in [box.margin_a, box.margin_b, box.inner]
-    # This should also be true, but may not be exact due to
-    # floating point errors:
+    values = box.margin_a, box.margin_b, box.inner
+    assert 'auto' not in values, str(values)
+    # Not always exact due to floating point semantics:
     assert _close(box.inner + box.padding_plus_border +
                   box.margin_a + box.margin_b, outer), str(
                       (box.inner, box.padding_plus_border,
@@ -414,8 +414,7 @@ def margin_box_content_layout(context, page, box):
         first_child = box.children[0]
         last_child = box.children[-1]
         top = first_child.position_y
-        # Not always exact because floating point errors
-        # assert top == box.content_box_y()
+        # Not always exact due to floating point semantics
         assert _close(top, box.content_box_y()), str((top, box.content_box_y()))
         bottom = last_child.position_y + last_child.margin_height()
         content_height = bottom - top

--- a/weasyprint/layout/pages.py
+++ b/weasyprint/layout/pages.py
@@ -235,7 +235,7 @@ def compute_variable_dimension(context, side_boxes, vertical, outer_sum):
                     # which case the sum can not be both <= and > outer_sum
                     # Therefore, one of the last two 'if' statements would not
                     # have lead us here.
-                    assert weight_sum > 0
+                    assert weight_sum > 0, str(weight_sum)
                     box_b.inner += available * weight_b / weight_sum
         if box_a.inner == 'auto':
             box_a.shrink_to_fit((outer_sum - box_b.outer) / 2 - box_a.sugar)
@@ -243,7 +243,7 @@ def compute_variable_dimension(context, side_boxes, vertical, outer_sum):
             box_c.shrink_to_fit((outer_sum - box_b.outer) / 2 - box_c.sugar)
     else:
         # Non-generated boxes get zero for every box-model property
-        assert box_b.inner == 0
+        assert box_b.inner == 0, str(box_b.inner)
         if box_a.inner == box_c.inner == 'auto':
             if outer_sum >= (
                     box_a.outer_max_content_size +
@@ -266,7 +266,7 @@ def compute_variable_dimension(context, side_boxes, vertical, outer_sum):
                     # which case the sum can not be both <= and > outer_sum
                     # Therefore, one of the last two 'if' statements would not
                     # have lead us here.
-                    assert weight_sum > 0
+                    assert weight_sum > 0, str(weight_sum)
                     box_a.inner += available * weight_a / weight_sum
                     box_c.inner += available * weight_c / weight_sum
         elif box_a.inner == 'auto':
@@ -275,7 +275,8 @@ def compute_variable_dimension(context, side_boxes, vertical, outer_sum):
             box_c.shrink_to_fit(outer_sum - box_a.outer - box_c.sugar)
 
     # And, we’re done!
-    assert 'auto' not in [box.inner for box in side_boxes]
+    values = [box.inner for box in side_boxes]
+    assert 'auto' not in values, str(values)
     # Set the actual attributes back.
     for box in side_boxes:
         box.restore_box_attributes()
@@ -405,7 +406,7 @@ def margin_box_content_layout(context, page, box):
         max_position_y=float('inf'), skip_stack=None,
         device_size=page.style.size, page_is_empty=True,
         absolute_boxes=[], fixed_boxes=[])
-    assert resume_at is None
+    assert resume_at is None, str(resume_at) # could be a large string!
 
     vertical_align = box.style.vertical_align
     # Every other value is read as 'top', ie. no change.
@@ -415,6 +416,7 @@ def margin_box_content_layout(context, page, box):
         top = first_child.position_y
         # Not always exact because floating point errors
         # assert top == box.content_box_y()
+        assert _close(top, box.content_box_y()), str((top, box.content_box_y()))
         bottom = last_child.position_y + last_child.margin_height()
         content_height = bottom - top
         offset = box.height - content_height
@@ -505,7 +507,7 @@ def make_page(context, root_box, page_type, resume_at, content_empty,
 
     # TODO: handle cases where the root element is something else.
     # See http://www.w3.org/TR/CSS21/visuren.html#dis-pos-flo
-    assert isinstance(root_box, boxes.BlockBox)
+    assert isinstance(root_box, boxes.BlockBox), str(type(root_box))
     context.create_block_formatting_context()
     page_is_empty = True
     adjoining_margins = []
@@ -514,7 +516,7 @@ def make_page(context, root_box, page_type, resume_at, content_empty,
         context, root_box, page_content_bottom, resume_at,
         initial_containing_block, device_size, page_is_empty,
         positioned_boxes, positioned_boxes, adjoining_margins)
-    assert root_box
+    assert root_box, str(root_box)
 
     page.fixed_boxes = [
         placeholder._box for placeholder in positioned_boxes
@@ -568,7 +570,7 @@ def make_all_pages(context, root_box):
         page, resume_at, next_page = make_page(
             context, root_box, page_type, resume_at, content_empty,
             page_number)
-        assert next_page
+        assert next_page, str(next_page)
         yield page
         if resume_at is None:
             return
@@ -576,7 +578,8 @@ def make_all_pages(context, root_box):
         right_page = not right_page
 
 
-# Similar to Numpy allclose(), but symetric
+# Similar to Numpy allclose(), but symetric: True if the numbers are "close"
+# with respect to the relative and absolute tolerances.
 # https://docs.scipy.org/doc/numpy/reference/generated/numpy.allclose.html
 def _close(a, b, rtol=1e-05, atol=1e-08):
-    return abs(a - b) <= (atol + rtol * (abs(a) + abs(b)) * 0.5)
+    return abs(a - b) <= (rtol * (abs(a) + abs(b)) * 0.5 + atol)


### PR DESCRIPTION
This is an RFC, WIP, not a PR for merging.

This PR shows a few examples of how I'd like to add a terse detail string for assert failures.  The rationale for the pattern (stringify a tuple of local objects) is that an assert failure will be dealt with by an expert who will have to examine the code in question, so there's no need for helpful prose.  What can be helpful to the expert (or the end-user who reports a one-off failure) is to report details about the local state that gave rise to the failure.

I intend to apply this pattern to the other 103 asserts in the non-test code of the project.
