### PR TITLE
Fix a typo in install.rst

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -98,7 +98,7 @@ Debian 9.0 Stretch or newer, Ubuntu 16.04 Xenial or newer:
 
 .. code-block:: sh
 
-    sudo apt-get install build-essential python3-dev python3-pip python3-cffi libcairo2 libpango1.0-0 libgdk-pixbuf2.0-0 libffi-dev shared-mime-info
+    sudo apt-get install build-essential python3-dev python3-pip python3-cffi libcairo2 libpango-1.0-0 libgdk-pixbuf2.0-0 libffi-dev shared-mime-info
 
 Debian 8.0 Jessie or newer, Ubuntu 14.04 Trusty or newer (with Python 2, but Python 3 may work):
 


### PR DESCRIPTION
It should be `libpango-1.0-0` instead of `libpango1.0-0`.