### PR TITLE
Add missing libpangocairo dependency

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -98,19 +98,19 @@ Debian 9.0 Stretch or newer, Ubuntu 16.04 Xenial or newer:
 
 .. code-block:: sh
 
-    sudo apt-get install build-essential python3-dev python3-pip python3-cffi libcairo2 libpango-1.0-0 libgdk-pixbuf2.0-0 libffi-dev shared-mime-info
+    sudo apt-get install build-essential python3-dev python3-pip python3-cffi libcairo2 libpango-1.0-0 libpangocairo-1.0.0 libgdk-pixbuf2.0-0 libffi-dev shared-mime-info
 
 Debian 8.0 Jessie or newer, Ubuntu 14.04 Trusty or newer (with Python 2, but Python 3 may work):
 
 .. code-block:: sh
 
-    sudo apt-get install build-essential python-dev python-pip python-cffi libcairo2 libpango1.0-0 libgdk-pixbuf2.0-0 libffi-dev shared-mime-info
+    sudo apt-get install build-essential python-dev python-pip python-cffi libcairo2 libpango1.0-0 libpangocairo-1.0.0 libgdk-pixbuf2.0-0 libffi-dev shared-mime-info
 
 Debian 7.0 Wheezy or newer, Ubuntu 12.04 Precise or newer (with Python 2, but Python 3 may work):
 
 .. code-block:: sh
 
-    sudo apt-get install build-essential python-dev python-pip libcairo2 libpango1.0-0 libgdk-pixbuf2.0-0 libffi-dev shared-mime-info
+    sudo apt-get install build-essential python-dev python-pip libcairo2 libpango1.0-0 libpangocairo-1.0.0 libgdk-pixbuf2.0-0 libffi-dev shared-mime-info
 
 Fedora
 ~~~~~~


### PR DESCRIPTION
Without this, you'll get 

```
OSError: cannot load library pangocairo-1.0: pangocairo-1.0: cannot open shared object file: No such file or directory.
Additionally, ctypes.util.find_library() did not manage to locate a library called 'pangocairo-1.0'
```