### PR TITLE
Fix the line breaking algorithm

### DIFF
--- a/weasyprint/html.py
+++ b/weasyprint/html.py
@@ -330,7 +330,7 @@ def strip_whitespace(string):
     http://www.whatwg.org/html#space-character
 
     """
-    return string.strip(' \t\n\f\r')
+    return string.strip(HTML_WHITESPACE)
 
 
 # YYYY (eg 1997)

--- a/weasyprint/images.py
+++ b/weasyprint/images.py
@@ -214,7 +214,7 @@ def get_image_from_uri(cache, url_fetcher, url, forced_mime_type=None):
                             'the only image formats available.')
                     try:
                         image = SVGImage(string, url, url_fetcher)
-                    except:
+                    except BaseException:
                         try:
                             surface, format_name = (
                                 pixbuf.decode_to_image_surface(string))

--- a/weasyprint/layout/inlines.py
+++ b/weasyprint/layout/inlines.py
@@ -14,11 +14,9 @@ from __future__ import division, unicode_literals
 
 import unicodedata
 
-import uniseg.linebreak
-
 from ..css.computed_values import ex_ratio, strut_layout
 from ..formatting_structure import boxes
-from ..text import split_first_line
+from ..text import can_break_text, split_first_line
 from .absolute import AbsolutePlaceholder, absolute_layout
 from .float import avoid_collisions, float_layout
 from .min_max import handle_min_max_height, handle_min_max_width
@@ -703,8 +701,8 @@ def split_inline_box(context, box, position_x, max_x, skip_stack,
         if None in (last_letter, first):
             can_break = True
         else:
-            can_break = bool(list(uniseg.linebreak.line_break_breakables(
-                last_letter + first))[1])
+            can_break = can_break_text(
+                last_letter + first, child.style['lang'])
 
         if can_break:
             children.extend(waiting_children)
@@ -1118,9 +1116,7 @@ def can_break_inside(box):
     if isinstance(box, boxes.AtomicInlineLevelBox):
         return False
     elif isinstance(box, boxes.TextBox):
-        if box.text:
-            return any(uniseg.linebreak.line_break_breakables(box.text[1:]))
+        return can_break_text(box.text, box.style['lang'])
     elif isinstance(box, boxes.ParentBox):
         return any(can_break_inside(child) for child in box.children)
-    else:
-        return False
+    return False

--- a/weasyprint/layout/inlines.py
+++ b/weasyprint/layout/inlines.py
@@ -740,14 +740,15 @@ def split_inline_box(context, box, position_x, max_x, skip_stack,
 
 
 def split_text_box(context, box, available_width, skip):
-    """Keep as much text as possible from a TextBox in a limitied width.
+    """Keep as much text as possible from a TextBox in a limited width.
+
     Try not to overflow but always have some text in ``new_box``
 
     Return ``(new_box, skip, preserved_line_break)``. ``skip`` is the number of
     UTF-8 bytes to skip form the start of the TextBox for the next line, or
     ``None`` if all of the text fits.
 
-    Also break on preserved whitespace.
+    Also break on preserved line breaks.
 
     """
     assert isinstance(box, boxes.TextBox)
@@ -800,8 +801,9 @@ def split_text_box(context, box, available_width, skip):
         preserved_line_break = (length != resume_at) and between.strip(' ')
         if preserved_line_break:
             # See http://unicode.org/reports/tr14/
-            # TODO: are there others? Find Pango docs on this
-            assert between in ('\n', '\u2029'), (
+            # \r is already handled by process_whitespace
+            line_breaks = ('\n', '\t', '\f', '\u0085', '\u2028', '\u2029')
+            assert between in line_breaks, (
                 'Got %r between two lines. '
                 'Expected nothing or a preserved line break' % (between,))
         resume_at += skip

--- a/weasyprint/layout/inlines.py
+++ b/weasyprint/layout/inlines.py
@@ -226,7 +226,7 @@ def remove_last_whitespace(context, box):
         if len(new_text) == len(box.text):
             return
         box.text = new_text
-        new_box, resume, _ = split_text_box(context, box, None, None, 0)
+        new_box, resume, _ = split_text_box(context, box, None, 0)
         assert new_box is not None
         assert resume is None
         space_width = box.width - new_box.width
@@ -566,7 +566,7 @@ def split_inline_level(context, box, position_x, max_x, skip_stack,
             assert skip_stack is None
 
         new_box, skip, preserved_line_break = split_text_box(
-            context, box, max_x - position_x, max_x, skip)
+            context, box, max_x - position_x, skip)
 
         if skip is None:
             resume_at = None
@@ -739,15 +739,15 @@ def split_inline_box(context, box, position_x, max_x, skip_stack,
     return new_box, resume_at, preserved_line_break
 
 
-def split_text_box(context, box, available_width, line_width, skip):
+def split_text_box(context, box, available_width, skip):
     """Keep as much text as possible from a TextBox in a limitied width.
     Try not to overflow but always have some text in ``new_box``
 
-    Return ``(new_box, skip)``. ``skip`` is the number of UTF-8 bytes
-    to skip form the start of the TextBox for the next line, or ``None``
-    if all of the text fits.
+    Return ``(new_box, skip, preserved_line_break)``. ``skip`` is the number of
+    UTF-8 bytes to skip form the start of the TextBox for the next line, or
+    ``None`` if all of the text fits.
 
-    Also break an preserved whitespace.
+    Also break on preserved whitespace.
 
     """
     assert isinstance(box, boxes.TextBox)
@@ -756,8 +756,7 @@ def split_text_box(context, box, available_width, line_width, skip):
     if font_size == 0 or not text:
         return None, None, False
     layout, length, resume_at, width, height, baseline = split_first_line(
-        text, box.style, context, available_width, line_width,
-        box.justification_spacing)
+        text, box.style, context, available_width, box.justification_spacing)
     assert resume_at != 0
 
     # Convert ``length`` and ``resume_at`` from UTF-8 indexes in text
@@ -1013,7 +1012,7 @@ def add_word_spacing(context, box, justification_spacing, x_advance):
         nb_spaces = count_spaces(box)
         if nb_spaces > 0:
             layout, _, resume_at, width, _, _ = split_first_line(
-                box.text, box.style, context, float('inf'), None,
+                box.text, box.style, context, float('inf'),
                 box.justification_spacing)
             assert resume_at is None
             # XXX new_box.width - box.width is always 0???

--- a/weasyprint/layout/markers.py
+++ b/weasyprint/layout/markers.py
@@ -33,7 +33,6 @@ def list_marker_layout(context, box):
             (marker.pango_layout, _, _, marker.width, marker.height,
                 marker.baseline) = split_first_line(
                     marker.text, marker.style, context, max_width=None,
-                    line_width=None,
                     justification_spacing=marker.justification_spacing)
             baseline = find_in_flow_baseline(box)
         else:

--- a/weasyprint/tests/test_text.py
+++ b/weasyprint/tests/test_text.py
@@ -29,7 +29,7 @@ def make_text(text, width=None, **style):
     new_style.update(style)
     return split_first_line(
         text, StyleDict(new_style), context=None, max_width=width,
-        line_width=None, justification_spacing=0)
+        justification_spacing=0)
 
 
 @assert_no_logs

--- a/weasyprint/text.py
+++ b/weasyprint/text.py
@@ -954,7 +954,7 @@ def split_first_line(text, style, context, max_width, justification_spacing):
         second_line = next(lines, None)
     resume_at = None if second_line is None else second_line.start_index
 
-    # Step #2: Don't hyphenize when it's not needed
+    # Step #2: Don't split lines when it's not needed
     if max_width is None:
         # The first line can take all the place needed
         return first_line_metrics(
@@ -1126,7 +1126,7 @@ def split_first_line(text, style, context, max_width, justification_spacing):
         # The way new lines are processed in this function (one by one with no
         # memory of the last) prevents shaping characters (arabic, for
         # instance) from keeping their shape when wrapped on the next line with
-        # pango layout.  Maybe insert Unicode shaping characters in text ?
+        # pango layout. Maybe insert Unicode shaping characters in text?
         layout.set_text(text)
         pango.pango_layout_set_width(
             layout.layout, units_from_double(max_width))

--- a/weasyprint/text.py
+++ b/weasyprint/text.py
@@ -907,8 +907,7 @@ def create_layout(text, style, context, max_width, justification_spacing):
     return layout
 
 
-def split_first_line(text, style, context, max_width, line_width,
-                     justification_spacing):
+def split_first_line(text, style, context, max_width, justification_spacing):
     """Fit as much as possible in the available width for one line of text.
 
     Return ``(layout, length, resume_at, width, height, baseline)``.
@@ -933,7 +932,7 @@ def split_first_line(text, style, context, max_width, line_width,
 
     # Step #1: Get a draft layout with the first line
     layout = None
-    if max_width is not None and max_width != float('inf'):
+    if max_width is not None and max_width != float('inf') and style.font_size:
         expected_length = int(max_width / style.font_size * 2.5)
         if expected_length < len(text):
             # Try to use a small amount of text instead of the whole text
@@ -1156,14 +1155,6 @@ def split_first_line(text, style, context, max_width, line_width,
     return first_line_metrics(
         first_line, text, layout, resume_at, space_collapse, style, hyphenated,
         style.hyphenate_character)
-
-
-def line_widths(text, style, context, width, justification_spacing):
-    """Return the width for each line."""
-    layout = create_layout(text, style, context, width, justification_spacing)
-    for line in layout.iter_lines():
-        width, _height = get_size(line, style)
-        yield width
 
 
 def show_first_line(context, pango_layout, hinting):


### PR DESCRIPTION
Close #301.

I was wrong about so many things.

- The line breaking algorithm is [really well defined in the Text 3 module](https://www.w3.org/TR/css-text-3/#line-break-details). It does not rely on [fragmentation](https://www.w3.org/TR/css-break-3/), that's so cool. Most of the rules were already supported, the spec mainly relies on the "soft wrap opportunities" that's not defined in the spec, but…

- This "soft wrap opportunities" thing is very, very well supported by Pango. As for everyting around Unicode, I thought that it was complicated, and it is actually really more complicated than just complicated. Did I want to rewrite this? OMG, I was crazy. But…

- After reading the current code, the only real missing feature to cleanly support line breaking was to remove the soft wrap opportunities at tags boundaries. And that's all. Pango is incredible to cut lines, it just doesn't know specific CSS rules (as space trimming and stripping), but we don't care. We can imagine workarounds in WeasyPrint, that's not bad, everybody does that (except "real" browsers that can hire Behdad to rewrite Pango for their needs). And…

- We already have the workarounds. We don't have to rewrite the line breaking algorithm, because Pango + workarounds is actually a really smart way to do what we want to do. There's no important thing to add, except from cleaning some complicated `*-wrap` and `*-break` attributes and from line-breaks at tags boundaries. And…

- Line-breaks at tags boundaries are now correctly supported. That's what this PR is about. That's all, and that was pretty easy. And…

- Let's talk about right-to-left and bidi. Let's talk about #106. Pango already handles this in text. I'm now sure that we can handle this for boxes, thanks to some features Pango will provide, and a lot of tests. Thanks to the W3C, we already have tests. So… Let's go!