### PR TITLE
Fix root when frozen with pyinstaller

### DIFF
--- a/weasyprint/html.py
+++ b/weasyprint/html.py
@@ -34,7 +34,11 @@ level = LOGGER.level
 LOGGER.setLevel(logging.ERROR)
 
 if hasattr(sys, "frozen"):
-    root = os.path.dirname(sys.executable)
+    if hasattr(sys, "_MEIPASS"):
+        # Frozen with PyInstaller
+        root = sys._MEIPASS
+    else:
+        root = os.path.dirname(sys.executable)
 else:
     root = os.path.dirname(__file__)
 HTML5_UA_STYLESHEET = CSS(filename=os.path.join(root, 'css', 'html5_ua.css'))


### PR DESCRIPTION
When freezing a WeasyPrint application with PyInstaller, `root` needs to be set to `sys._MEIPASS`, which is the absolute path to the bundle folder (source:
 <https://pythonhosted.org/PyInstaller/runtime-information.html>). `_MEIPASS` appears to be uniquely set by PyInstaller so my code change simply checks for this attribute and sets the appropriate `root`.

You can recreate the issue by performing the following steps.
Environment:
macOS 10.12.6
python 3.6 (or 3.4) via anaconda

1. Create a basic weasyprint program `weasyprint_frozen.py`:
```
import weasyprint
print(weasyprint.__version__)
input('Press enter to exit the program: ')
```

2. Freeze the program with PyInstaller. Note some files from WeasyPrint need to be bundled with the frozen application (that's what the `--add-data` options are for):
```
pip install pyinstaller
pyinstaller weasyprint_frozen.py --name 'Weasyprint App' --log-level ERROR --clean --add-data '/Users/Jonnymetz/anaconda/lib/python3.6/site-packages/pyphen/dictionaries:pyphen/dictionaries' --add-data '/Users/Jonnymetz/anaconda/lib/python3.6/site-packages/weasyprint/css/html5_ph.css:css' --add-data '/Users/Jonnymetz/anaconda/lib/python3.6/site-packages/weasyprint/css/html5_ua.css:css' --onefile
```

As WeasyPrints currently stands, the frozen application will not run and the traceback should look similar to this:
```
Traceback (most recent call last):
  File "weasyprint_frozen.py", line 1, in <module>
  File "<frozen importlib._bootstrap>", line 971, in _find_and_load
  File "<frozen importlib._bootstrap>", line 955, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
  File "/Users/Jonnymetz/anaconda/envs/pyweasy36/lib/python3.6/site-packages/PyInstaller/loader/pyimod03_importers.py", line 631, in exec_module
    exec(bytecode, module.__dict__)
  File "site-packages/weasyprint/__init__.py", line 376, in <module>
  File "<frozen importlib._bootstrap>", line 971, in _find_and_load
  File "<frozen importlib._bootstrap>", line 955, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
  File "/Users/Jonnymetz/anaconda/envs/pyweasy36/lib/python3.6/site-packages/PyInstaller/loader/pyimod03_importers.py", line 631, in exec_module
    exec(bytecode, module.__dict__)
  File "site-packages/weasyprint/html.py", line 40, in <module>
  File "site-packages/weasyprint/__init__.py", line 261, in __init__
  File "contextlib.py", line 81, in __enter__
  File "site-packages/weasyprint/__init__.py", line 338, in _select_source
FileNotFoundError: [Errno 2] No such file or directory: '/Users/Jonnymetz/github/basic_flask/dist/css/html5_ua.css'
[24858] Failed to execute script weasyprint_frozen
```

With my code change, the frozen application should run as expected:
```
0.41
Press enter to exit the program: 
```