### PR TITLE
Update docs/hacking.rst to include required pytest plugins

### DIFF
--- a/docs/hacking.rst
+++ b/docs/hacking.rst
@@ -12,7 +12,7 @@ install the `development version`_ of WeasyPrint:
     cd WeasyPrint
     virtualenv --system-site-packages env
     . env/bin/activate
-    pip install pytest Sphinx -e .
+    pip install pytest pytest-cov pytest-flake8 pytest-isort Sphinx -e .
     weasyprint --help
 
 This will install WeasyPrint in “editable” mode


### PR DESCRIPTION
The doc says:

> Use the `py.test` command from the `WeasyPrint` directory to run the test suite.

This doesn't work unless these additional `pytest` plugins are installed as well.