### PR TITLE
support @font-face on Windows

### DIFF
--- a/weasyprint/fonts.py
+++ b/weasyprint/fonts.py
@@ -132,12 +132,6 @@ if fontconfig and pangoft2:
             cairo_font_type_t fonttype);
     ''')
 
-    fontconfig = dlopen(ffi, 'fontconfig', 'libfontconfig',
-                        'libfontconfig-1.dll',
-                        'libfontconfig.so.1', 'libfontconfig-1.dylib')
-    pangoft2 = dlopen(ffi, 'pangoft2-1.0', 'libpangoft2-1.0-0',
-                      'libpangoft2-1.0.so', 'libpangoft2-1.0.dylib')
-
     FONTCONFIG_WEIGHT_CONSTANTS = {
         'normal': 'normal',
         'bold': 'bold',
@@ -169,6 +163,15 @@ if fontconfig and pangoft2:
         'extra-expanded': 'extraexpanded',
         'ultra-expanded': 'ultraexpanded',
     }
+
+    _warned_once = False
+
+    def _warn_once(msg):
+        """don't annoy with warnings, one is enough"""
+        global _warned_once
+        if not _warned_once:
+            warnings.warn(msg)
+            _warned_once = True
 
     def _checkfontconfiguration(font_config):
         """
@@ -203,10 +206,10 @@ if fontconfig and pangoft2:
         configfiles = fontconfig.FcConfigGetConfigFiles(font_config)
         file = fontconfig.FcStrListNext(configfiles)
         if file == ffi.NULL:
-            warnings.warn(
+            _warn_once(
                 '@font-face not supported: Cannot load default config file')
         else:
-            warnings.warn('@font-face not supported: no fonts configured')
+            _warn_once('@font-face not supported: no fonts configured')
         # fall back to defaul @font-face-less behaviour
         return False
         # on Windows we could try to add the system fonts like that:

--- a/weasyprint/fonts.py
+++ b/weasyprint/fonts.py
@@ -46,9 +46,13 @@ else:
         pangoft2 = dlopen(ffi, 'pangoft2-1.0', 'libpangoft2-1.0-0',
                           'libpangoft2-1.0.so', 'libpangoft2-1.0.dylib')
     except Exception as err:
-        warnings.warn("'@font-face not supported: {0}".format(err))
-        fontconfig = None
-        pangoft2 = None
+        # dont alter behavior on other platforms!
+        if not sys.platform.startswith('win'):
+            raise err
+        else:
+            warnings.warn("'@font-face not supported: {0}".format(err))
+            fontconfig = None
+            pangoft2 = None
 
 
 # if both libraries are present: Use them


### PR DESCRIPTION
UPPs, the branch name is a bit ... misleading ...

Since at the moment I have no access to another OS than Windows and the existing code in `weasyprint/fonts.py` probably was ok for other platfoms, I implemented the fix in a way that only affects `sys.platform.startswith('win')`.

Switching to FreeType rendering not only enables `@font-face`; suddenly other CSS properties, like `font-stretch` and `font-variant`, start to work as expected -- see  #587 -- even the killer css `font-size: 0` doesn't crash Pango anymore!

There is one minor drawback on Windows: FontConfiguration can't delete the temporary font files it creates during rendering. I think Pango keeps the file handles open (until the Python process is finished), couldn't find a way to persuade it to let them go...

FontConfig and PangoFT2 not only require the proper libraries but also a working font configuration.

Maybe on Nix it never happens that those config files are missing, but [Tom Schoonjans' GTK3 Runtime](https://github.com/tschoonj/GTK-for-Windows-Runtime-Environment-Installer), recommended in the WeasyPrint docs [Installing on Windows](http://weasyprint.readthedocs.io/en/latest/install.html#windows), though installing all required DLLs, doesn't create the `/etc/fonts` folder. I created an issue, status == open.

Lucky me having Inkscape installed with an appropriate `etc/fonts`...

That's why (besides trying and catching `dlopen`), before actually using FontConfig, the code checks whether it has access to at least one font.
If that's the case, font rendering is done via FreeType, otherwise it falls back to the, `@font-face`-less, native system fonts rendering mode.

I tried to support the fontconfig library with an `os.environ['FONTCONFIG_PATH'] = 'default/etc/fonts/we/could/add/to/weasyprint'` when it complains about a missing `fonts.conf`.
Doesn't work. Probably again due to the way how DLLs are loaded in Python. The DLL only sees the global environment that the python script is running in. Changes during runtime don't reach the DLL.
Contemplated about `FcConfigAppFontAddDir(<WINDOWSFONTDIR>)` to circumvent such a situation...

Windows-testers welcome!
