### PR TITLE
rectify index

### DIFF
--- a/weasyprint/css/validation/properties.py
+++ b/weasyprint/css/validation/properties.py
@@ -446,7 +446,7 @@ def content(tokens, base_url):
             break
     if len(tokens) == 0:
         return
-    if len(tokens) >= 3 and tokens[-2].type == 'string' and (
+    if len(tokens) >= 3 and tokens[-1].type == 'string' and (
             tokens[-2].type == 'literal' and tokens[-2].value == '/'):
         # Ignore text for speech
         tokens = tokens[:-2]


### PR DESCRIPTION
Did I get you right? 
In the `content()` function in weasyprint.css.validation.properties -- the purpose of the `parsed_tokens` is only a stub to cover the spec's comma separated URI list. Since this 'alternate resources with fallback' concept isn't (yet) implemented they are silently discarded.


