### PR TITLE
Possible optimizations - do not merge

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,38 @@
 WeasyPrint changelog
 ====================
 
+
+Versions 0.42.x will only get simple bug fixes backported from the master
+branch. New features, opitimizations and complex bug fixes will only be added
+to the 43+ versions that don't support Python 2 anymore.
+
+Do not rely on future versions, development on the 0.x branch may be stopped at
+any moment.
+
+
+Version 0.42.1
+--------------
+
+Released on 2018-02-01.
+
+Bug fixes:
+
+* `#566 <https://github.com/Kozea/WeasyPrint/issues/566>`_:
+  Don't crash when using @font-config.
+* `#567 <https://github.com/Kozea/WeasyPrint/issues/567>`_:
+  Fix text-indent with text-align: justify.
+* `#465 <https://github.com/Kozea/WeasyPrint/issues/465>`_:
+  Fix string(*, start).
+* `#562 <https://github.com/Kozea/WeasyPrint/issues/562>`_:
+  Handle named pages with pseudo-class.
+* `#507 <https://github.com/Kozea/WeasyPrint/issues/507>`_:
+  Fix running headers.
+* `#557 <https://github.com/Kozea/WeasyPrint/issues/557>`_:
+  Avoid infinite loops in inline_line_width.
+* `#555 <https://github.com/Kozea/WeasyPrint/issues/555>`_:
+  Fix margins, borders and padding in column layouts.
+
+
 Version 0.42
 ------------
 

--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,29 @@ Do not rely on future versions, development on the 0.x branch may be stopped at
 any moment.
 
 
+Version 0.42.3
+--------------
+
+Released on 2018-03-27.
+
+Bug fixes:
+
+* `#583 <https://github.com/Kozea/WeasyPrint/issues/583>`_:
+  Fix floating-point number error to fix floating box layout
+* `#586 <https://github.com/Kozea/WeasyPrint/issues/586>`_:
+  Don't optimize resume_at when splitting lines with trailing spaces
+* `#582 <https://github.com/Kozea/WeasyPrint/issues/582>`_:
+  Fix table layout with no overflow
+* `#580 <https://github.com/Kozea/WeasyPrint/issues/580>`_:
+  Fix inline box breaking function
+* `#576 <https://github.com/Kozea/WeasyPrint/issues/576>`_:
+  Split replaced_min_content_width and replaced_max_content_width
+* `#574 <https://github.com/Kozea/WeasyPrint/issues/574>`_:
+  Respect text direction and don't translate rtl columns twice
+* `#569 <https://github.com/Kozea/WeasyPrint/issues/569>`_:
+  Get only first line's width of inline children to get linebox width
+
+
 Version 0.42.2
 --------------
 

--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,17 @@ Do not rely on future versions, development on the 0.x branch may be stopped at
 any moment.
 
 
+Version 0.42.2
+--------------
+
+Released on 2018-02-04.
+
+Bug fixes:
+
+* `#560 <https://github.com/Kozea/WeasyPrint/issues/560>`_:
+  Fix a couple of crashes and endless loops when breaking lines.
+
+
 Version 0.42.1
 --------------
 

--- a/docs/hacking.rst
+++ b/docs/hacking.rst
@@ -12,13 +12,13 @@ install the `development version`_ of WeasyPrint:
     cd WeasyPrint
     virtualenv --system-site-packages env
     . env/bin/activate
-    pip install pytest Sphinx -e .
+    pip install Sphinx -e .[test]
     weasyprint --help
 
 This will install WeasyPrint in “editable” mode
 (which means that you don’t need to re-install it
 every time you make a change in the source code)
-as well as `py.test <http://pytest.org/>`_
+as well as `pytest <http://pytest.org/>`_
 and `Sphinx <http://sphinx.pocoo.org/>`_.
 
 Lastly, in order to pass unit tests, your system must have two particular fonts:
@@ -43,7 +43,7 @@ The website version is updated automatically when we push to master on GitHub.
 Code changes
 ------------
 
-Use the ``py.test`` command from the ``WeasyPrint`` directory to run the
+Use the ``pytest`` command from the ``WeasyPrint`` directory to run the
 test suite.
 
 Please report any bugs/feature requests and submit patches/pull requests

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -100,7 +100,7 @@ Debian 9.0 Stretch or newer, Ubuntu 16.04 Xenial or newer:
 
 .. code-block:: sh
 
-    sudo apt-get install build-essential python3-dev python3-pip python3-cffi libcairo2 libpango-1.0-0 libpangocairo-1.0.0 libgdk-pixbuf2.0-0 libffi-dev shared-mime-info
+    sudo apt-get install build-essential python3-dev python3-pip python3-cffi libcairo2 libpango-1.0-0 libpangocairo-1.0-0 libgdk-pixbuf2.0-0 libffi-dev shared-mime-info
 
 Debian 8.0 Jessie or newer, Ubuntu 14.04 Trusty or newer (with Python 2, but Python 3 may work):
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -4,8 +4,8 @@ Installing
 WeasyPrint |version| depends on:
 
 * CPython_ 2.7 or ≥ 3.4
-* cairo_ [#]_
-* Pango_
+* cairo_ ≥ 1.15.0 [#]_
+* Pango_ ≥ 1.29.3
 * CFFI_ ≥ 0.6
 * html5lib_ ≥ 0.999999999
 * cairocffi_ ≥ 0.5
@@ -14,7 +14,7 @@ WeasyPrint |version| depends on:
 * CairoSVG_ ≥ 1.0.20
 * Pyphen_ ≥ 0.8
 * pdfrw_ ≥ 0.4
-* Optional: GDK-PixBuf_ [#]_
+* Optional: GDK-PixBuf_ ≥ 2.25.0 [#]_
 
 .. _CPython: http://www.python.org/
 .. _cairo: http://cairographics.org/
@@ -69,9 +69,11 @@ If everything goes well, you’re ready to :doc:`start using </tutorial>`
 WeasyPrint! Otherwise, please copy the full error message and
 `report the problem <http://weasyprint.org/community/>`_.
 
-.. [#] cairo ≥ 1.12 is best but older versions should work too.
-       The test suite passes on cairo 1.8 and 1.10 with some tests marked as
-       “expected failures” due to behavior changes or bugs in cairo.
+.. [#] cairo ≥ 1.15 is best but older versions may work too. The test suite
+       passes on cairo 1.12 and 1.14, and passes with some tests marked as
+       “expected failures” on 1.8 and 1.10 due to behavior changes or bugs in
+       cairo. With cairo 1.14, WeasyPrint sometimes creates PDF files that may
+       not be correctly interpreted by GhostScript or CUPS.
 
 .. [#] Without it, PNG and SVG are the only supported image formats.
        JPEG, GIF and others are not available.

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -243,7 +243,6 @@ by configuring the ``weasyprint`` logger object:
 
     import logging
     logger = logging.getLogger('weasyprint')
-    logger.handlers = []  # Remove the default stderr handler
     logger.addHandler(logging.FileHandler('/path/to/weasyprint.log'))
 
 The ``INFO`` level is used to report the rendering progress. It is useful to

--- a/weasyprint/__init__.py
+++ b/weasyprint/__init__.py
@@ -21,7 +21,7 @@ import cssselect2
 import tinycss2
 
 
-VERSION = '0.42.1'
+VERSION = '0.42.2'
 __version__ = VERSION
 
 # Used for 'User-Agent' in HTTP and 'Creator' in PDF

--- a/weasyprint/__init__.py
+++ b/weasyprint/__init__.py
@@ -21,7 +21,7 @@ import cssselect2
 import tinycss2
 
 
-VERSION = '0.42.2'
+VERSION = '0.42.3'
 __version__ = VERSION
 
 # Used for 'User-Agent' in HTTP and 'Creator' in PDF

--- a/weasyprint/__init__.py
+++ b/weasyprint/__init__.py
@@ -21,7 +21,7 @@ import cssselect2
 import tinycss2
 
 
-VERSION = '0.42'
+VERSION = '0.42.1'
 __version__ = VERSION
 
 # Used for 'User-Agent' in HTTP and 'Creator' in PDF

--- a/weasyprint/css/__init__.py
+++ b/weasyprint/css/__init__.py
@@ -586,6 +586,82 @@ def computed_from_cascaded(element, cascaded, parent_style, pseudo_type=None,
         base_url))
 
 
+def parse_page_selectors(rule):
+    """Parse a page selector rule.
+
+    Return a list of page data if the rule is correctly parsed. Page data are a
+    dict containing:
+
+    - 'side' ('left', 'right' or None),
+    - 'blank' (True or False),
+    - 'first' (True or False),
+    - 'name' (page name string or None), and
+    - 'spacificity' (list of numbers).
+
+    Return ``None` if something went wrong while parsing the rule.
+
+    """
+    # See https://drafts.csswg.org/css-page-3/#syntax-page-selector
+
+    tokens = list(remove_whitespace(rule.prelude))
+    page_data = []
+
+    # TODO: Specificity is probably wrong, should clean and test that.
+    if not tokens:
+        page_data.append({
+            'side': None, 'blank': False, 'first': False, 'name': None,
+            'specificity': [0, 0, 0]})
+        return page_data
+
+    while tokens:
+        types = {
+            'side': None, 'blank': False, 'first': False, 'name': None,
+            'specificity': [0, 0, 0]}
+
+        if tokens[0].type == 'ident':
+            token = tokens.pop(0)
+            types['name'] = token.value
+            types['specificity'][0] = 1
+
+        if len(tokens) == 1:
+            return None
+        elif not tokens:
+            page_data.append(types)
+            return page_data
+
+        while tokens:
+            literal = tokens.pop(0)
+            if literal.type != 'literal':
+                return None
+
+            if literal.value == ':':
+                if not tokens or tokens[0].type != 'ident':
+                    return None
+                ident = tokens.pop(0)
+                pseudo_class = ident.lower_value
+                if pseudo_class in ('left', 'right'):
+                    if types['side']:
+                        return None
+                    types['side'] = pseudo_class
+                    types['specificity'][2] += 1
+                elif pseudo_class in ('blank', 'first'):
+                    if types[pseudo_class]:
+                        return None
+                    types[pseudo_class] = True
+                    types['specificity'][1] += 1
+                else:
+                    return None
+            elif literal.value == ',':
+                if tokens and any(types['specificity']):
+                    break
+                else:
+                    return None
+
+        page_data.append(types)
+
+    return page_data
+
+
 def preprocess_stylesheet(device_media_type, base_url, stylesheet_rules,
                           url_fetcher, matcher, page_rules, fonts,
                           font_config, ignore_imports=False):
@@ -671,64 +747,44 @@ def preprocess_stylesheet(device_media_type, base_url, stylesheet_rules,
                 matcher, page_rules, fonts, font_config, ignore_imports=True)
 
         elif rule.type == 'at-rule' and rule.lower_at_keyword == 'page':
-            tokens = remove_whitespace(rule.prelude)
-            types = {
-                'side': None, 'blank': False, 'first': False, 'name': None}
-            # TODO: Specificity is probably wrong, should clean and test that.
-            if not tokens:
-                specificity = (0, 0, 0)
-            elif (len(tokens) == 2 and
-                    tokens[0].type == 'literal' and
-                    tokens[0].value == ':' and
-                    tokens[1].type == 'ident'):
-                pseudo_class = tokens[1].lower_value
-                if pseudo_class in ('left', 'right'):
-                    types['side'] = pseudo_class
-                    specificity = (0, 0, 1)
-                elif pseudo_class in ('blank', 'first'):
-                    types[pseudo_class] = True
-                    specificity = (0, 1, 0)
-                else:
-                    LOGGER.warning('Unknown @page pseudo-class "%s", '
-                                   'the whole @page rule was ignored '
-                                   'at %s:%s.',
-                                   pseudo_class,
-                                   rule.source_line, rule.source_column)
-                    continue
-            elif len(tokens) == 1 and tokens[0].type == 'ident':
-                types['name'] = tokens[0].value
-                specificity = (1, 0, 0)
-            else:
-                LOGGER.warning('Unsupported @page selector "%s", '
-                               'the whole @page rule was ignored at %s:%s.',
-                               tinycss2.serialize(rule.prelude),
-                               rule.source_line, rule.source_column)
+            data = parse_page_selectors(rule)
+
+            if data is None:
+                LOGGER.warning(
+                    'Unsupported @page selector "%s", '
+                    'the whole @page rule was ignored at %s:%s.',
+                    tinycss2.serialize(rule.prelude),
+                    rule.source_line, rule.source_column)
                 continue
+
             ignore_imports = True
-            page_type = PageType(**types)
-            # Use a double lambda to have a closure that holds page_types
-            match = (lambda page_type: lambda page_names: list(
-                matching_page_types(page_type, names=page_names)))(page_type)
-            content = tinycss2.parse_declaration_list(rule.content)
-            declarations = list(preprocess_declarations(base_url, content))
+            for page_type in data:
+                specificity = page_type.pop('specificity')
+                page_type = PageType(**page_type)
+                # Use a double lambda to have a closure that holds page_types
+                match = (lambda page_type: lambda page_names: list(
+                    matching_page_types(page_type, names=page_names)))(
+                        page_type)
+                content = tinycss2.parse_declaration_list(rule.content)
+                declarations = list(preprocess_declarations(base_url, content))
 
-            if declarations:
-                selector_list = [(specificity, None, match)]
-                page_rules.append((rule, selector_list, declarations))
-
-            for margin_rule in content:
-                if margin_rule.type != 'at-rule' or (
-                        margin_rule.content is None):
-                    continue
-                declarations = list(preprocess_declarations(
-                    base_url,
-                    tinycss2.parse_declaration_list(margin_rule.content)))
                 if declarations:
-                    selector_list = [(
-                        specificity, '@' + margin_rule.lower_at_keyword,
-                        match)]
-                    page_rules.append(
-                        (margin_rule, selector_list, declarations))
+                    selector_list = [(specificity, None, match)]
+                    page_rules.append((rule, selector_list, declarations))
+
+                for margin_rule in content:
+                    if margin_rule.type != 'at-rule' or (
+                            margin_rule.content is None):
+                        continue
+                    declarations = list(preprocess_declarations(
+                        base_url,
+                        tinycss2.parse_declaration_list(margin_rule.content)))
+                    if declarations:
+                        selector_list = [(
+                            specificity, '@' + margin_rule.lower_at_keyword,
+                            match)]
+                        page_rules.append(
+                            (margin_rule, selector_list, declarations))
 
         elif rule.type == 'at-rule' and rule.lower_at_keyword == 'font-face':
             ignore_imports = True

--- a/weasyprint/css/properties.py
+++ b/weasyprint/css/properties.py
@@ -308,6 +308,7 @@ TABLE_WRAPPER_BOX_PROPERTIES = set('''
     margin_left
     margin_right
     opacity
+    overflow
     position
     right
     top

--- a/weasyprint/css/validation.py
+++ b/weasyprint/css/validation.py
@@ -1585,8 +1585,7 @@ def validate_content_list_token(token):
         elif prototype in (('content', ()), ('content', ('ident',))):
             if not args:
                 return (name, 'text')
-            elif args[0] in ('text', 'after', 'before'):
-                # TODO: first-letter should be allowed here too
+            elif args[0] in ('text', 'after', 'before', 'first-letter'):
                 return (name, args[0])
         elif prototype in (('counter', ('ident',)),
                            ('counters', ('ident', 'string'))):

--- a/weasyprint/document.py
+++ b/weasyprint/document.py
@@ -324,10 +324,11 @@ class Document(object):
             font_config, html, cascaded_styles, computed_styles)
         rendering = cls(
             [Page(p, enable_hinting) for p in page_boxes],
-            DocumentMetadata(**html._get_metadata()), html.url_fetcher)
+            DocumentMetadata(**html._get_metadata()),
+            html.url_fetcher, font_config)
         return rendering
 
-    def __init__(self, pages, metadata, url_fetcher):
+    def __init__(self, pages, metadata, url_fetcher, font_config):
         #: A list of :class:`Page` objects.
         self.pages = pages
         #: A :class:`DocumentMetadata` object.
@@ -337,6 +338,10 @@ class Document(object):
         #: A ``url_fetcher`` for resources that have to be read when writing
         #: the output.
         self.url_fetcher = url_fetcher
+        # Keep a reference to font_config to avoid its garbage collection until
+        # rendering is destroyed. This is needed as font_config.__del__ removes
+        # fonts that may be used when rendering
+        self._font_config = font_config
 
     def copy(self, pages='all'):
         """Take a subset of the pages.
@@ -371,7 +376,8 @@ class Document(object):
             pages = self.pages
         elif not isinstance(pages, list):
             pages = list(pages)
-        return type(self)(pages, self.metadata, self.url_fetcher)
+        return type(self)(
+            pages, self.metadata, self.url_fetcher, self._font_config)
 
     def resolve_links(self):
         """Resolve internal hyperlinks.

--- a/weasyprint/document.py
+++ b/weasyprint/document.py
@@ -242,7 +242,7 @@ class DocumentMetadata(object):
     """Contains meta-information about a :class:`Document`
     that belongs to the whole document rather than specific pages.
 
-   New attributes may be added in future versions of WeasyPrint.
+    New attributes may be added in future versions of WeasyPrint.
 
     .. _W3C’s profile of ISO 8601: http://www.w3.org/TR/NOTE-datetime
 

--- a/weasyprint/formatting_structure/boxes.py
+++ b/weasyprint/formatting_structure/boxes.py
@@ -95,6 +95,7 @@ class Box(object):
     def __init__(self, element_tag, style):
         self.element_tag = element_tag
         self.style = style
+        self._cached_margin_height = None
 
     def __repr__(self):
         return '<%s %s>' % (type(self).__name__, self.element_tag)
@@ -157,7 +158,11 @@ class Box(object):
 
     def margin_height(self):
         """Height of the margin box (aka. outer box)."""
-        return self.border_height() + self.margin_top + self.margin_bottom
+        if self._cached_margin_height is None:
+            self._cached_margin_height = \
+                self.border_height() + self.margin_top + self.margin_bottom
+
+        return self._cached_margin_height
 
     # Corners positions
 

--- a/weasyprint/formatting_structure/boxes.py
+++ b/weasyprint/formatting_structure/boxes.py
@@ -83,6 +83,7 @@ class Box(object):
     # Default, may be overriden on instances.
     is_table_wrapper = False
     is_for_root_element = False
+    is_column = False
     transformation_matrix = None
     bookmark_label = None
     string_set = None

--- a/weasyprint/formatting_structure/build.py
+++ b/weasyprint/formatting_structure/build.py
@@ -209,7 +209,7 @@ def before_after_to_box(element, pseudo_type, state, style_for,
 
 
 def content_to_boxes(style, parent_box, quote_depth, counter_values,
-                     get_image_from_uri, context=None):
+                     get_image_from_uri, context=None, page=None):
     """Takes the value of a ``content`` property and yield boxes."""
     texts = []
     for type_, value in style.content:
@@ -233,8 +233,8 @@ def content_to_boxes(style, parent_box, quote_depth, counter_values,
                 counters.format(counter_value, counter_style)
                 for counter_value in counter_values.get(counter_name, [0])
             ))
-        elif type_ == 'string' and context is not None:
-            text = context.get_string_set_for(*value)
+        elif type_ == 'string' and context is not None and page is not None:
+            text = context.get_string_set_for(page, *value)
             texts.append(text)
         else:
             assert type_ == 'QUOTE'

--- a/weasyprint/formatting_structure/build.py
+++ b/weasyprint/formatting_structure/build.py
@@ -17,6 +17,7 @@
 from __future__ import division, unicode_literals
 
 import re
+import unicodedata
 
 import tinycss2.color3
 
@@ -1160,8 +1161,20 @@ def box_text(box):
 
 
 def box_text_first_letter(box):
+    # TODO: use the same code as in inlines.first_letter_to_box
+    character_found = False
+    first_letter = ''
     text = box_text(box)
-    return text[0] if text else ''
+    while text:
+        next_letter = text[0]
+        category = unicodedata.category(next_letter)
+        if category not in ('Ps', 'Pe', 'Pi', 'Pf', 'Po'):
+            if character_found:
+                break
+            character_found = True
+        first_letter += next_letter
+        text = text[1:]
+    return first_letter
 
 
 def box_text_before(box):

--- a/weasyprint/formatting_structure/build.py
+++ b/weasyprint/formatting_structure/build.py
@@ -1159,6 +1159,11 @@ def box_text(box):
         return ''
 
 
+def box_text_first_letter(box):
+    text = box_text(box)
+    return text[0] if text else ''
+
+
 def box_text_before(box):
     if isinstance(box, boxes.ParentBox):
         return ''.join(
@@ -1182,4 +1187,5 @@ def box_text_after(box):
 TEXT_CONTENT_EXTRACTORS = {
     'text': box_text,
     'before': box_text_before,
-    'after': box_text_after}
+    'after': box_text_after,
+    'first-letter': box_text_first_letter}

--- a/weasyprint/layout/blocks.py
+++ b/weasyprint/layout/blocks.py
@@ -173,6 +173,7 @@ def columns_layout(context, box, max_position_y, skip_stack, containing_block,
         column_box = box.anonymous_from(box, children=[
             child.copy() for child in box.children])
         resolve_percentages(column_box, containing_block)
+        column_box.is_column = True
         column_box.width = width
         column_box.position_x = box.content_box_x()
         column_box.position_y = box.content_box_y()
@@ -347,7 +348,7 @@ def block_level_width(box, containing_block):
                 margin_r = box.margin_right = 0
     if width != 'auto' and margin_l != 'auto' and margin_r != 'auto':
         # The equation is over-constrained.
-        if containing_block.style.direction == 'rtl':
+        if containing_block.style['direction'] == 'rtl' and not box.is_column:
             box.position_x += (
                 cb_width - paddings_plus_borders - width - margin_r - margin_l)
         # Do nothing in ltr.

--- a/weasyprint/layout/blocks.py
+++ b/weasyprint/layout/blocks.py
@@ -241,7 +241,11 @@ def columns_layout(context, box, max_position_y, skip_stack, containing_block,
             if i == count - 1:
                 max_position_y = original_max_position_y
             column_box = create_column_box()
-            column_box.position_x += i * (width + style.column_gap)
+            if style['direction'] == 'rtl':
+                column_box.position_x += (
+                    box.width - (i + 1) * width - i * style['column_gap'])
+            else:
+                column_box.position_x += i * (width + style['column_gap'])
             new_child, skip_stack, next_page, _, _ = block_box_layout(
                 context, column_box, max_position_y, skip_stack,
                 containing_block, device_size, page_is_empty, absolute_boxes,

--- a/weasyprint/layout/blocks.py
+++ b/weasyprint/layout/blocks.py
@@ -784,6 +784,9 @@ def block_container_layout(context, box, max_position_y, skip_stack,
         min(new_box.height, new_box.max_height),
         new_box.min_height)
 
+    if next_page['page'] is None:
+        next_page['page'] = new_box.page_values()[1]
+
     return new_box, resume_at, next_page, adjoining_margins, collapsing_through
 
 

--- a/weasyprint/layout/float.py
+++ b/weasyprint/layout/float.py
@@ -118,8 +118,13 @@ def get_clearance(context, box, collapsed_margin=0):
     hypothetical_position = box.position_y + collapsed_margin
     # Hypothetical position is the position of the top border edge
     for excluded_shape in context.excluded_shapes:
+        y = excluded_shape.position_y
+        # Skip expensive attribute lookups if there's already
+        # no possibility of clearance.
+        if hypothetical_position >= y:
+            continue
+        h = excluded_shape.margin_height()
         if box.style['clear'] in (excluded_shape.style.float, 'both'):
-            y, h = excluded_shape.position_y, excluded_shape.margin_height()
             if hypothetical_position < y + h:
                 clearance = max(
                     (clearance or 0), y + h - hypothetical_position)

--- a/weasyprint/layout/float.py
+++ b/weasyprint/layout/float.py
@@ -124,7 +124,7 @@ def get_clearance(context, box, collapsed_margin=0):
         if hypothetical_position >= y:
             continue
         h = excluded_shape.margin_height()
-        if box.style['clear'] in (excluded_shape.style.float, 'both'):
+        if box.style['clear'] in (excluded_shape.style['float'], 'both'):
             if hypothetical_position < y + h:
                 clearance = max(
                     (clearance or 0), y + h - hypothetical_position)

--- a/weasyprint/layout/float.py
+++ b/weasyprint/layout/float.py
@@ -131,6 +131,20 @@ def get_clearance(context, box, collapsed_margin=0):
     return clearance
 
 
+def get_colliding_shapes(excluded_shapes, position_y, box_height):
+    colliding_shapes = []
+    for shape in excluded_shapes:
+        # Assign locals to avoid slow attribute lookups.
+        s_py = shape.position_y
+        s_mh = shape.margin_height()
+        if (s_py < position_y < s_py + s_mh) or \
+        (s_py < position_y + box_height < s_py + s_mh) or \
+        (s_py >= position_y and s_py + s_mh <= position_y + box_height):
+            colliding_shapes.append(shape)
+
+    return colliding_shapes
+
+
 def avoid_collisions(context, box, containing_block, outer=True):
     excluded_shapes = context.excluded_shapes
     position_y = box.position_y if outer else box.border_box_y()
@@ -142,16 +156,8 @@ def avoid_collisions(context, box, containing_block, outer=True):
         return 0, 0, containing_block.width
 
     while True:
-        colliding_shapes = [
-            shape for shape in excluded_shapes
-            if (shape.position_y < position_y <
-                shape.position_y + shape.margin_height()) or
-            (shape.position_y < position_y + box_height <
-                shape.position_y + shape.margin_height()) or
-            (shape.position_y >= position_y and
-                shape.position_y + shape.margin_height() <=
-                position_y + box_height)
-        ]
+        colliding_shapes = \
+            get_colliding_shapes(excluded_shapes, position_y, box_height)
         left_bounds = [
             shape.position_x + shape.margin_width()
             for shape in colliding_shapes

--- a/weasyprint/layout/inlines.py
+++ b/weasyprint/layout/inlines.py
@@ -116,7 +116,7 @@ def get_next_linebox(context, linebox, position_y, skip_stack,
         new_position_x, _, new_available_width = avoid_collisions(
             context, linebox, containing_block, outer=False)
         alignment_available_width = (
-            new_available_width + new_position_x - position_x)
+            new_available_width + new_position_x - linebox.position_x)
         offset_x = text_align(
             context, line, alignment_available_width,
             last=(resume_at is None or preserved_line_break))

--- a/weasyprint/layout/inlines.py
+++ b/weasyprint/layout/inlines.py
@@ -132,6 +132,10 @@ def get_next_linebox(context, linebox, position_y, skip_stack,
         line.margin_bottom = 0
 
         line.translate(offset_x, offset_y)
+        # Avoid floating point errors, as position_y - top + top != position_y
+        # Removing this line breaks the position == linebox.position test below
+        # See https://github.com/Kozea/WeasyPrint/issues/583
+        line.position_y = position_y
 
         if line.height <= candidate_height:
             break

--- a/weasyprint/layout/inlines.py
+++ b/weasyprint/layout/inlines.py
@@ -792,23 +792,6 @@ def split_inline_box(context, box, position_x, max_x, skip_stack,
                             # let's break it!
                             break_found = True
 
-                            # We have to check whether the child we're breaking
-                            # is the one broken by the initial skip stack.
-                            broken_child = bool(
-                                initial_skip_stack and
-                                initial_skip_stack[0] == child_index and
-                                initial_skip_stack[1])
-                            if broken_child:
-                                # This child is already broken by the original
-                                # skip stack, let's skip the already rendered
-                                # part before rendering the waiting child
-                                # again.
-                                current_skip, child_skip = (
-                                    initial_skip_stack[1])
-                            else:
-                                # This child has to be rendered from its start.
-                                child_skip = None
-
                             # We break the waiting child at its last possible
                             # breaking point.
                             # TODO: The dirty solution chosen here is to
@@ -819,7 +802,7 @@ def split_inline_box(context, box, position_x, max_x, skip_stack,
                             child_new_child, child_resume_at, _, _, _ = (
                                 split_inline_level(
                                     context, child, child.position_x, max_x,
-                                    child_skip, box, device_size,
+                                    None, box, device_size,
                                     absolute_boxes, fixed_boxes,
                                     line_placeholders, waiting_floats,
                                     line_children))
@@ -830,14 +813,37 @@ def split_inline_box(context, box, position_x, max_x, skip_stack,
                             else:
                                 children += [(child_index, child_new_child)]
 
+                            # We have to check whether the child we're breaking
+                            # is the one broken by the initial skip stack.
+                            broken_child = bool(
+                                initial_skip_stack and
+                                initial_skip_stack[0] == child_index and
+                                initial_skip_stack[1])
                             if broken_child:
                                 # As this child has already been broken
                                 # following the original skip stack, we have to
                                 # add the original skip stack to the partial
                                 # skip stack we get after the new rendering.
+
+                                # We have to do:
+                                # child_resume_at += initial_skip_stack[1]
+                                # but adding skip stacks is a bit complicated
+                                current_skip, grandchild_skip = (
+                                    initial_skip_stack[1])
+                                current_resume_at, grandchild_resume_at = (
+                                    child_resume_at)
+                                if grandchild_skip is None:
+                                    grandchild_resume_at = child_resume_at[1]
+                                elif grandchild_resume_at is None:
+                                    grandchild_resume_at = grandchild_skip
+                                else:
+                                    grandchild_resume_at = (
+                                        grandchild_skip[0] +
+                                        grandchild_resume_at[0],
+                                        None)
                                 child_resume_at = (
-                                    child_resume_at[0] + current_skip,
-                                    child_resume_at[1])
+                                    current_resume_at + current_skip,
+                                    grandchild_resume_at)
 
                             resume_at = (child_index, child_resume_at)
                             break

--- a/weasyprint/layout/inlines.py
+++ b/weasyprint/layout/inlines.py
@@ -788,14 +788,18 @@ def split_inline_box(context, box, position_x, max_x, skip_stack,
                         # TODO: what about relative children?
                         if (child.is_in_normal_flow() and
                                 can_break_inside(child)):
+                            broken_child = (
+                                not waiting_children_copy and
+                                initial_skip_stack and initial_skip_stack[1])
                             break_found = True
                             max_x = child.position_x + child.margin_width()
                             # TODO: replace -1, we use it to cut the last word
                             # of the line.
                             max_x -= 1
                             child_skip = None
-                            if initial_skip_stack and initial_skip_stack[1]:
-                                child_skip = initial_skip_stack[1][1]
+                            if broken_child:
+                                current_skip, child_skip = (
+                                    initial_skip_stack[1])
                             child_new_child, child_resume_at, _, _, _ = (
                                 split_inline_level(
                                     context, child, child.position_x, max_x,
@@ -809,6 +813,10 @@ def split_inline_box(context, box, position_x, max_x, skip_stack,
                                 assert isinstance(child, boxes.TextBox)
                             else:
                                 children += [(child_index, child_new_child)]
+                            if broken_child:
+                                child_resume_at = (
+                                    child_resume_at[0] + current_skip,
+                                    child_resume_at[1])
                             resume_at = (child_index, child_resume_at)
                             break
                     if break_found:

--- a/weasyprint/layout/pages.py
+++ b/weasyprint/layout/pages.py
@@ -310,7 +310,7 @@ def make_margin_boxes(context, page, counter_values):
             quote_depth = [0]
             box.children = build.content_to_boxes(
                 box.style, box, quote_depth, counter_values,
-                context.get_image_from_uri, context)
+                context.get_image_from_uri, context, page)
             # content_to_boxes() only produces inline-level boxes, no need to
             # run other post-processors from build.build_formatting_structure()
             box = build.inline_in_block(box)

--- a/weasyprint/layout/preferred.py
+++ b/weasyprint/layout/preferred.py
@@ -222,7 +222,8 @@ def inline_line_widths(context, box, outer, is_line_start, minimum,
 
         if isinstance(child, boxes.InlineBox):
             lines = inline_line_widths(
-                context, child, outer, is_line_start, minimum, skip_stack)
+                context, child, outer, is_line_start, minimum, skip_stack,
+                first_line)
             if first_line:
                 lines = [next(lines)]
             else:

--- a/weasyprint/layout/preferred.py
+++ b/weasyprint/layout/preferred.py
@@ -81,7 +81,7 @@ def max_content_width(context, box, outer=True):
         return inline_max_content_width(
             context, box, outer, is_line_start=True)
     elif isinstance(box, boxes.ReplacedBox):
-        return replaced_min_content_width(box, outer)
+        return replaced_max_content_width(box, outer)
     else:
         raise TypeError(
             'max-content width for %s not handled yet' % type(box).__name__)
@@ -618,6 +618,28 @@ def replaced_min_content_width(box, outer=True):
     elif box.style.width.unit == '%':
         # See https://drafts.csswg.org/css-sizing/#intrinsic-contribution
         width = 0
+    else:
+        assert width.unit == 'px'
+        width = width.value
+    return adjust(box, outer, width)
+
+
+def replaced_max_content_width(box, outer=True):
+    """Return the max-content width for an ``InlineReplacedBox``."""
+    width = box.style['width']
+    if width == 'auto':
+        height = box.style['height']
+        if height == 'auto' or height.unit == '%':
+            height = 'auto'
+        else:
+            assert height.unit == 'px'
+            height = height.value
+        image = box.replacement
+        iwidth, iheight = image.get_intrinsic_size(
+            box.style['image_resolution'], box.style['font_size'])
+        width, _ = default_image_sizing(
+            iwidth, iheight, image.intrinsic_ratio, 'auto', height,
+            default_width=300, default_height=150)
     else:
         assert width.unit == 'px'
         width = width.value

--- a/weasyprint/layout/preferred.py
+++ b/weasyprint/layout/preferred.py
@@ -640,6 +640,9 @@ def replaced_max_content_width(box, outer=True):
         width, _ = default_image_sizing(
             iwidth, iheight, image.intrinsic_ratio, 'auto', height,
             default_width=300, default_height=150)
+    elif box.style['width'].unit == '%':
+        # See https://drafts.csswg.org/css-sizing/#intrinsic-contribution
+        width = 0
     else:
         assert width.unit == 'px'
         width = width.value

--- a/weasyprint/layout/preferred.py
+++ b/weasyprint/layout/preferred.py
@@ -255,7 +255,8 @@ def inline_line_widths(context, box, outer, is_line_start, minimum,
                     _, _, new_resume_at, width, _, _ = (
                         text.split_first_line(
                             child_text[resume_at:], child.style, context,
-                            max_width, child.justification_spacing))
+                            max_width, child.justification_spacing,
+                            minimum=True))
                     lines.append(width)
                     if first_line:
                         break

--- a/weasyprint/layout/tables.py
+++ b/weasyprint/layout/tables.py
@@ -536,6 +536,10 @@ def auto_table_layout(context, box, containing_block):
     cb_width, _ = containing_block
     available_width = cb_width - margins - paddings
 
+    if table.style['border_collapse'] == 'collapse':
+        available_width -= (
+            table.border_left_width + table.border_right_width)
+
     if table.width == 'auto':
         if available_width <= table_min_content_width:
             table.width = table_min_content_width

--- a/weasyprint/pdf.py
+++ b/weasyprint/pdf.py
@@ -89,13 +89,15 @@ def _create_compressed_file_object(source):
 
     pdf_file_object = PdfDict(
         Type=PdfName('EmbeddedFile'), Filter=PdfName('FlateDecode'))
-    pdf_file_object.stream = b''
+
+    # pdfrw needs Latin-1-decoded unicode strings in object.stream
+    pdf_file_object.stream = ''
     size = 0
     for data in iter(lambda: source.read(4096), b''):
         size += len(data)
         md5.update(data)
-        pdf_file_object.stream += compress.compress(data)
-    pdf_file_object.stream += compress.flush(zlib.Z_FINISH)
+        pdf_file_object.stream += compress.compress(data).decode('latin-1')
+    pdf_file_object.stream += compress.flush(zlib.Z_FINISH).decode('latin-1')
     pdf_file_object.Params = PdfDict(
         CheckSum=PdfString('<{}>'.format(md5.hexdigest())), Size=size)
     return pdf_file_object

--- a/weasyprint/pdf.py
+++ b/weasyprint/pdf.py
@@ -89,15 +89,13 @@ def _create_compressed_file_object(source):
 
     pdf_file_object = PdfDict(
         Type=PdfName('EmbeddedFile'), Filter=PdfName('FlateDecode'))
-
-    # pdfrw needs Latin-1-decoded unicode strings in object.stream
-    pdf_file_object.stream = ''
+    pdf_file_object.stream = b''
     size = 0
     for data in iter(lambda: source.read(4096), b''):
         size += len(data)
         md5.update(data)
-        pdf_file_object.stream += compress.compress(data).decode('latin-1')
-    pdf_file_object.stream += compress.flush(zlib.Z_FINISH).decode('latin-1')
+        pdf_file_object.stream += compress.compress(data)
+    pdf_file_object.stream += compress.flush(zlib.Z_FINISH)
     pdf_file_object.Params = PdfDict(
         CheckSum=PdfString('<{}>'.format(md5.hexdigest())), Size=size)
     return pdf_file_object

--- a/weasyprint/tests/test_api.py
+++ b/weasyprint/tests/test_api.py
@@ -972,7 +972,7 @@ def test_html_meta():
             <meta name=dummy>
             <meta content=ignored>
             <meta>
-            <meta name=keywords content="html ,	css,
+            <meta name=keywords content="html ,\tcss,
                                          pdf,css">
             <meta name=dcterms.created content=2011-04>
             <meta name=dcterms.created content=2011-05>

--- a/weasyprint/tests/test_css.py
+++ b/weasyprint/tests/test_css.py
@@ -12,10 +12,11 @@
 
 from __future__ import division, unicode_literals
 
+import tinycss2
 from pytest import raises
 
 from .. import CSS, css, default_url_fetcher
-from ..css import PageType, get_all_computed_styles
+from ..css import PageType, get_all_computed_styles, parse_page_selectors
 from ..css.computed_values import strut_layout
 from ..layout.pages import set_page_type_computed_styles
 from ..urls import open_data_url, path2url
@@ -286,6 +287,71 @@ def test_page():
         PageType(side='right', first=True, blank=False, name=None),
         '@top-right')
     assert style.font_size == 10
+
+
+@assert_no_logs
+def test_page_selectors():
+    """Test the ``@page`` selectors parsing."""
+    at_rule, = tinycss2.parse_stylesheet('@page {}')
+    assert parse_page_selectors(at_rule) == [
+        {'side': None, 'blank': False, 'first': False, 'name': None,
+         'specificity': [0, 0, 0]}]
+
+    at_rule, = tinycss2.parse_stylesheet('@page :left {}')
+    assert parse_page_selectors(at_rule) == [
+        {'side': 'left', 'blank': False, 'first': False, 'name': None,
+         'specificity': [0, 0, 1]}]
+
+    at_rule, = tinycss2.parse_stylesheet('@page:first:left {}')
+    assert parse_page_selectors(at_rule) == [
+        {'side': 'left', 'blank': False, 'first': True, 'name': None,
+         'specificity': [0, 1, 1]}]
+
+    at_rule, = tinycss2.parse_stylesheet('@page pagename {}')
+    assert parse_page_selectors(at_rule) == [
+        {'side': None, 'blank': False, 'first': False, 'name': 'pagename',
+         'specificity': [1, 0, 0]}]
+
+    at_rule, = tinycss2.parse_stylesheet('@page pagename:first:right:blank {}')
+    assert parse_page_selectors(at_rule) == [
+        {'side': 'right', 'blank': True, 'first': True, 'name': 'pagename',
+         'specificity': [1, 2, 1]}]
+
+    at_rule, = tinycss2.parse_stylesheet('@page pagename, :first {}')
+    assert parse_page_selectors(at_rule) == [
+        {'side': None, 'blank': False, 'first': False, 'name': 'pagename',
+         'specificity': [1, 0, 0]},
+        {'side': None, 'blank': False, 'first': True, 'name': None,
+         'specificity': [0, 1, 0]}]
+
+    at_rule, = tinycss2.parse_stylesheet('@page page page {}')
+    assert parse_page_selectors(at_rule) is None
+
+    at_rule, = tinycss2.parse_stylesheet('@page :left page {}')
+    assert parse_page_selectors(at_rule) is None
+
+    at_rule, = tinycss2.parse_stylesheet('@page :left, {}')
+    assert parse_page_selectors(at_rule) is None
+
+    at_rule, = tinycss2.parse_stylesheet('@page , {}')
+    assert parse_page_selectors(at_rule) is None
+
+    at_rule, = tinycss2.parse_stylesheet('@page :left, test, {}')
+    assert parse_page_selectors(at_rule) is None
+
+    at_rule, = tinycss2.parse_stylesheet('@page :wrong {}')
+    assert parse_page_selectors(at_rule) is None
+
+    at_rule, = tinycss2.parse_stylesheet('@page :left:wrong {}')
+    assert parse_page_selectors(at_rule) is None
+
+    # TODO: The rules following this line should probably be correct and
+    # ignored, but they are currently rejected.
+    at_rule, = tinycss2.parse_stylesheet('@page :first:first {}')
+    assert parse_page_selectors(at_rule) is None
+
+    at_rule, = tinycss2.parse_stylesheet('@page :left:right {}')
+    assert parse_page_selectors(at_rule) is None
 
 
 @assert_no_logs

--- a/weasyprint/tests/test_layout.py
+++ b/weasyprint/tests/test_layout.py
@@ -709,7 +709,7 @@ def test_breaking_linebox():
             assert textbox_2.text == 'c def'
             assert textbox_3.text == 'g hi'
 
-    # Regression test for https://github.com/Kozea/WeasyPrint/issues/560
+    # Regression test #1 for https://github.com/Kozea/WeasyPrint/issues/560
     page, = parse(
         '<div style="width: 5.5em; font-family: ahem">'
         'aaaa aaaa a [<span>aaa</span>]')
@@ -723,6 +723,20 @@ def test_breaking_linebox():
     assert text1.text == '['
     assert text2.text == ']'
     assert span.children[0].text == 'aaa'
+
+    # Regression test #2 for https://github.com/Kozea/WeasyPrint/issues/560
+    page, = parse(
+        '<div style="width: 5.5em; font-family: ahem">'
+        'aaaa a <span>b c</span>d')
+    html, = page.children
+    body, = html.children
+    pre, = body.children
+    line1, line2, line3 = pre.children
+    assert line1.children[0].text == 'aaaa'
+    assert line2.children[0].text == 'a '
+    assert line2.children[1].children[0].text == 'b'
+    assert line3.children[0].children[0].text == 'c'
+    assert line3.children[1].text == 'd'
 
 
 @assert_no_logs

--- a/weasyprint/tests/test_layout.py
+++ b/weasyprint/tests/test_layout.py
@@ -715,8 +715,8 @@ def test_breaking_linebox():
         'aaaa aaaa a [<span>aaa</span>]')
     html, = page.children
     body, = html.children
-    pre, = body.children
-    line1, line2, line3, line4 = pre.children
+    div, = body.children
+    line1, line2, line3, line4 = div.children
     assert line1.children[0].text == line2.children[0].text == 'aaaa'
     assert line3.children[0].text == 'a'
     text1, span, text2 = line4.children
@@ -730,13 +730,27 @@ def test_breaking_linebox():
         'aaaa a <span>b c</span>d')
     html, = page.children
     body, = html.children
-    pre, = body.children
-    line1, line2, line3 = pre.children
+    div, = body.children
+    line1, line2, line3 = div.children
     assert line1.children[0].text == 'aaaa'
     assert line2.children[0].text == 'a '
     assert line2.children[1].children[0].text == 'b'
     assert line3.children[0].children[0].text == 'c'
     assert line3.children[1].text == 'd'
+
+    # Regression test #1 for https://github.com/Kozea/WeasyPrint/issues/580
+    page, = parse(
+        '<div style="width: 5.5em; font-family: ahem">'
+        '<span>aaaa aaaa a a a</span><span>bc</span>')
+    html, = page.children
+    body, = html.children
+    div, = body.children
+    line1, line2, line3, line4 = div.children
+    assert line1.children[0].children[0].text == 'aaaa'
+    assert line2.children[0].children[0].text == 'aaaa'
+    assert line3.children[0].children[0].text == 'a a'
+    assert line4.children[0].children[0].text == 'a'
+    assert line4.children[1].children[0].text == 'bc'
 
 
 @assert_no_logs

--- a/weasyprint/tests/test_layout.py
+++ b/weasyprint/tests/test_layout.py
@@ -738,7 +738,7 @@ def test_breaking_linebox():
     assert line3.children[0].children[0].text == 'c'
     assert line3.children[1].text == 'd'
 
-    # Regression test #1 for https://github.com/Kozea/WeasyPrint/issues/580
+    # Regression test for https://github.com/Kozea/WeasyPrint/issues/580
     page, = parse(
         '<div style="width: 5.5em; font-family: ahem">'
         '<span>aaaa aaaa a a a</span><span>bc</span>')
@@ -751,6 +751,17 @@ def test_breaking_linebox():
     assert line3.children[0].children[0].text == 'a a'
     assert line4.children[0].children[0].text == 'a'
     assert line4.children[1].children[0].text == 'bc'
+
+    # Regression test for https://github.com/Kozea/WeasyPrint/issues/586
+    page, = parse(
+        '<div style="width: 5.5em; font-family: ahem">'
+        'a a <span style="white-space: nowrap">/ccc</span>')
+    html, = page.children
+    body, = html.children
+    div, = body.children
+    line1, line2 = div.children
+    assert line1.children[0].text == 'a a'
+    assert line2.children[0].children[0].text == '/ccc'
 
 
 @assert_no_logs

--- a/weasyprint/tests/test_layout.py
+++ b/weasyprint/tests/test_layout.py
@@ -709,6 +709,21 @@ def test_breaking_linebox():
             assert textbox_2.text == 'c def'
             assert textbox_3.text == 'g hi'
 
+    # Regression test for https://github.com/Kozea/WeasyPrint/issues/560
+    page, = parse(
+        '<div style="width: 5.5em; font-family: ahem">'
+        'aaaa aaaa a [<span>aaa</span>]')
+    html, = page.children
+    body, = html.children
+    pre, = body.children
+    line1, line2, line3, line4 = pre.children
+    assert line1.children[0].text == line2.children[0].text == 'aaaa'
+    assert line3.children[0].text == 'a'
+    text1, span, text2 = line4.children
+    assert text1.text == '['
+    assert text2.text == ']'
+    assert span.children[0].text == 'aaa'
+
 
 @assert_no_logs
 def test_linebox_text():

--- a/weasyprint/tests/test_pdf.py
+++ b/weasyprint/tests/test_pdf.py
@@ -15,6 +15,7 @@ from __future__ import division, unicode_literals
 import hashlib
 import io
 import os
+import zlib
 
 import cairocffi
 import pytest
@@ -427,27 +428,39 @@ def test_embedded_files():
     pdf = PdfReader(fdata=pdf_bytes)
     embedded = pdf.Root.Names.EmbeddedFiles.Names
 
+    assert zlib.decompress(
+        embedded[1].EF.F.stream.encode('latin-1')) == b'hi there'
     assert embedded[1].EF.F.Params.CheckSum == (
         '<{}>'.format(hashlib.md5(b'hi there').hexdigest()))
     assert embedded[1].F.decode() == ''
     assert embedded[1].UF.decode() == 'attachment.bin'
     assert embedded[1].Desc.decode() == 'some file attachment äöü'
 
+    assert zlib.decompress(
+        embedded[3].EF.F.stream.encode('latin-1')) == b'12345678'
     assert embedded[3].EF.F.Params.CheckSum == (
         '<{}>'.format(hashlib.md5(adata).hexdigest()))
     assert embedded[3].UF.decode() == os.path.basename(absolute_tmp_file)
 
+    assert zlib.decompress(
+        embedded[5].EF.F.stream.encode('latin-1')) == b'abcdefgh'
     assert embedded[5].EF.F.Params.CheckSum == (
         '<{}>'.format(hashlib.md5(rdata).hexdigest()))
     assert embedded[5].UF.decode() == os.path.basename(relative_tmp_file)
 
+    assert zlib.decompress(
+        embedded[7].EF.F.stream.encode('latin-1')) == b'oob attachment'
     assert embedded[7].EF.F.Params.CheckSum == (
         '<{}>'.format(hashlib.md5(b'oob attachment').hexdigest()))
     assert embedded[7].Desc.decode() == 'Hello'
 
+    assert zlib.decompress(
+        embedded[9].EF.F.stream.encode('latin-1')) == b'raw URL'
     assert embedded[9].EF.F.Params.CheckSum == (
         '<{}>'.format(hashlib.md5(b'raw URL').hexdigest()))
 
+    assert zlib.decompress(
+        embedded[11].EF.F.stream.encode('latin-1')) == b'file like obj'
     assert embedded[11].EF.F.Params.CheckSum == (
         '<{}>'.format(hashlib.md5(b'file like obj').hexdigest()))
 

--- a/weasyprint/tests/test_pdf.py
+++ b/weasyprint/tests/test_pdf.py
@@ -15,7 +15,6 @@ from __future__ import division, unicode_literals
 import hashlib
 import io
 import os
-import zlib
 
 import cairocffi
 import pytest
@@ -428,39 +427,27 @@ def test_embedded_files():
     pdf = PdfReader(fdata=pdf_bytes)
     embedded = pdf.Root.Names.EmbeddedFiles.Names
 
-    assert zlib.decompress(
-        embedded[1].EF.F.stream.encode('latin-1')) == b'hi there'
     assert embedded[1].EF.F.Params.CheckSum == (
         '<{}>'.format(hashlib.md5(b'hi there').hexdigest()))
     assert embedded[1].F.decode() == ''
     assert embedded[1].UF.decode() == 'attachment.bin'
     assert embedded[1].Desc.decode() == 'some file attachment äöü'
 
-    assert zlib.decompress(
-        embedded[3].EF.F.stream.encode('latin-1')) == b'12345678'
     assert embedded[3].EF.F.Params.CheckSum == (
         '<{}>'.format(hashlib.md5(adata).hexdigest()))
     assert embedded[3].UF.decode() == os.path.basename(absolute_tmp_file)
 
-    assert zlib.decompress(
-        embedded[5].EF.F.stream.encode('latin-1')) == b'abcdefgh'
     assert embedded[5].EF.F.Params.CheckSum == (
         '<{}>'.format(hashlib.md5(rdata).hexdigest()))
     assert embedded[5].UF.decode() == os.path.basename(relative_tmp_file)
 
-    assert zlib.decompress(
-        embedded[7].EF.F.stream.encode('latin-1')) == b'oob attachment'
     assert embedded[7].EF.F.Params.CheckSum == (
         '<{}>'.format(hashlib.md5(b'oob attachment').hexdigest()))
     assert embedded[7].Desc.decode() == 'Hello'
 
-    assert zlib.decompress(
-        embedded[9].EF.F.stream.encode('latin-1')) == b'raw URL'
     assert embedded[9].EF.F.Params.CheckSum == (
         '<{}>'.format(hashlib.md5(b'raw URL').hexdigest()))
 
-    assert zlib.decompress(
-        embedded[11].EF.F.stream.encode('latin-1')) == b'file like obj'
     assert embedded[11].EF.F.Params.CheckSum == (
         '<{}>'.format(hashlib.md5(b'file like obj').hexdigest()))
 

--- a/weasyprint/tests/test_pdf.py
+++ b/weasyprint/tests/test_pdf.py
@@ -371,7 +371,7 @@ def test_document_info():
         <title>Test document</title>
         <h1>Another title</h1>
         <meta name=generator content="Human after all">
-        <meta name=keywords content="html ,	css,
+        <meta name=keywords content="html ,\tcss,
                                      pdf,css">
         <meta name=description content="Blah… ">
         <meta name=dcterms.created content=2011-04>

--- a/weasyprint/tests/test_presentational_hints.py
+++ b/weasyprint/tests/test_presentational_hints.py
@@ -15,7 +15,6 @@ from __future__ import division, unicode_literals
 from .. import CSS, HTML
 from .testing_utils import assert_no_logs
 
-
 PH_TESTING_CSS = CSS(string='''
 @page {margin: 0; size: 1000px 1000px}
 body {margin: 0}

--- a/weasyprint/tests/test_text.py
+++ b/weasyprint/tests/test_text.py
@@ -266,6 +266,43 @@ def test_text_align_justify():
     text, = line_1.children
     assert text.position_x == 0
 
+    # text-indent
+    page, = parse('''
+        <style>
+            @page { size: 300px 1000px }
+            body { text-align: justify }
+            p { text-indent: 3px }
+        </style>
+        <p><img src="pattern.png" style="width: 40px">
+            <strong>
+                <img src="pattern.png" style="width: 60px">
+                <img src="pattern.png" style="width: 10px">
+                <img src="pattern.png" style="width: 100px"
+            ></strong><img src="pattern.png" style="width: 290px"
+            ><!-- Last image will be on its own line. -->''')
+    html, = page.children
+    body, = html.children
+    paragraph, = body.children
+    line_1, line_2 = paragraph.children
+    image_1, space_1, strong = line_1.children
+    image_2, space_2, image_3, space_3, image_4 = strong.children
+    image_5, = line_2.children
+    assert space_1.text == ' '
+    assert space_2.text == ' '
+    assert space_3.text == ' '
+
+    assert image_1.position_x == 3
+    assert space_1.position_x == 43
+    assert strong.position_x == 72
+    assert image_2.position_x == 72
+    assert space_2.position_x == 132
+    assert image_3.position_x == 161
+    assert space_3.position_x == 171
+    assert image_4.position_x == 200
+    assert strong.width == 228
+
+    assert image_5.position_x == 0
+
 
 @assert_no_logs
 def test_word_spacing():

--- a/weasyprint/text.py
+++ b/weasyprint/text.py
@@ -915,7 +915,8 @@ def create_layout(text, style, context, max_width, justification_spacing):
     return layout
 
 
-def split_first_line(text, style, context, max_width, justification_spacing):
+def split_first_line(text, style, context, max_width, justification_spacing,
+                     minimum=False):
     """Fit as much as possible in the available width for one line of text.
 
     Return ``(layout, length, resume_at, width, height, baseline)``.
@@ -1127,7 +1128,7 @@ def split_first_line(text, style, context, max_width, justification_spacing):
     first_line_width, _ = get_size(first_line, style)
     space = max_width - first_line_width
     # If we can break words and the first line is too long
-    if overflow_wrap == 'break-word' and space < 0:
+    if not minimum and overflow_wrap == 'break-word' and space < 0:
         # Is it really OK to remove hyphenation for word-break ?
         hyphenated = False
         # TODO: Modify code to preserve W3C condition:

--- a/weasyprint/text.py
+++ b/weasyprint/text.py
@@ -24,7 +24,6 @@ from .logger import LOGGER
 
 # XXX No unicode_literals, cffi likes native strings
 
-
 if cairo.cairo_version() <= 11400:
     warnings.warn('There are known rendering problems with Cairo <= 1.14.0')
 

--- a/weasyprint/text.py
+++ b/weasyprint/text.py
@@ -1001,8 +1001,6 @@ def split_first_line(text, style, context, max_width, justification_spacing,
             if second_line is None and first_line_text:
                 # The next word fits in the first line, keep the layout
                 resume_at = len(new_first_line_text.encode('utf-8')) + 1
-                if resume_at == len(text.encode('utf-8')):
-                    resume_at = None
                 return first_line_metrics(
                     first_line, text, layout, resume_at, space_collapse, style)
             elif second_line:


### PR DESCRIPTION
I was profiling WeasyPrint and came across a few optimizations that were a 25% speed increase on my particular use case.

3210ea8 simply caches `Box.margin_height()` because it gets called thousands of times. This is the largest speedup though all three are respectable. Is this safe?

89e269a see if `hypothetical_position` is already greater than `shape.position_y` before performing attribute lookups.

71f7415 just assign locals instead of performing 9 different attribute lookups in the original list comprehension.

Thoughts?