### PR TITLE
Minor issues with build_sphinx

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -66,7 +66,7 @@ point to http://weasyprint.org/news/ in PDF files.
 PDF bookmarks are also called outlines and are generally shown in a
 sidebar. Clicking on an entry scrolls the matching part of the document
 into view. By default all ``<h1>`` to ``<h6>`` titles generate bookmarks,
-but this can be controlled with CSS (see :ref:`bookmarks`.)
+but this can be controlled with CSS (see :ref:`Bookmarks <bookmarks>`.)
 
 Attachments are related files, embedded in the PDF itself. They can be
 specified through ``<link rel=attachment>`` elements to add resources globally
@@ -299,6 +299,8 @@ defining "new properties and values, so that authors may bring new techniques
 (running headers and footers, footnotes, leaders, bookmarks) to paged media".
 
 Two features from this module have been implemented in WeasyPrint.
+
+.. _bookmarks:
 
 The first feature is `PDF bookmarks`_.  Using the experimental_
 ``bookmark-level`` and ``bookmark-level`` properties, you can add

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -90,6 +90,8 @@ WeasyPrint! Otherwise, please copy the full error message and
        JPEG, GIF and others are not available.
 
 
+.. _linux:
+
 Linux
 -----
 
@@ -147,6 +149,8 @@ install it with pip after installing the following packages:
     emerge pip setuptools wheel cairo pango gdk-pixbuf cffi
 
 
+.. _macos:
+
 macOS
 -----
 
@@ -168,6 +172,8 @@ end up crying blood with sad dolphins for eternity"**):
 
     sudo port install py-pip cairo pango gdk-pixbuf2 libffi
 
+
+.. _windows:
 
 Windows
 -------


### PR DESCRIPTION
After creating an editable environment with Sphinx and everything for WeasyPrint -- BTW: On Windows the `activate` command is located in `env/Scripts`, not in `env/bin`, will edit `hacking.rst` later  -- I tried to build the `docs` by issuing `python setup.py build_sphinx`. 

Got no htmls but *Theme error: sphinx_rtd_theme is no longer a hard dependency since version 1.4.0. Please install it manually.(pip install sphinx_rtd_theme)*.
Don't know how / in which config-or-what-file this can be fixed or whether it should be fixed at all...  problem solved by running `pip install`.

After that the expected htmls were created successfully, though with some WARNINGs. The 4 warnings about `:ref:`not finding its target are solved by 2ea0c6c.

