### PR TITLE
Fix link

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -81,7 +81,7 @@ WeasyPrint! Otherwise, please copy the full error message and
        you get incomplete SVG renderings, please read `#339
        <https://github.com/Kozea/WeasyPrint/issues/339>`_. If you get invalid
        PDF files, please read `#565
-       <https://github.com/Kozea/WeasyPrint/issues/565>`.
+       <https://github.com/Kozea/WeasyPrint/issues/565>`_.
 
 .. [#] pango ≥ 1.29.3 is required, but 1.38.0 is needed to handle `@font-face`
        CSS rules.


### PR DESCRIPTION
Besides this little link I'd like to improve the installation instructions for Windows (as desired e.g. by [@liZe](https://github.com/Kozea/WeasyPrint/issues/589#issuecomment-373124636) but not sure how to do that.

The instructions for Win64 are, maybe a bit meager, but almost correct:
Install Python3, install Tom Schoonjans' GTK3 Runtime, install the appropriate MSVC,
install Weasyprint.
No need to reboot, but before `pip install WeasyPrint` do a `pip install --update setuptools`.

Problem is **Win32**.  No problem with Python, no problem with MSVC.
But. There isn't an up-to-date, ready-to-use GTK+ anymore. I know, WeasyPrint doesnt need GTK+ but it requires Pango, Cairo and GDK-PixBuf and GTK+ contains all the required stuff.

Spent a few hours to find out a smart way. But there isn't.

Pango instructs us to download its Windows binaries from a 404 gtk.org page, [gtk.org tells us ](https://www.gtk.org/download/windows.php) that GTK+ for Windows isn't meant for end-users anymore instead developers should use MSYS2 and deploy the libraries with their application. Fine.

So Win32 user have three choices:

1. Wait until someone creates and maintains a GTK+Project for Win32
2. Install msys2, install and maintain therein the `mingw-w64-i686-pango` and the `mingw-w64-i686-gdk-pixbuf2` packages and insert the MSYS2-mingw32-bin-Path into their PATH
3. Install GIMP (or Inkscape or another Win32 application that uses a current GTK+), keep it up-to-date and insert the appropriate folder into their PATH -- in GIMP it's the ./bin subfolder

That's how it is. Shall I try to re-write the WeasyPrint installation instructions accordingly? Which recipe is preferable? Msys2 is a good thing when you plan to become a developer, but otherwise a slight overkill...

BTW: Both, the msys2 and the GIMP solution work for Win64, too.
