### PR TITLE
Prevent RuntimeError

### DIFF
--- a/weasyprint/fonts.py
+++ b/weasyprint/fonts.py
@@ -267,6 +267,13 @@ else:
                         result = ffi.new('FcResult *')
                         matching_pattern = fontconfig.FcFontMatch(
                             config, pattern, result)
+                        # prevent RuntimeError, see issue #677
+                        if matching_pattern == ffi.NULL:
+                            LOGGER.warning(
+                                'Failed to get matching local font for "%s"',
+                                font_name.decode('utf-8'))
+                            continue
+
                         # TODO: do many fonts have multiple family values?
                         fontconfig.FcPatternGetString(
                             matching_pattern, b'fullname', 0, family)


### PR DESCRIPTION
Resolves #677

Considering @mes3yd's circumstances I think `fonts._check_font_configuration()` should check fontconfig's  local fonts and give warnings on all OSses, not only on Windows.