### PR TITLE
Added section to tutorial on adjusting `@page` attributes

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -28,6 +28,28 @@ If you have many documents to convert you may prefer using the Python API
 in long-lived processes to avoid paying the start-up costs every time.
 
 
+Adjusting Document Dimensions
+.............................
+
+Currently, WeasyPrint does not provide support for adjusting page size
+or document margins via command-line flags. This is best accomplished
+with the CSS ``@page`` at-rule. Consider the following example:
+
+.. code-block:: css
+  
+  @page {
+    size: Letter; /* Change from the default size of A4 */
+    margin-left: 2.5cm; /* Set margin on each page */
+  }
+
+There is much more which can be achieved with the ``@page`` at-rule, 
+such as page numbers, headers, etc. Read more about the page_ at-rule,
+and find an example here_.
+
+.. _page: https://developer.mozilla.org/en-US/docs/Web/CSS/@page
+.. _here: https://weasyprint.org
+
+
 As a Python library
 -------------------
 .. currentmodule:: weasyprint

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -39,7 +39,7 @@ with the CSS ``@page`` at-rule. Consider the following example:
   
   @page {
     size: Letter; /* Change from the default size of A4 */
-    margin-left: 2.5cm; /* Set margin on each page */
+    margin: 2.5cm; /* Set margin on each page */
   }
 
 There is much more which can be achieved with the ``@page`` at-rule, 


### PR DESCRIPTION
This adds a section to the tutorial page in the docs which explains:

- There are no command line flags to set page size/margin
- How to do this in CSS
- Links to the MDN page on the `@page` at-rule
- Links to weasyprint.org main page, which demonstrates adding page numbers and headers to the output file

This may be controversial because it is considered outside the scope of the documentation (as it is a CSS feature), however as an end user (especially one who has little experience with writing print-friendly HTML), I believe that at demonstrating at least those two options is incredibly useful. 

Further, an example using the `@page` rule _is_ on the main page, however it does not show how to change page size, which I believe to be important because the default size of A4 is not as common in North America.

This question is what prompted this addition to the docs:
https://stackoverflow.com/questions/29831775/weasyprint-page-size-wrong-8-27in-x-11-69-in

Postscript:
This should have been one commit not two - I did not initially realize that the docs/_build directory is omitted from the repository