### PR TITLE
Ship LICENSE in sdist/bist, document minimum setuptools version

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE
+include AUTHORS

--- a/README.rst
+++ b/README.rst
@@ -17,3 +17,5 @@ pagination, and meant to be easy to hack on.
 * Source code and issue tracker: https://github.com/Kozea/WeasyPrint
 * Tests: https://travis-ci.org/Kozea/WeasyPrint
 * Support: https://www.patreon.com/kozea
+
+Minimum setuptools version required is 39.2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ classifiers =
 [options]
 packages = find:
 zip_safe = false
+include_package_data=True
 setup_requires = pytest-runner
 install_requires =
   cffi>=0.6


### PR DESCRIPTION
Since the code says:
    :copyright: Copyright 2011-2018 Simon Sapin and contributors, see AUTHORS.
    :license: BSD, see LICENSE for details.
It is more complete/clearer if the referenced files are included in the dists.  This is particularly true for the BSD license, since there are many variants of the BSD license.

Additionally, it took me awhile to figure out what version of setuptools I needed.  I was finally able to figure it out from the meta data section of https://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files.  I think it would be helpful to document the version requirements for people that can't just upgrade to the latest.