### PR TITLE
gdk-pixbuf Error on Alpine 3.8

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -159,7 +159,7 @@ For Alpine Linux 3.6 or newer:
 
 .. code-block:: sh
 
-    apk --update --upgrade add gcc musl-dev jpeg-dev zlib-dev libffi-dev cairo-dev pango-dev gdk-pixbuf
+    apk --update --upgrade add gcc musl-dev jpeg-dev zlib-dev libffi-dev cairo-dev pango-dev gdk-pixbuf-dev
 
 
 .. _macos:


### PR DESCRIPTION
Hi,

Got some problems with gdk-pixbuf on Alpine 3.8.
@elyak123's command at #699 seems ok at beggining but after some builds (without images), i finally got some error on JPEG images, like : 
```bash
ERROR: Failed to load image at "file:///builds/1.jpg" (Could not load GDK-Pixbuf. PNG and SVG are the only image formats available.)
ERROR: Failed to load image at "file:///builds/2.jpg" (Could not load GDK-Pixbuf. PNG and SVG are the only image formats available.)
[...]
```

I try some extra packages without success. Eventually, looks like add the devel version of gdk-pixbuf fix the problem.

Unfortunatly i didn't try on other Alpine version but since `gdk-pixbuf-dev` include `gdk-pixbuf` it does not seem too risky.