### PR TITLE
note on alpine installation and ctypes.util

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -162,6 +162,21 @@ For Alpine Linux 3.6 or newer:
     apk --update --upgrade add gcc musl-dev jpeg-dev zlib-dev libffi-dev cairo-dev pango-dev gdk-pixbuf-dev
 
 
+.. note::
+
+    Some Alpine images do not resolv the library path via ctypes.utils.find_library. So if you get 
+    `OSError: dlopen() failed to load a library: cairo / cairo-2 / cairo-gobject-2`
+    then change find_library and open the library directly:
+    /usr/local/lib/python3.7/site-packages/cairocffi/__init__.py
+    ```
+    try:        
+        lib = ffi.dlopen(name)                                    
+        if lib:
+    ....
+    cairo = dlopen(ffi, 'libcairo.so.2')                                      
+    ```
+    
+    
 .. _macos:
 
 macOS


### PR DESCRIPTION
fix for broken ldconfig / ctypes.util.find_library as mentioned in:

https://github.com/docker-library/python/issues/111#issuecomment-437625964
https://github.com/Kozea/WeasyPrint/issues/699#issuecomment-455180488