### PR TITLE
Add LICENSE to sdist

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -87,7 +87,8 @@ WeasyPrint! Otherwise, please copy the full error message and
        CSS rules.
 
 .. [#] setuptools ≥ 30.3.0 is required to install WeasyPrint, but 39.2.0 is
-       required to build the package.
+       required to build the package. setuptools << 40.8.0 will not include
+       the LICENSE file.
 
 .. [#] Without it, PNG and SVG are the only supported image formats.
        JPEG, GIF and others are not available.

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,7 @@ name = WeasyPrint
 url = https://weasyprint.org/
 version = file: weasyprint/VERSION
 license = BSD
+license_file = LICENSE
 description = The Gorgeous Document Factory
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
It turned out it wasn't possible to add the LICENSE using setup.cfg, but it is now.  This PR implements what we discussed a few months ago (now that it's possible).  This is safe even though it uses a new feature because older setuptools will just not install the file.  I didn't get any errors when I tested it.