### PR TITLE
Windows requires path2url in test_assert_bookmarks

### DIFF
--- a/weasyprint/tests/test_api.py
+++ b/weasyprint/tests/test_api.py
@@ -628,8 +628,8 @@ def test_low_level_api():
         <style>
           img { display: block; bookmark-label: attr(alt); bookmark-level: 1 }
         </style>
-        <img src="file://%s" alt="Chocolate" />
-    ''' % resource_filename('pattern.png'),
+        <img src="%s" alt="Chocolate" />
+    ''' % path2url(resource_filename('pattern.png')),
      [[(1, 'Chocolate', (0, 0))]], [('Chocolate', (0, 0, 0), [])], False),
     ('''
         <h1 style="transform-origin: 0 0;


### PR DESCRIPTION
Without the patch pytest fails on Windows with file-not-found-error in the 6th snippet of test_api.test_assert_bookmarks().

Which is reasonable because indeed an image source of `file://C:%5CPath%5CTo%5Cweasyprint%5Ctests%5Cresources%5Cpattern.png` doesnt exist.
