### PR TITLE
Prevent endless loop and index out of range in pagination

### DIFF
--- a/weasyprint/layout/pages.py
+++ b/weasyprint/layout/pages.py
@@ -765,14 +765,15 @@ def remake_page(index, context, root_box, html, cascaded_styles,
             'anchors': [],
             'content_lookups': [],
         }
+        # Setting content_changed to True ensures remake.
+        # If resume_at is None (last page) it must be False to prevent endless
+        # loops and list index out of range (see #794).
+        remake_state['content_changed'] = resume_at is not None
         # page_state is already a deepcopy
         item = resume_at, next_page, right_page, page_state, remake_state
         if index + 1 >= len(page_maker):
-            # content_changed must be False otherwise: enldess loop
             page_maker.append(item)
         else:
-            # content_changed must be True otherwise: no remake
-            remake_state['content_changed'] = True
             page_maker[index + 1] = item
 
     return page, resume_at


### PR DESCRIPTION
Ensures re-pagination while avoiding endless loops and 'list index out of range'.
Should fix #794 

The endless loop can (could) easily be triggered.

The aforesaid 'list index out of range' error happens when resolving page based counters **decreases** the number of pages.
Though I tried hard I was unable to create an HTML/CSS that per se produced the error, had to tweak the source code to artificailly enforce re-pagination with decreasing pages, hence I'm highly interested to see @guateandrew's real-world document, or at least the CSS?
