### PR TITLE
refs Kozea#412 Avoid default Logger

### DIFF
--- a/weasyprint/logger.py
+++ b/weasyprint/logger.py
@@ -23,7 +23,8 @@
 import logging
 
 LOGGER = logging.getLogger('weasyprint')
-LOGGER.setLevel(logging.WARNING)
-LOGGER.addHandler(logging.NullHandler())
+if not LOGGER.handlers:
+    LOGGER.setLevel(logging.WARNING)
+    LOGGER.addHandler(logging.NullHandler())
 
 PROGRESS_LOGGER = logging.getLogger('weasyprint.progress')


### PR DESCRIPTION
If you want to use Weasyprint under django, you can configure
weasyprint's logger via django, but this setting never is set