### PR TITLE
Addition of standard print media sizes

### DIFF
--- a/weasyprint/css/computed_values.py
+++ b/weasyprint/css/computed_values.py
@@ -112,6 +112,34 @@ PAGE_SIZES = dict(
         Dimension(11, 'in'),
         Dimension(17, 'in'),
     ),
+    paperback_massmarket=(
+        Dimension(4.25, 'in'),
+        Dimension(6.87, 'in'),
+    ),
+    paperback_novella=(
+        Dimension(5, 'in'),
+        Dimension(8, 'in'),
+    ),
+    paperback_digest=(
+        Dimension(5.5, 'in'),
+        Dimension(8.5, 'in'),
+    ),
+    paperback_us_trade=(
+        Dimension(6, 'in'),
+        Dimension(9, 'in'),
+    ),
+    textbook_small=(
+        Dimension(6, 'in'),
+        Dimension(9, 'in'),
+    ),
+    textbook_medium=(
+        Dimension(7, 'in'),
+        Dimension(10, 'in'),
+    ),
+    textbook_fullsize=(
+        Dimension(8.5, 'in'),
+        Dimension(11, 'in'),
+    )   
 )
 # In "portrait" orientation.
 for w, h in PAGE_SIZES.values():

--- a/weasyprint/css/computed_values.py
+++ b/weasyprint/css/computed_values.py
@@ -139,7 +139,7 @@ PAGE_SIZES = dict(
     textbook_fullsize=(
         Dimension(8.5, 'in'),
         Dimension(11, 'in'),
-    )   
+    ),
 )
 # In "portrait" orientation.
 for w, h in PAGE_SIZES.values():


### PR DESCRIPTION
css/computed_valued.py: Added dimensions for output to defined common book sizes (mass market paperback/novella/digest/us_tradeback, textbook small/medium/fullsize).