### PR TITLE
allow ability to ignore ssl verification within default_url_fetcher

### DIFF
--- a/weasyprint/urls.py
+++ b/weasyprint/urls.py
@@ -202,7 +202,7 @@ HTTP_HEADERS = {
 }
 
 
-def default_url_fetcher(url, timeout=10, verify=True):
+def default_url_fetcher(url, timeout=10, ssl_context=None):
     """Fetch an external resource such as an image or stylesheet.
 
     Another callable with the same signature can be given as the
@@ -241,14 +241,8 @@ def default_url_fetcher(url, timeout=10, verify=True):
             url = url.split('?')[0]
 
         url = iri_to_uri(url)
-        if verify:
-            ctx = ssl.create_default_context()
-            ctx.check_hostname = False
-            response = urlopen(Request(url, headers=HTTP_HEADERS),
-                               timeout=timeout, context=ctx)
-        else:
-            response = urlopen(Request(url, headers=HTTP_HEADERS),
-                               timeout=timeout)
+        response = urlopen(Request(url, headers=HTTP_HEADERS), 
+                           timeout=timeout, context=ssl_context)
         response_info = response.info()
         result = dict(redirected_url=response.geturl(),
                       mime_type=response_info.get_content_type(),

--- a/weasyprint/urls.py
+++ b/weasyprint/urls.py
@@ -16,10 +16,10 @@ import gzip
 import io
 import os.path
 import re
+import ssl
 import sys
 import traceback
 import zlib
-import ssl
 from base64 import decodebytes
 from gzip import GzipFile
 from urllib.parse import quote, unquote, urljoin, urlsplit

--- a/weasyprint/urls.py
+++ b/weasyprint/urls.py
@@ -16,7 +16,6 @@ import gzip
 import io
 import os.path
 import re
-import ssl
 import sys
 import traceback
 import zlib
@@ -241,7 +240,7 @@ def default_url_fetcher(url, timeout=10, ssl_context=None):
             url = url.split('?')[0]
 
         url = iri_to_uri(url)
-        response = urlopen(Request(url, headers=HTTP_HEADERS), 
+        response = urlopen(Request(url, headers=HTTP_HEADERS),
                            timeout=timeout, context=ssl_context)
         response_info = response.info()
         result = dict(redirected_url=response.geturl(),

--- a/weasyprint/urls.py
+++ b/weasyprint/urls.py
@@ -19,6 +19,7 @@ import re
 import sys
 import traceback
 import zlib
+import ssl
 from base64 import decodebytes
 from gzip import GzipFile
 from urllib.parse import quote, unquote, urljoin, urlsplit
@@ -201,7 +202,7 @@ HTTP_HEADERS = {
 }
 
 
-def default_url_fetcher(url, timeout=10):
+def default_url_fetcher(url, timeout=10, verify=True):
     """Fetch an external resource such as an image or stylesheet.
 
     Another callable with the same signature can be given as the
@@ -240,7 +241,12 @@ def default_url_fetcher(url, timeout=10):
             url = url.split('?')[0]
 
         url = iri_to_uri(url)
-        response = urlopen(Request(url, headers=HTTP_HEADERS), timeout=timeout)
+        if verify:
+            ctx = ssl.create_default_context()
+            ctx.check_hostname = False
+            response = urlopen(Request(url, headers=HTTP_HEADERS), timeout=timeout, context=ctx)
+        else:
+            response = urlopen(Request(url, headers=HTTP_HEADERS), timeout=timeout)
         response_info = response.info()
         result = dict(redirected_url=response.geturl(),
                       mime_type=response_info.get_content_type(),

--- a/weasyprint/urls.py
+++ b/weasyprint/urls.py
@@ -244,9 +244,11 @@ def default_url_fetcher(url, timeout=10, verify=True):
         if verify:
             ctx = ssl.create_default_context()
             ctx.check_hostname = False
-            response = urlopen(Request(url, headers=HTTP_HEADERS), timeout=timeout, context=ctx)
+            response = urlopen(Request(url, headers=HTTP_HEADERS),
+                               timeout=timeout, context=ctx)
         else:
-            response = urlopen(Request(url, headers=HTTP_HEADERS), timeout=timeout)
+            response = urlopen(Request(url, headers=HTTP_HEADERS),
+                               timeout=timeout)
         response_info = response.info()
         result = dict(redirected_url=response.geturl(),
                       mime_type=response_info.get_content_type(),


### PR DESCRIPTION
This fix is very helpful if i want to have images in html that are coming from un-trusted host.
This is applicable when i have a load balancer for all test servers and their global CA is not signed.