### PR TITLE
tables: add -weasy-break-inside-threshold proprietary extension

### DIFF
--- a/weasyprint/css/properties.py
+++ b/weasyprint/css/properties.py
@@ -203,6 +203,7 @@ INITIAL_VALUES = {
     'anchor': None,  # computed value of 'none'
     'link': None,  # computed value of 'none'
     'lang': None,  # computed value of 'none'
+    'break_inside_threshold': float('inf'),
 
     # Internal, to implement the "static position" for absolute boxes.
     '_weasy_specified_display': 'inline',

--- a/weasyprint/css/validation/properties.py
+++ b/weasyprint/css/validation/properties.py
@@ -16,10 +16,10 @@ from ...formatting_structure import counters
 from .. import computed_values
 from ..properties import KNOWN_PROPERTIES, Dimension
 from ..utils import (
-    InvalidValues, check_var_function, comma_separated_list, get_angle,
-    get_content_list, get_content_list_token, get_custom_ident, get_image,
-    get_keyword, get_length, get_resolution, get_single_keyword, get_url,
-    parse_2d_position, parse_function, parse_position, single_keyword,
+    LENGTHS_TO_PIXELS, InvalidValues, check_var_function, comma_separated_list,
+    get_angle, get_content_list, get_content_list_token, get_custom_ident,
+    get_image, get_keyword, get_length, get_resolution, get_single_keyword,
+    get_url, parse_2d_position, parse_function, parse_position, single_keyword,
     single_token)
 
 PREFIX = '-weasy-'
@@ -317,6 +317,15 @@ def break_before_after(keyword):
 def break_inside(keyword):
     """``break-inside`` property validation."""
     return keyword in ('auto', 'avoid', 'avoid-page', 'avoid-column')
+
+
+@property(proprietary=True)
+@single_token
+def break_inside_threshold(token):
+    """``break-inside-threshold`` property validation."""
+    length = get_length(token, negative=False, percentage=False)
+    if length:
+        return length.value * LENGTHS_TO_PIXELS[length.unit]
 
 
 @property()

--- a/weasyprint/layout/tables.py
+++ b/weasyprint/layout/tables.py
@@ -217,7 +217,10 @@ def table_layout(context, table, max_position_y, skip_stack,
 
         # Do not keep the row group if we made a page break
         # before any of its rows or with 'avoid'
+        # or when it exceeds a proprietary threshold in height
         if resume_at and not original_page_is_empty and (
+                (position_y - group.position_y) <
+                group.style['break_inside_threshold']) and (
                 group.style['break_inside'] in ('avoid', 'avoid-page') or
                 not new_group_children):
             return None, None


### PR DESCRIPTION
break-inside: avoid-page is an all of nothing affair, when applied
on large table row group the result may be less than stellar with
regard to large amounts of useless semi-unintentional white space.

this patch introduces a threshold where the largest size of a
table row group is defined that is to honour the break-inside.
attribute.

usage example:

tbody
{
  break-inside: avoid-page;
  -weasy-break-inside-threshold: 100mm;
}