### PR TITLE
fix erroneous document title

### DIFF
--- a/weasyprint/html.py
+++ b/weasyprint/html.py
@@ -307,11 +307,11 @@ def get_html_metadata(wrapper_element, base_url):
         elif element.tag == 'link' and element_has_link_type(
                 element, 'attachment'):
             url = get_url_attribute(element, 'href', base_url)
-            title = element.get('title', None)
+            atitle = element.get('title', None)
             if url is None:
                 LOGGER.error('Missing href in <link rel="attachment">')
             else:
-                attachments.append((url, title))
+                attachments.append((url, atitle))
     return dict(title=title, description=description, generator=generator,
                 keywords=keywords, authors=authors,
                 created=created, modified=modified,


### PR DESCRIPTION
consider the following document

```html
<html>
<head>
  <title>Document Title</title>
  <link rel="attachment" href="attached.txt" title="title of the attachment">
</head>
<body>
<p>Lorem ipsum etc</p>
</body>
</html>
```

You probably dont wanna see "title of the attachment" as the document title in the PDF's metadata.
