### PR TITLE
feature to help book designers debug their line grid

### DIFF
--- a/weasyprint/__init__.py
+++ b/weasyprint/__init__.py
@@ -135,7 +135,7 @@ class HTML(object):
         return get_html_metadata(self.wrapper_element, self.base_url)
 
     def render(self, stylesheets=None, enable_hinting=False,
-               presentational_hints=False, font_config=None):
+               presentational_hints=False, font_config=None, grid_debug=None):
         """Lay out and paginate the document, but do not (yet) export it
         to PDF or PNG.
 
@@ -165,11 +165,11 @@ class HTML(object):
         """
         return Document._render(
             self, stylesheets, enable_hinting, presentational_hints,
-            font_config)
+            font_config, grid_debug)
 
     def write_pdf(self, target=None, stylesheets=None, zoom=1,
                   attachments=None, presentational_hints=False,
-                  font_config=None):
+                  font_config=None, grid_debug=None):
         """Render the document to a PDF file.
 
         This is a shortcut for calling :meth:`render`, then
@@ -208,7 +208,8 @@ class HTML(object):
         return self.render(
             stylesheets, enable_hinting=False,
             presentational_hints=presentational_hints,
-            font_config=font_config).write_pdf(
+            font_config=font_config,
+            grid_debug=grid_debug).write_pdf(
                 target, zoom, attachments)
 
     def write_image_surface(self, stylesheets=None, resolution=96,
@@ -250,7 +251,8 @@ class HTML(object):
         return surface
 
     def write_png(self, target=None, stylesheets=None, resolution=96,
-                  presentational_hints=False, font_config=None):
+                  presentational_hints=False, font_config=None,
+                  grid_debug=None):
         """Paint the pages vertically to a single PNG image.
 
         There is no decoration around pages other than those specified in CSS
@@ -287,7 +289,8 @@ class HTML(object):
         png_bytes, _width, _height = (
             self.render(stylesheets, enable_hinting=True,
                         presentational_hints=presentational_hints,
-                        font_config=font_config)
+                        font_config=font_config,
+                        grid_debug=grid_debug)
             .write_png(target, resolution))
         return png_bytes
 

--- a/weasyprint/__main__.py
+++ b/weasyprint/__main__.py
@@ -179,7 +179,7 @@ def main(argv=None, stdout=None, stdin=None):
     if args.attachment:
         if format_ == 'pdf':
             kwargs['attachments'] = args.attachment
-        else:            
+        else:
             parser.error('--attachment only applies for the PDF format.')
 
     if args.grid_debug:

--- a/weasyprint/__main__.py
+++ b/weasyprint/__main__.py
@@ -58,6 +58,10 @@ def main(argv=None, stdout=None, stdin=None):
         Set the base for relative URLs in the HTML input.
         Defaults to the input’s own URL, or the current directory for stdin.
 
+    .. option:: --grid-debug <file>
+
+        Filename for writing output useful when debugging a document's grid.
+
     .. option:: -a <file>, --attachment <file>
 
         Adds an attachment to the document.  The attachment is
@@ -112,6 +116,9 @@ def main(argv=None, stdout=None, stdin=None):
     parser.add_argument('-a', '--attachment', action='append',
                         help='URL or filename of a file '
                              'to attach to the PDF document')
+    parser.add_argument('--grid-debug',
+                        help="Filename for writing output useful when "
+                             "debugging a document's grid.")
     parser.add_argument('-p', '--presentational-hints', action='store_true',
                         help='Follow HTML presentational hints.')
     parser.add_argument('-v', '--verbose', action='store_true',
@@ -172,8 +179,11 @@ def main(argv=None, stdout=None, stdin=None):
     if args.attachment:
         if format_ == 'pdf':
             kwargs['attachments'] = args.attachment
-        else:
+        else:            
             parser.error('--attachment only applies for the PDF format.')
+
+    if args.grid_debug:
+        kwargs['grid_debug'] = args.grid_debug        
 
     # Default to logging to stderr.
     if args.debug:

--- a/weasyprint/document.py
+++ b/weasyprint/document.py
@@ -17,6 +17,8 @@ import warnings
 import cairocffi as cairo
 from weasyprint.layout import LayoutContext
 
+from pprint import pprint
+
 from . import CSS
 from .css import get_all_computed_styles
 from .css.targets import TargetCollector
@@ -375,8 +377,46 @@ class Document(object):
         return context
 
     @classmethod
+    def _write_grid_debug_output(cls, page_boxes, grid_debug):
+        
+        def extract_lines(children):
+            for child in children:
+                if isinstance(child, boxes.LineBox):
+                    yield child;
+                if hasattr(child, "children"):
+                    for line in extract_lines( child.children ):
+                        yield line;
+        
+        def extract_text( children ):
+            accumulated_text = "";
+            for child in children:
+                if hasattr(child, "pango_layout"):
+                    if hasattr( child.pango_layout, "text" ):
+                        accumulated_text += child.pango_layout.text + " ";
+                if hasattr( child, "children" ):
+                    for text in extract_text( child.children ):
+                        accumulated_text += text + " ";
+            return accumulated_text;
+
+        with open( grid_debug, "wt", encoding="utf-8" ) as f:
+
+            for ( pageno, page ) in enumerate( page_boxes ):
+                for ( lineno, line ) in enumerate( extract_lines( page.children ) ):
+                    text = extract_text( line.children );
+                    print(
+                        "{:3d}|{:3d}|{:3.3f}|{:3.3f}|{:s}"\
+                           .format(
+                                pageno,
+                                lineno,
+                                line.position_y,
+                                line.height,
+                                text ),
+                        file=f );
+
+    @classmethod
     def _render(cls, html, stylesheets, enable_hinting,
-                presentational_hints=False, font_config=None):
+                presentational_hints=False, font_config=None,
+                grid_debug=None):
         if font_config is None:
             font_config = FontConfiguration()
 
@@ -389,6 +429,10 @@ class Document(object):
             html.base_url, context.target_collector)
 
         page_boxes = layout_document(html, root_box, context)
+
+        if grid_debug is not None:
+            cls._write_grid_debug_output( page_boxes, grid_debug );
+        
         rendering = cls(
             [Page(page_box, enable_hinting) for page_box in page_boxes],
             DocumentMetadata(**html._get_metadata()),

--- a/weasyprint/document.py
+++ b/weasyprint/document.py
@@ -382,27 +382,27 @@ class Document(object):
         def extract_lines(children):
             for child in children:
                 if isinstance(child, boxes.LineBox):
-                    yield child;
+                    yield child
                 if hasattr(child, "children"):
                     for line in extract_lines( child.children ):
-                        yield line;
+                        yield line
         
         def extract_text( children ):
-            accumulated_text = "";
+            accumulated_text = ""
             for child in children:
                 if hasattr(child, "pango_layout"):
                     if hasattr( child.pango_layout, "text" ):
-                        accumulated_text += child.pango_layout.text + " ";
+                        accumulated_text += child.pango_layout.text + " "
                 if hasattr( child, "children" ):
                     for text in extract_text( child.children ):
-                        accumulated_text += text + " ";
-            return accumulated_text;
+                        accumulated_text += text + " "
+            return accumulated_text
 
         with open( grid_debug, "wt", encoding="utf-8" ) as f:
 
             for ( pageno, page ) in enumerate( page_boxes ):
                 for ( lineno, line ) in enumerate( extract_lines( page.children ) ):
-                    text = extract_text( line.children );
+                    text = extract_text( line.children )
                     print(
                         "{:3d}|{:3d}|{:3.3f}|{:3.3f}|{:s}"\
                            .format(
@@ -411,7 +411,7 @@ class Document(object):
                                 line.position_y,
                                 line.height,
                                 text ),
-                        file=f );
+                        file=f )
 
     @classmethod
     def _render(cls, html, stylesheets, enable_hinting,
@@ -431,7 +431,8 @@ class Document(object):
         page_boxes = layout_document(html, root_box, context)
 
         if grid_debug is not None:
-            cls._write_grid_debug_output( page_boxes, grid_debug );
+            page_boxes = list(page_boxes)
+            cls._write_grid_debug_output(page_boxes, grid_debug)
         
         rendering = cls(
             [Page(page_box, enable_hinting) for page_box in page_boxes],

--- a/weasyprint/document.py
+++ b/weasyprint/document.py
@@ -17,8 +17,6 @@ import warnings
 import cairocffi as cairo
 from weasyprint.layout import LayoutContext
 
-from pprint import pprint
-
 from . import CSS
 from .css import get_all_computed_styles
 from .css.targets import TargetCollector


### PR DESCRIPTION
Dear WeasyPrint Team!

First of all: Thanks a lot to the maintainers here for creating WeasyPrint and making it open source.  I am in the middle of doing an expansive book-publishing project with WeasyPrint and have found it absolutely great.  I'm sure this software has a bright future.

This PR is a piece of functionality that I've added that helps me in debugging design issues for the book.  There seems to be a pretty hard rule within the design profession that lines of a book on two opposing pages should always line up to the same raster.  This is not always easy to do in HTML, since HTML will reflow stuff and if there is even a single box that is not the height you are expecting it to be, then it will move everything below it and push all the lines to go out of alignment.

So I've created this function where, by adding the parameter `--grid-debug somefile.csv`, weasyprint will create a file `somefile.csv` that the designer can expect to check if lines have the expected heights and their y_positions line up with each other.

I'm hoping other people might find this useful, hence the PR.

Thanks again, and keep up the good work!

cheers,

Richard