### PR TITLE
facility to override font metrics

### DIFF
--- a/weasyprint/text.py
+++ b/weasyprint/text.py
@@ -14,6 +14,7 @@ import re
 import cairocffi as cairo
 import cffi
 import pyphen
+from tinycss2.ast import IdentToken
 
 from .logger import LOGGER
 
@@ -631,7 +632,12 @@ def first_line_metrics(first_line, text, layout, resume_at, space_collapse,
                         break
         length += soft_hyphens * 2  # len('\u00ad'.encode('utf8'))
     width, height = get_size(first_line, style)
-    baseline = units_to_double(pango.pango_layout_get_baseline(layout.layout))
+    override = style.get( "__override_font_metrics", (None,) )[0]
+    if isinstance(override, IdentToken) and override.value == "on":
+        height = style["font_size"]
+        baseline = height
+    else:
+        baseline = units_to_double(pango.pango_layout_get_baseline(layout.layout))
     layout.deactivate()
     return layout, length, resume_at, width, height, baseline
 


### PR DESCRIPTION
This is hacky way to go about issue #931 which I'm using for my book project.

It would allow me to insert the line
```
--override-font-metrics: on;
```
in the CSS, so that the HTML would now look like this:

```
<!DOCTYPE html>
<html lang="en">
<head>

<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
<title>A Design</title>

<style>

body, p, h1 {
  font-family: 'Prociono';
  font-size: 10pt;
  line-height: 12pt;
  --override-font-metrics: on;
  text-align: justify;
  hyphens: auto;
}

@page {
  size: 148.0mm 210.0mm;
  margin-top: 12.0mm;
  margin-bottom: 21.0mm;
  margin-left: 17.0mm;
  margin-right: 17.0mm;
}

p:before {
  content: "▪ ";
}

p {
  margin: 0;
}

</style>

</head>

<body>

<h1>A Design That's Trying to be Very Clever</h1>

<p>Line 1: This is an example of a design that's trying to be very
clever and having unintended side-effects weasyprint.</p>

<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
tempor incididunt ut labore et dolore magna aliqua. Dolor sed viverra
ipsum nunc aliquet bibendum enim. In massa tempor nec feugiat.</p>
<p>Nunc aliquet bibendum enim facilisis gravida.</p>
<p>Nisl nunc mi ipsum faucibus vitae aliquet nec ullamcorper. Amet luctus
venenatis lectus magna fringilla. Volutpat maecenas volutpat blandit aliquam
etiam erat velit scelerisque in. Egestas egestas fringilla phasellus faucibus
scelerisque eleifend. Sagittis orci a scelerisque purus semper eget duis.
Nulla pharetra diam sit amet nisl suscipit.</p>
<p>Sed adipiscing diam donec adipiscing tristique risus nec feugiat in.</p>
<p>Fusce ut placerat orci nulla. Pharetra vel turpis nunc eget lorem dolor.</p>

</body>

</html>
```

This would make the line placements look like this:
```
  0|  0|54.288|16.000|A Design That's Trying to be Very Clever
  0|  1|79.221|16.000|▪     Line 1: This is an example of a design that's trying to be very clever
  0|  2|95.221|16.000|and having unintended side-effects weasyprint.
  0|  3|111.221|16.000|▪     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eius‐
  0|  4|127.221|16.000|mod tempor incididunt ut labore et dolore magna aliqua. Dolor sed viver‐
  0|  5|143.221|16.000|ra ipsum nunc aliquet bibendum enim. In massa tempor nec feugiat.
  0|  6|159.221|16.000|▪     Nunc aliquet bibendum enim facilisis gravida.
  0|  7|175.221|16.000|▪     Nisl nunc mi ipsum faucibus vitae aliquet nec ullamcorper. Amet luc‐
  0|  8|191.221|16.000|tus venenatis lectus magna fringilla. Volutpat maecenas volutpat blandit
  0|  9|207.221|16.000|aliquam etiam erat velit scelerisque in. Egestas egestas fringilla phasellus
  0| 10|223.221|16.000|faucibus scelerisque eleifend. Sagittis orci a scelerisque purus semper
  0| 11|239.221|16.000|eget duis. Nulla pharetra diam sit amet nisl suscipit.
  0| 12|255.221|16.000|▪     Sed adipiscing diam donec adipiscing tristique risus nec feugiat in.
  0| 13|271.221|16.000|▪     Fusce ut placerat orci nulla. Pharetra vel turpis nunc eget lorem dolor.
```
![sample_expected](https://user-images.githubusercontent.com/14801887/63968469-122c9300-caa0-11e9-95a1-0eeae3bf12af.png)
