### PR TITLE
Fix comparison in ParentBox._remove_decoration

### DIFF
--- a/weasyprint/formatting_structure/boxes.py
+++ b/weasyprint/formatting_structure/boxes.py
@@ -321,7 +321,7 @@ class ParentBox(Box):
             self._reset_spacing('top')
         if end:
             self._reset_spacing('bottom')
-        if (start or end) and old_style == self.style:
+        if (start or end) and old_style != self.style:
             # Don't copy style if there's no need to, save some memory
             self.style = old_style
 


### PR DESCRIPTION
Should fix #943

> Don't copy style if there's no need to, save some memory

Indeed.
