### PR TITLE
Sanitize simplified line breaking

### DIFF
--- a/weasyprint/layout/inlines.py
+++ b/weasyprint/layout/inlines.py
@@ -858,11 +858,27 @@ def split_inline_box(context, box, position_x, max_x, skip_stack,
                             # add the original skip stack to the partial
                             # skip stack we get after the new rendering.
 
-                            # We have to do:
-                            # resume_at + initial_skip_stack
-                            # but adding skip stacks is a bit complicated
-                            current_skip_stack = initial_skip_stack
-                            current_resume_at = (child_index, child_resume_at)
+                            # Combining skip stacks is a bit complicated
+                            # We have to:
+                            # - set `child_index` as the first number
+                            # - append the new stack if it's an absolute one
+                            # - otherwise append the combined stacks
+                            #   (resume_at + initial_skip_stack)
+
+                            # extract the initial index
+                            if initial_skip_stack is None:
+                                current_skip_stack = None
+                                initial_index = 0
+                            else:
+                                initial_index, current_skip_stack = (
+                                    initial_skip_stack)
+                            # child_resume_at is an absolute skip stack
+                            if child_index > initial_index:
+                                resume_at = (child_index, child_resume_at)
+                                break
+
+                            # combine the stacks
+                            current_resume_at = child_resume_at
                             stack = []
                             while current_skip_stack and current_resume_at:
                                 skip, current_skip_stack = (
@@ -875,6 +891,8 @@ def split_inline_box(context, box, position_x, max_x, skip_stack,
                             resume_at = current_resume_at
                             while stack:
                                 resume_at = (stack.pop(), resume_at)
+                            # insert the child index
+                            resume_at = (child_index, resume_at)
                             break
                     if break_found:
                         break

--- a/weasyprint/tests/test_layout/test_inline.py
+++ b/weasyprint/tests/test_layout/test_inline.py
@@ -405,16 +405,13 @@ def test_breaking_linebox_regression_12():
     # Regression test for https://github.com/Kozea/WeasyPrint/issues/953
     page, = parse(
         '<style>@font-face {src: url(AHEM____.TTF); font-family: ahem}</style>'
-        '<p style="width:10em; font-family: ahem; line-height: 1">'
+        '<p style="width:10em; font-family: ahem">'
         '  <br><span>123 567 90</span>x'
         '</p>')
     html, = page.children
     body, = html.children
     p, = body.children
     line1, line2, line3 = p.children
-    print(line1.children)
-    assert line1.position_y == 0
-    assert line2.position_y == 16
     assert line2.children[0].children[0].text == '123 567'
     assert line3.children[0].children[0].text == '90'
     assert line3.children[1].text == 'x'

--- a/weasyprint/tests/test_layout/test_inline.py
+++ b/weasyprint/tests/test_layout/test_inline.py
@@ -383,6 +383,62 @@ def test_breaking_linebox_regression_10():
 
 
 @assert_no_logs
+def test_breaking_linebox_regression_11():
+    # Regression test for https://github.com/Kozea/WeasyPrint/issues/953
+    page, = parse(
+        '<style>@font-face {src: url(AHEM____.TTF); font-family: ahem}</style>'
+        '<p style="width:10.5ch; font-family: ahem">'
+        '  line 1<br><span>123 567 90</span>x'
+        '</p>')
+    html, = page.children
+    body, = html.children
+    p, = body.children
+    line1, line2, line3 = p.children
+    assert line1.children[0].text == 'line 1'
+    assert line2.children[0].children[0].text == '123 567'
+    assert line3.children[0].children[0].text == '90'
+    assert line3.children[1].text == 'x'
+
+
+@assert_no_logs
+def test_breaking_linebox_regression_12():
+    # Regression test for https://github.com/Kozea/WeasyPrint/issues/953
+    page, = parse(
+        '<style>@font-face {src: url(AHEM____.TTF); font-family: ahem}</style>'
+        '<p style="width:10.5ch; font-family: ahem">'
+        '  <br><span>123 567 90</span>x'
+        '</p>')
+    html, = page.children
+    body, = html.children
+    p, = body.children
+    line1, line2, line3 = p.children
+    print(line1.children)
+    assert line1.position_y == 0
+    assert line2.position_y == 17
+    assert line2.children[0].children[0].text == '123 567'
+    assert line3.children[0].children[0].text == '90'
+    assert line3.children[1].text == 'x'
+
+
+@assert_no_logs
+def test_breaking_linebox_regression_13():
+    # Regression test for https://github.com/Kozea/WeasyPrint/issues/953
+    page, = parse(
+        '<style>@font-face {src: url(AHEM____.TTF); font-family: ahem}</style>'
+        '<p style="width:10.5ch; font-family: ahem">'
+        '  123 567 90 <span>123 567 90</span>x'
+        '</p>')
+    html, = page.children
+    body, = html.children
+    p, = body.children
+    line1, line2, line3 = p.children
+    assert line1.children[0].text == '123 567 90'
+    assert line2.children[0].children[0].text == '123 567'
+    assert line3.children[0].children[0].text == '90'
+    assert line3.children[1].text == 'x'
+
+
+@assert_no_logs
 def test_linebox_text():
     page, = parse('''
       <style>

--- a/weasyprint/tests/test_layout/test_inline.py
+++ b/weasyprint/tests/test_layout/test_inline.py
@@ -405,7 +405,7 @@ def test_breaking_linebox_regression_12():
     # Regression test for https://github.com/Kozea/WeasyPrint/issues/953
     page, = parse(
         '<style>@font-face {src: url(AHEM____.TTF); font-family: ahem}</style>'
-        '<p style="width:10em; font-family: ahem">'
+        '<p style="width:10em; font-family: ahem; line-height: 1">'
         '  <br><span>123 567 90</span>x'
         '</p>')
     html, = page.children
@@ -414,7 +414,7 @@ def test_breaking_linebox_regression_12():
     line1, line2, line3 = p.children
     print(line1.children)
     assert line1.position_y == 0
-    assert line2.position_y == 17
+    assert line2.position_y == 16
     assert line2.children[0].children[0].text == '123 567'
     assert line3.children[0].children[0].text == '90'
     assert line3.children[1].text == 'x'

--- a/weasyprint/tests/test_layout/test_inline.py
+++ b/weasyprint/tests/test_layout/test_inline.py
@@ -387,7 +387,7 @@ def test_breaking_linebox_regression_11():
     # Regression test for https://github.com/Kozea/WeasyPrint/issues/953
     page, = parse(
         '<style>@font-face {src: url(AHEM____.TTF); font-family: ahem}</style>'
-        '<p style="width:10.5ch; font-family: ahem">'
+        '<p style="width:10em; font-family: ahem">'
         '  line 1<br><span>123 567 90</span>x'
         '</p>')
     html, = page.children
@@ -405,7 +405,7 @@ def test_breaking_linebox_regression_12():
     # Regression test for https://github.com/Kozea/WeasyPrint/issues/953
     page, = parse(
         '<style>@font-face {src: url(AHEM____.TTF); font-family: ahem}</style>'
-        '<p style="width:10.5ch; font-family: ahem">'
+        '<p style="width:10em; font-family: ahem">'
         '  <br><span>123 567 90</span>x'
         '</p>')
     html, = page.children
@@ -425,7 +425,7 @@ def test_breaking_linebox_regression_13():
     # Regression test for https://github.com/Kozea/WeasyPrint/issues/953
     page, = parse(
         '<style>@font-face {src: url(AHEM____.TTF); font-family: ahem}</style>'
-        '<p style="width:10.5ch; font-family: ahem">'
+        '<p style="width:10em; font-family: ahem">'
         '  123 567 90 <span>123 567 90</span>x'
         '</p>')
     html, = page.children


### PR DESCRIPTION
The special case that an already broken child must be split again confronts us with two skip stacks: The initial (absolute) and the adjusted (partial) stack. Often the new stack is a relative one and (carefully) adding both stacks is ok. But the following must be observed:

- The first number of the combined stack has to be the index of the child  we broke twice.
- A child index bigger than the starting index of the initial stack denotes  that the new skip stack is an absolute stack. Don't add nothing.

Should fix #953