### PR TITLE
Return appropriate tuple for string-set:none

### DIFF
--- a/weasyprint/css/validation/properties.py
+++ b/weasyprint/css/validation/properties.py
@@ -1369,7 +1369,7 @@ def string_set(tokens, base_url):
         if None not in parsed_tokens:
             return (var_name, parsed_tokens)
     elif tokens and get_keyword(tokens[0]) == 'none':
-        return 'none'
+        return 'none', ()
 
 
 @property()


### PR DESCRIPTION
This snippet used to crash WeasyPrint with `UnboundLocalError: local variable 'computed_value' referenced before assignment`:

```html
<style>
div {
  string-set: none;
}
</style>
<div>OMG</div>
```

Reason being the tuple-constructor in `computed_values.string_set()` splitting `'none'` instead of a tuple consiting of a string-name and its string-value. 

BTW: WeasyPrint's unconventional way of handling `string-set` enables declarations like `string-set: none, stringname "value";`.
