### PR TITLE
Dont crash due to invalid var() values

### DIFF
--- a/weasyprint/css/computed_values.py
+++ b/weasyprint/css/computed_values.py
@@ -737,6 +737,10 @@ def word_spacing(computer, name, value):
     """Compute the ``word-spacing`` property."""
     if value == 'normal':
         return 0
+    elif isinstance(value, int):
+        # The initial value can get here, but length() would fail as
+        # it does not have a 'unit' attribute.
+        return value
     else:
         return length(computer, name, value, pixels_only=True)
 

--- a/weasyprint/css/computed_values.py
+++ b/weasyprint/css/computed_values.py
@@ -20,8 +20,8 @@ from ..logger import LOGGER
 from ..urls import get_link_attribute
 from .properties import INHERITED, INITIAL_VALUES, Dimension
 from .utils import (
-    ANGLE_TO_RADIANS, LENGTH_UNITS, LENGTHS_TO_PIXELS, check_var_function,
-    safe_urljoin)
+    ANGLE_TO_RADIANS, LENGTH_UNITS, LENGTHS_TO_PIXELS, InvalidValues,
+    check_var_function, safe_urljoin)
 
 ZERO_PIXELS = Dimension(0, 'px')
 
@@ -226,10 +226,14 @@ def compute(element, pseudo_type, specified, computed, parent_style,
                 new_value = None
             else:
                 prop = PROPERTIES[name.replace('_', '-')]
-                if prop.wants_base_url:
-                    new_value = prop(computed_value, base_url)
-                else:
-                    new_value = prop(computed_value)
+                # catch InvalidValues, e.g. for transform
+                try:
+                    if prop.wants_base_url:
+                        new_value = prop(computed_value, base_url)
+                    else:
+                        new_value = prop(computed_value)
+                except InvalidValues:
+                    new_value = None
 
             # See https://drafts.csswg.org/css-variables/#invalid-variables
             if new_value is None:

--- a/weasyprint/css/computed_values.py
+++ b/weasyprint/css/computed_values.py
@@ -615,6 +615,9 @@ def font_size(computer, name, value):
                 return keyword_values[-i - 1]
         else:
             return parent_font_size * 0.8
+    elif isinstance(value, int):
+        # Due to improper var() the unit-less parent value can get here
+        return value
     elif value.unit == '%':
         return value.value * parent_font_size / 100.
     else:

--- a/weasyprint/css/computed_values.py
+++ b/weasyprint/css/computed_values.py
@@ -545,14 +545,21 @@ def bookmark_label(computer, name, values):
 def string_set(computer, name, values):
     """Compute the ``string-set`` property."""
     # Spec asks for strings after custom keywords, but we allow content-lists
-    return tuple(
-        (string_set[0], _content_list(computer, string_set[1]))
-        for string_set in values)
+    # The initial value of 'none' can get here by improper var()
+    if values == 'none':
+        return ()
+    else:
+        return tuple(
+            (string_set[0], _content_list(computer, string_set[1]))
+            for string_set in values)
 
 
 @register_computer('content')
 def content(computer, name, values):
     """Compute the ``content`` property."""
+    # take care for INITIAL_VALUES['content']
+    if values == 'normal':
+        return 'inhibit' if computer['pseudo_type'] else 'contents'
     if len(values) == 1:
         value, = values
         if value == 'normal':

--- a/weasyprint/css/computed_values.py
+++ b/weasyprint/css/computed_values.py
@@ -252,6 +252,9 @@ def compute(element, pseudo_type, specified, computed, parent_style,
                     value = INITIAL_VALUES[name]
             else:
                 value = new_value
+            # no value, no fallback, no need for a function call
+            if value is None:
+                function = None
 
         if function is not None:
             value = function(computer, name, value)

--- a/weasyprint/css/computed_values.py
+++ b/weasyprint/css/computed_values.py
@@ -301,7 +301,9 @@ def length_or_percentage_tuple(computer, name, values):
 @register_computer('clip')
 def length_tuple(computer, name, values):
     """Compute the properties with a list of lengths."""
-    return tuple(length(computer, name, value, pixels_only=True)
+    # be aware of parent_style/initial values being plain numbers
+    return tuple(value if isinstance(value, (int, float)) else
+                 length(computer, name, value, pixels_only=True)
                  for value in values)
 
 

--- a/weasyprint/tests/test_variables.py
+++ b/weasyprint/tests/test_variables.py
@@ -9,6 +9,7 @@
 
 """
 
+from ..css.properties import KNOWN_PROPERTIES
 from .test_boxes import render_pages as parse
 
 
@@ -95,3 +96,15 @@ def test_variable_initial():
     body, = html.children
     paragraph, = body.children
     assert paragraph.width == 10
+
+
+def test_variable_fallback():
+    parse('''
+      <style>
+        div {
+          --var: improperValue;
+          %s
+        }
+      </style>
+      <div></div>
+    ''' % ''.join(name + ': var(--var);\n' for name in KNOWN_PROPERTIES))


### PR DESCRIPTION
When a css property is defined via the var() function and the variable contains an invalid value a WARNING is generated and either an initial or the parent-value is assigned. 

In most cases the fallback is an appropriate value and computation succeeds without further intervention, but for some properties this is not the case. We could adjust `css.properties.INITIAL_VALUES`, but I suppose there are reasons for the *improper* values, probably they are required elsewhere.

That means we must take care for those special fallback values in the corresponding @register_computer-function. Like in `border_width()` -- this function pays attention since fadb60c14fc3fe7c7cb790ca505488ff8a8467b3, 8 years ago.

