### PR TITLE
require Pyphen >= 0.9.1

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -13,7 +13,7 @@ WeasyPrint |version| depends on:
 * tinycss2_ ≥ 1.0.0
 * cssselect2_ ≥ 0.1
 * CairoSVG_ ≥ 2.4.0
-* Pyphen_ ≥ 0.8
+* Pyphen_ ≥ 0.9.1
 * GDK-PixBuf_ ≥ 2.25.0 [#]_
 
 .. _CPython: http://www.python.org/

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ install_requires =
   tinycss2>=1.0.0
   cssselect2>=0.1
   CairoSVG>=2.4.0
-  Pyphen>=0.8
+  Pyphen>=0.9.1
 tests_require =
   pytest-runner
   pytest-cov


### PR DESCRIPTION
With older versions tests I get 19 test failures in test_text.py. I am not sure if this is peculiarity of the test suite but 0.9.1 was released almost 6 years ago (December 2013) so requiring it should be fine.

Side note: ~~Fedora still ships 0.9.0~~ Fedora 30 ships 0.9.1 but somehow that version also triggers the same test failures. Anyway 0.9.0 is definitively not good enough to get the test suite passing.