### PR TITLE
Fix when frozen with cx_freeze

### DIFF
--- a/weasyprint/__init__.py
+++ b/weasyprint/__init__.py
@@ -34,7 +34,7 @@ if hasattr(sys, 'frozen'):  # pragma: no cover
     else:
         # Frozen with something else (py2exe, etc.)
         # See https://github.com/Kozea/WeasyPrint/pull/269
-        ROOT = os.path.dirname(sys.executable)
+        ROOT = Path(os.path.dirname(sys.executable))
 else:
     ROOT = Path(os.path.dirname(__file__))
 


### PR DESCRIPTION
Fixes

```
    from weasyprint import HTML
  File "/usr/local/lib/python3.7/dist-packages/weasyprint/__init__.py", line 41, in <module>
    VERSION = __version__ = (ROOT / 'VERSION').read_text().strip()
TypeError: unsupported operand type(s) for /: 'str' and 'str'
```