### PR TITLE
Use platform.uname instead of os.uname

### DIFF
--- a/weasyprint/__main__.py
+++ b/weasyprint/__main__.py
@@ -11,7 +11,6 @@
 
 import argparse
 import logging
-import os
 import sys
 
 import cairosvg
@@ -22,8 +21,9 @@ from .text import cairo, pango
 
 class PrintInfo(argparse.Action):
     def __call__(*_, **__):
-        uname = os.uname()
-        print('System:', uname.sysname)
+        import platform
+        uname = platform.uname()
+        print('System:', uname.system)
         print('Machine:', uname.machine)
         print('Version:', uname.version)
         print('Release:', uname.release)


### PR DESCRIPTION
`platform.uname()` should work on all platforms (cf. https://github.com/Kozea/WeasyPrint/issues/1023#issuecomment-573250759) and therefore `weasyprint --info`, too.

Decided to `import platform` locally to avoid unnecessary initialization when there is no `--info` argument.

It's just educated guessing that it reveals interesting facts on Windows -- I don't have no Windows computer anymore.

Have no idea how to write a unit test for `PrintInfo` action :flushed: 

