### PR TITLE
Update instructions for install on Windows

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -448,6 +448,7 @@ Let's find out. Enter the following command:
 .. code-block:: console
 
     WHERE libcairo-2.dll
+    WHERE zlib1.dll
 
 This should respond with
 *path\\to\\recently\\installed\\gtk\\binaries\\libcairo-2.dll*, for example:
@@ -455,6 +456,7 @@ This should respond with
 .. code-block:: console
 
     C:\msys2\mingw64\bin\libcairo-2.dll
+    C:\Program Files\GTK3-Runtime Win64\bin\zlib1.dll
 
 If your system answers with *nothing found* or returns a filename not related
 to your recently-installed-gtk or lists more than one location and the first


### PR DESCRIPTION
In a try to run command "python -m weasyprint http://weasyprint.org weasyprint.pdf" I have encountered on problem "Entry Point Not Found" with following text: "The procedure entry point inflateValidate could not be located in the dynamic link library C:\Program Files\GTK3-Runtime Win64\bin\libpng16-16.dll".
After 90-120 mins I found the problem - there were two "zlib1.dll" files - the second came from PostgreSQL (v10) and because it was first in the PATH it was called instead of GTK's version.
With this small change someone else could save the time and potential new tickets are prevented.