### PR TITLE
RTL: render table correctly when direction is rtl

### DIFF
--- a/weasyprint/layout/tables.py
+++ b/weasyprint/layout/tables.py
@@ -31,7 +31,6 @@ def table_layout(context, table, max_position_y, skip_stack, containing_block,
         border_spacing_x = 0
         border_spacing_y = 0
 
-    # TODO: reverse this for direction: rtl
     column_positions = table.column_positions = []
     position_x = table.content_box_x()
     rows_x = position_x + border_spacing_x
@@ -40,6 +39,10 @@ def table_layout(context, table, max_position_y, skip_stack, containing_block,
         column_positions.append(position_x)
         position_x += width
     rows_width = position_x - rows_x
+
+    # This should fix the rtl direction for table
+    if table.style['direction'] == 'rtl':
+        column_positions.reverse()
 
     if table.style['border_collapse'] == 'collapse':
         if skip_stack:

--- a/weasyprint/tests/test_layout/test_table.py
+++ b/weasyprint/tests/test_layout/test_table.py
@@ -1540,6 +1540,36 @@ def test_layout_table_auto_50():
 
 
 @assert_no_logs
+@pytest.mark.parametrize('size, width', (
+    ('242px', 242),
+    ('100%', 793),
+))
+def test_explicit_width_table_percent_rtl(size, width):
+    page, = render_pages('''
+      <table style="width: %s; direction:rtl">
+        <tr>
+          <th>الاسم</th>
+          <th>العائلة</th>
+          <th>العمر</th>
+        </tr>
+        <tr>
+          <td>محمد يوسف</td>
+          <td>النجدي</td>
+          <td>29</td>
+        </tr>
+      </table>
+    ''' % size)
+    html, = page.children
+    body, = html.children
+    wrapper, = body.children
+    table, = wrapper.children
+    row_group, = table.children
+
+    assert table.position_x == 0
+    assert int(table.width) == width
+
+
+@assert_no_logs
 def test_table_column_width_1():
     source = '''
       <style>


### PR DESCRIPTION
This pull request should fix the table rendering in RTL.which is part of the issue: #106 