### PR TITLE
Changed ASCII encoding to MBCS encoding to support special characters in paths

### DIFF
--- a/weasyprint/fonts.py
+++ b/weasyprint/fonts.py
@@ -417,9 +417,9 @@ else:
                     os.close(fd)
                     self._filenames.append(conf_filename)
                     fontconfig.FcConfigParseAndLoad(
-                        config, conf_filename.encode('ascii'), True)
+                        config, conf_filename.encode('mbcs'), True)
                     font_added = fontconfig.FcConfigAppFontAddFile(
-                        config, filename.encode('ascii'))
+                        config, filename.encode('mbcs'))
                     if font_added:
                         # TODO: We should mask local fonts with the same name
                         # too as explained in Behdad's blog entry.


### PR DESCRIPTION
ASCII only uses 7 out of the 8 bits which causes an exception when using something like åäö in a path. This causes issues for me while testing this on Windows 10 as my username has those characters in them

I've only tested this on Windows 10, i don't know if this will cause any issues with other platforms, but i have a feeling it'll work fine on all platforms based on my understanding of how MBCS works (encoding ASCII ranged characters the same as ASCII does)