### PR TITLE
HTML: prevent FutureWarning from xml.etree.ElementTree.Element

### DIFF
--- a/weasyprint/__init__.py
+++ b/weasyprint/__init__.py
@@ -114,7 +114,7 @@ class HTML:
                     source, override_encoding=encoding,
                     transport_encoding=protocol_encoding,
                     namespaceHTMLElements=False)
-            assert result
+            assert (result is not None) and len(result)
         self.base_url = find_base_url(result, base_url)
         self.url_fetcher = url_fetcher
         self.media_type = media_type


### PR DESCRIPTION
`__bool__()`/`__nonzero__()` is deprecated and raises a `FutureWarning`. This warning is usually not visible with CPython. However it is highly irritating with pypy3 (v7.1.1).

- pypy3: https://foss.heptapod.net/pypy/pypy/blob/branch/default/lib-python/2.7/xml/etree/ElementTree.py#L250
- CPython: https://github.com/python/cpython/blob/master/Lib/xml/etree/ElementTree.py#L214

I'm not sure if the `assert` is actually necessary (it was added in 4069a1cc366f532806189f257e5e2a98dcb9a48d) but the change just mirrors what `__bool__()` is doing right now.
