### PR TITLE
Try fixing a bug encountered when using weasyprint in Pyinstaller context

### DIFF
--- a/weasyprint/__init__.py
+++ b/weasyprint/__init__.py
@@ -27,7 +27,7 @@ if hasattr(sys, 'frozen'):  # pragma: no cover
     if hasattr(sys, '_MEIPASS'):
         # Frozen with PyInstaller
         # See https://github.com/Kozea/WeasyPrint/pull/540
-        ROOT = Path(sys._MEIPASS)
+        ROOT = Path(sys._MEIPASS) / 'weasyprint'
     else:
         # Frozen with something else (py2exe, etc.)
         # See https://github.com/Kozea/WeasyPrint/pull/269


### PR DESCRIPTION
When packaging ``weasyprint`` as a dependency in a Pyinstaller project, it looks for the ``VERSION`` file in the root ``sys._MEIPASS`` when the actual file ends up in ``sys._MEIPASS``'s subdirectory ``weasyprint``. This pull request fixes that.

Maybe there's a reason the code is currently implemented this way. In that case I wouldn't mind to look for a solution to support all use cases.

Sample stack trace of the problem on runtime of an executable created with PyInstaller:
```
Traceback (most recent call last):
  File "site-packages\(...)\__init__.py", line 8, in <module>
  File "<frozen importlib._bootstrap>", line 971, in _find_and_load
  File "<frozen importlib._bootstrap>", line 955, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
  File "c:\Python36\lib\site-packages\PyInstaller\loader\pyimod03_importers.py", line 627, in exec_module
  File "site-packages\weasyprint\__init__.py", line 41, in <module>
  File "pathlib.py", line 1174, in read_text
  File "pathlib.py", line 1161, in open
  File "pathlib.py", line 1015, in _opener
  File "pathlib.py", line 387, in wrapped
PermissionError: [Errno 13] Permission denied: 'C:\\Users\\bart\\AppData\\Local\\Temp\\_MEI826202\\VERSION'
```