### PR TITLE
dlopen shared library symlink using major version name.

### DIFF
--- a/weasyprint/fonts.py
+++ b/weasyprint/fonts.py
@@ -49,7 +49,7 @@ else:
                         'libfontconfig-1.dll',
                         'libfontconfig.so.1', 'libfontconfig-1.dylib')
     pangoft2 = dlopen(ffi, 'pangoft2-1.0', 'libpangoft2-1.0-0',
-                      'libpangoft2-1.0.so', 'libpangoft2-1.0.dylib')
+                      'libpangoft2-1.0.so.0', 'libpangoft2-1.0.dylib')
 
     ffi.cdef('''
         // FontConfig

--- a/weasyprint/text.py
+++ b/weasyprint/text.py
@@ -253,12 +253,12 @@ def dlopen(ffi, *names):
     return ffi.dlopen(names[0])  # pragma: no cover
 
 
-gobject = dlopen(ffi, 'gobject-2.0', 'libgobject-2.0-0', 'libgobject-2.0.so',
+gobject = dlopen(ffi, 'gobject-2.0', 'libgobject-2.0-0', 'libgobject-2.0.so.0',
                  'libgobject-2.0.dylib')
-pango = dlopen(ffi, 'pango-1.0', 'libpango-1.0-0', 'libpango-1.0.so',
+pango = dlopen(ffi, 'pango-1.0', 'libpango-1.0-0', 'libpango-1.0.so.0',
                'libpango-1.0.dylib')
 pangocairo = dlopen(ffi, 'pangocairo-1.0', 'libpangocairo-1.0-0',
-                    'libpangocairo-1.0.so', 'libpangocairo-1.0.dylib')
+                    'libpangocairo-1.0.so.0', 'libpangocairo-1.0.dylib')
 
 gobject.g_type_init()
 


### PR DESCRIPTION
Hi, I'm not sure is it worth to change it now because that may breaks old setups of weasyprint but if I would releasing new software I would go with that change. The main disadvantage of current code was found in https://github.com/Kozea/WeasyPrint/issues/1003#issuecomment-623077742, when we zip libraries and theirs hard symlinks each symlink become separate file as a result weasyprint loads the .so file while the rest of the system is linked with .so.N file that leads to segfaults.

Related cairocffi PR https://github.com/Kozea/cairocffi/pull/156

**PR Rationale**

cffi.dlopen should use .so.N symlinks instead of .so to
make sure we load ABI compatible version of the library and
the same library used by the rest of the system.

cffi uses `ctypes.util.find_library` to search for libraries
and the docs for `find_library` states that
"The exact functionality is system dependent."
so different system may expect different names for the same library.

To overcome that problem we try to load several names until success
among these names exact file name with `.so` suffix
eg. `libcairo.so` but .so symlink is not always safe to use.

Shared library usually consist of two of three files:
- libcairo.so.N.M - N.M exact version number
- libcairo.so.N - symlink to library.so.N.M with major ABI version
- libcairo.so - symlink to library.so.N

When -lcairo flag is used linker search for libcairo.so,
but when the programm loaded it loads libcairo.so.N where N
is the version that it was linked with.

Some downsides of .so usage:
- .so may point to the wrong ABI version, e.g. we expect libcairo
  version 2 but libcairo.so points at libcairo.so.1
- usually .so files are shipped with development packages `-dev`
  in debian and `-devel` in centos and they are just symlinks
  to the .so.N files. So it safer to search for .so.N files they
  will exist even if dev package is not installed.
- hard symlink .so -> .so.N not always preserved, eg. if we zip
  them we get two copies of the library and while the rest of the
  system will use .so.N file we will load .so files that may lead
  to crash