### PR TITLE
Add missing validation package to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ project_urls =
 packages =
   weasyprint
   weasyprint.css
+  weasyprint.css.validation
   weasyprint.formatting_structure
   weasyprint.layout
   weasyprint.tests


### PR DESCRIPTION
The `weasyprint.css.validation` package was missing from the setup, which was causing a `ModuleNotFoundError: No module named 'weasyprint.css.validation'` when trying to run weasyprint that was installed directly from the `master` branch.