### PR TITLE
Dont clip page margins on account of body overflow

### DIFF
--- a/weasyprint/draw.py
+++ b/weasyprint/draw.py
@@ -184,6 +184,14 @@ def draw_stacking_context(context, stacking_context, enable_hinting):
     # See http://www.w3.org/TR/CSS2/zindex.html
     with stacked(context):
         box = stacking_context.box
+
+        # apply the viewport_overflow to the html box, see #35
+        if box.element_tag == 'html' and (
+                stacking_context.page.style['overflow'] != 'visible'):
+            rounded_box_path(context,
+                    stacking_context.page.rounded_padding_box())
+            context.clip()
+
         if box.is_absolutely_positioned() and box.style['clip']:
             top, right, bottom, left = box.style['clip']
             if top == 'auto':
@@ -223,7 +231,9 @@ def draw_stacking_context(context, stacking_context, enable_hinting):
                 context, stacking_context.page, box, enable_hinting)
 
         with stacked(context):
-            if box.style['overflow'] != 'visible':
+            # dont clip the PageBox, see #35
+            if box.style['overflow'] != 'visible' and not isinstance(
+                    box, boxes.PageBox):
                 # Only clip the content and the children:
                 # - the background is already clipped
                 # - the border must *not* be clipped

--- a/weasyprint/draw.py
+++ b/weasyprint/draw.py
@@ -186,7 +186,7 @@ def draw_stacking_context(context, stacking_context, enable_hinting):
         box = stacking_context.box
 
         # apply the viewport_overflow to the html box, see #35
-        if box.element_tag == 'html' and (
+        if box.is_for_root_element and (
                 stacking_context.page.style['overflow'] != 'visible'):
             rounded_box_path(
                 context,

--- a/weasyprint/draw.py
+++ b/weasyprint/draw.py
@@ -188,8 +188,9 @@ def draw_stacking_context(context, stacking_context, enable_hinting):
         # apply the viewport_overflow to the html box, see #35
         if box.element_tag == 'html' and (
                 stacking_context.page.style['overflow'] != 'visible'):
-            rounded_box_path(context,
-                    stacking_context.page.rounded_padding_box())
+            rounded_box_path(
+                context,
+                stacking_context.page.rounded_padding_box())
             context.clip()
 
         if box.is_absolutely_positioned() and box.style['clip']:

--- a/weasyprint/tests/test_draw/test_overflow.py
+++ b/weasyprint/tests/test_draw/test_overflow.py
@@ -79,6 +79,30 @@ def test_overflow_3():
 
 
 @assert_no_logs
+def test_overflow_4():
+    # Assert that the page margins aren't clipped by body's overflow
+    assert_pixels('border_box_overflow', 8, 8, '''
+        rr______
+        rr______
+        __BBBB__
+        __BBBB__
+        __BBBB__
+        __BBBB__
+        ________
+        ________
+    ''', '''
+      <style>
+        @page {
+          size: 8px;
+          margin: 2px;
+          background:#fff;
+          @top-left-corner { content: ''; background:#f00; } }
+        body { overflow: auto; background:#00f; }
+      </style>
+      ''')
+
+
+@assert_no_logs
 @requires('cairo', (1, 12, 0))
 @pytest.mark.parametrize('number, css, pixels', (
     (1, '5px, 5px, 9px, auto', '''


### PR DESCRIPTION
If we want the `viewport_overflow` restriction being applied to the `<BlockBox html>` only, the instructions for `draw_stacking_context()` are:

1. never clip when a PageBox is rendered
2. do the clip when drawing a `<BlockBox html>` whose page's overflow isn't `visible`

Good thing is: 
We can rely upon the `with stacked(context)` statement to save and restore the context state automagically.

fixes #35