### PR TITLE
Bookmark label

### DIFF
--- a/weasyprint/formatting_structure/build.py
+++ b/weasyprint/formatting_structure/build.py
@@ -244,6 +244,15 @@ def before_after_to_box(element, pseudo_type, state, style_for,
         target_collector, counter_style))
 
     box.children = children
+
+    # calculate the bookmark-label
+    if style['bookmark_label'] == 'none':
+        box.bookmark_label = ''
+    else:
+        _quote_depth, counter_values, _counter_scopes = state
+        compute_bookmark_label(
+            element, box, style['bookmark_label'], counter_values,
+            target_collector, counter_style)
     return [box]
 
 

--- a/weasyprint/layout/__init__.py
+++ b/weasyprint/layout/__init__.py
@@ -140,7 +140,7 @@ def layout_document(html, root_box, context, max_loops=8):
         if not reloop_content and not reloop_pages:
             break
 
-    # Calculate string-sets and bookmark-label containing page based counters
+    # Calculate string-sets and bookmark-labels containing page based counters
     # when pagination is finished. No need to do that (maybe multiple times) in
     # make_page because they dont create boxes, only appear in MarginBoxes and
     # in the final PDF.
@@ -157,6 +157,10 @@ def layout_document(html, root_box, context, max_loops=8):
                         context.target_collector.counter_lookup_items.items()):
                     if child.missing_link == box and css_token != 'content':
                         item.parse_again(page_counter_values)
+                        # string_set is a pointer, but the bookmark_label is
+                        # just a string: copy it
+                        if css_token == 'bookmark-label':
+                            child.bookmark_label = box.bookmark_label
             # Collect the string_sets in the LayoutContext
             string_sets = child.string_set
             if string_sets and string_sets != 'none':

--- a/weasyprint/tests/test_pdf.py
+++ b/weasyprint/tests/test_pdf.py
@@ -332,6 +332,22 @@ def test_bookmarks_8():
 
 
 @assert_no_logs
+@requires('cairo', (1, 15, 4))
+def test_bookmarks_9():
+    fileobj = io.BytesIO()
+    FakeHTML(string='''
+      <h1 style="bookmark-label: 'h1 on page ' counter(page)">a</h1>
+    ''').write_pdf(target=fileobj)
+    # h1 on page 1
+    pdf_file = pdf.PDFFile(fileobj)
+    outlines = pdf_file.catalog.get_indirect_dict('Outlines', pdf_file)
+    assert outlines.get_type() == 'Outlines'
+    assert outlines.get_value('Count', '(.*)') == b'-1'
+    o1 = outlines.get_indirect_dict('First', pdf_file)
+    assert o1.get_value('Title', '(.*)') == b'(h1 on page 1)'
+
+
+@assert_no_logs
 def test_links_none():
     fileobj = io.BytesIO()
     FakeHTML(string='<body>').write_pdf(target=fileobj)

--- a/weasyprint/tests/test_pdf.py
+++ b/weasyprint/tests/test_pdf.py
@@ -348,6 +348,32 @@ def test_bookmarks_9():
 
 
 @assert_no_logs
+@requires('cairo', (1, 15, 4))
+def test_bookmarks_10():
+    fileobj = io.BytesIO()
+    FakeHTML(string='''
+      <style>
+      div:before, div:after {
+         content: '';
+         bookmark-level: 1;
+         bookmark-label: 'x';
+      }
+      </style>
+      <div>a</div>
+    ''').write_pdf(target=fileobj)
+    # x
+    # x
+    pdf_file = pdf.PDFFile(fileobj)
+    outlines = pdf_file.catalog.get_indirect_dict('Outlines', pdf_file)
+    assert outlines.get_type() == 'Outlines'
+    assert outlines.get_value('Count', '(.*)') == b'-2'
+    o1 = outlines.get_indirect_dict('First', pdf_file)
+    assert o1.get_value('Title', '(.*)') == b'(x)'
+    o2 = o1.get_indirect_dict('Next', pdf_file)
+    assert o2.get_value('Title', '(.*)') == b'(x)'
+
+
+@assert_no_logs
 def test_links_none():
     fileobj = io.BytesIO()
     FakeHTML(string='<body>').write_pdf(target=fileobj)

--- a/weasyprint/tests/test_pdf.py
+++ b/weasyprint/tests/test_pdf.py
@@ -374,6 +374,34 @@ def test_bookmarks_10():
 
 
 @assert_no_logs
+@requires('cairo', (1, 15, 4))
+def test_bookmarks_11():
+    fileobj = io.BytesIO()
+    FakeHTML(string='''
+      <div style="display:inline; white-space:pre;
+       bookmark-level:1; bookmark-label:'a'">
+      a
+      a
+      a
+      </div>
+      <div style="bookmark-level:1; bookmark-label:'b'">
+        <div>b</div>
+        <div style="break-before:always">c</div>
+      </div>
+    ''').write_pdf(target=fileobj)
+    # a
+    # b
+    pdf_file = pdf.PDFFile(fileobj)
+    outlines = pdf_file.catalog.get_indirect_dict('Outlines', pdf_file)
+    assert outlines.get_type() == 'Outlines'
+    assert outlines.get_value('Count', '(.*)') == b'-2'
+    o1 = outlines.get_indirect_dict('First', pdf_file)
+    assert o1.get_value('Title', '(.*)') == b'(a)'
+    o2 = o1.get_indirect_dict('Next', pdf_file)
+    assert o2.get_value('Title', '(.*)') == b'(b)'
+
+
+@assert_no_logs
 def test_links_none():
     fileobj = io.BytesIO()
     FakeHTML(string='<body>').write_pdf(target=fileobj)


### PR DESCRIPTION
Incited by #1145 I started a research about how to implement bookmark-labels for the `:before` and `:after` pseudo-elements and stumbled upon page counters and target counters not being updated in bookmark-labels at all.

Of course, nobody ever will use page or target counters in her bookmark-labels...