### PR TITLE
Add support for concatenating var() functions in 'content' declarations

### DIFF
--- a/weasyprint/css/computed_values.py
+++ b/weasyprint/css/computed_values.py
@@ -271,7 +271,6 @@ def compute(element, pseudo_type, specified, computed, parent_style,
             if converted_to_list:
                 value, = value
 
-
         if function is not None and not already_computed_value:
             value = function(computer, name, value)
         # else: same as specified

--- a/weasyprint/css/computed_values.py
+++ b/weasyprint/css/computed_values.py
@@ -253,12 +253,14 @@ def compute(element, pseudo_type, specified, computed, parent_style,
             for i, val in enumerate(value):
                 if not isinstance(val, tuple) or val[0] != 'var()':
                     continue
-                new_value, already_computed_value = resolve_var(val, name, computed)
+                new_value, already_computed_value = \
+                    resolve_var(val, name, computed)
                 if name == 'content':
                     new_value = new_value[0]
                 value[i] = new_value
         elif value and isinstance(value, tuple) and value[0] == 'var()':
-            new_value, already_computed_value = resolve_var(value, name, computed)
+            new_value, already_computed_value = \
+                resolve_var(value, name, computed)
             if name == 'content':
                 new_value = new_value[0]
             value = new_value

--- a/weasyprint/css/computed_values.py
+++ b/weasyprint/css/computed_values.py
@@ -196,38 +196,35 @@ def compute(element, pseudo_type, specified, computed, parent_style,
     from .validation.properties import PROPERTIES
 
     def resolve_var(value, name, computed):
-        if isinstance(value, tuple) and value[0] == 'var()':
-            variable_name, default = value[1]
-            computed_value = _resolve_var(computed, variable_name, default)
-            if computed_value is None:
-                new_value = None
+        variable_name, default = value[1]
+        computed_value = _resolve_var(computed, variable_name, default)
+        if computed_value is None:
+            new_value = None
+        else:
+            prop = PROPERTIES[name.replace('_', '-')]
+            if prop.wants_base_url:
+                new_value = prop(computed_value, base_url)
             else:
-                prop = PROPERTIES[name.replace('_', '-')]
-                if prop.wants_base_url:
-                    new_value = prop(computed_value, base_url)
-                else:
-                    new_value = prop(computed_value)
-                new_value = new_value[0]
+                new_value = prop(computed_value)
 
-            # See https://drafts.csswg.org/css-variables/#invalid-variables
-            if new_value is None:
-                try:
-                    computed_value = ''.join(
-                        token.serialize() for token in computed_value)
-                except BaseException:
-                    pass
-                LOGGER.warning(
-                    'Unsupported computed value `%s` set in variable `%s` '
-                    'for property `%s`.', computed_value,
-                    variable_name.replace('_', '-'), name.replace('_', '-'))
-                if name in INHERITED and parent_style:
-                    already_computed_value = True
-                    return parent_style[name], already_computed_value
-                else:
-                    already_computed_value = name not in INITIAL_NOT_COMPUTED
-                    return INITIAL_VALUES[name], already_computed_value
-            return new_value, False
-        return value, False
+        # See https://drafts.csswg.org/css-variables/#invalid-variables
+        if new_value is None:
+            try:
+                computed_value = ''.join(
+                    token.serialize() for token in computed_value)
+            except BaseException:
+                pass
+            LOGGER.warning(
+                'Unsupported computed value `%s` set in variable `%s` '
+                'for property `%s`.', computed_value,
+                variable_name.replace('_', '-'), name.replace('_', '-'))
+            if name in INHERITED and parent_style:
+                already_computed_value = True
+                return parent_style[name], already_computed_value
+            else:
+                already_computed_value = name not in INITIAL_NOT_COMPUTED
+                return INITIAL_VALUES[name], already_computed_value
+        return new_value, False
 
     computer = {
         'is_root_element': parent_style is None,
@@ -254,10 +251,17 @@ def compute(element, pseudo_type, specified, computed, parent_style,
 
         if value and isinstance(value, list):
             for i, val in enumerate(value):
+                if not isinstance(val, tuple) or val[0] != 'var()':
+                    continue
                 new_value, already_computed_value = resolve_var(val, name, computed)
+                if name == 'content':
+                    new_value = new_value[0]
                 value[i] = new_value
-        elif value:
-            value, already_computed_value = resolve_var(value, name, computed)
+        elif value and isinstance(value, tuple) and value[0] == 'var()':
+            new_value, already_computed_value = resolve_var(value, name, computed)
+            if name == 'content':
+                new_value = new_value[0]
+            value = new_value
 
         if function is not None and not already_computed_value:
             value = function(computer, name, value)

--- a/weasyprint/css/utils.py
+++ b/weasyprint/css/utils.py
@@ -699,6 +699,11 @@ def get_content_list_token(token, base_url):
     if string is not None:
         return string
 
+    # <var>
+    var_function = check_var_function(token)
+    if var_function is not None:
+        return var_function
+
     # contents
     if get_keyword(token) == 'contents':
         return ('content', 'text')

--- a/weasyprint/css/utils.py
+++ b/weasyprint/css/utils.py
@@ -700,9 +700,9 @@ def get_content_list_token(token, base_url):
         return string
 
     # <var>
-    var_function = check_var_function(token)
-    if var_function is not None:
-        return var_function
+    var = check_var_function(token)
+    if var is not None:
+        return var
 
     # contents
     if get_keyword(token) == 'contents':

--- a/weasyprint/css/validation/properties.py
+++ b/weasyprint/css/validation/properties.py
@@ -89,10 +89,11 @@ def validate_non_shorthand(base_url, name, tokens, required=False):
     if not required and name not in PROPERTIES:
         raise InvalidValues('property not supported yet')
 
-    for token in tokens:
-        var_function = check_var_function(token)
-        if var_function:
-            return ((name, var_function),)
+    if name != 'content':
+        for token in tokens:
+            var_function = check_var_function(token)
+            if var_function:
+                return ((name, var_function),)
 
     keyword = get_single_keyword(tokens)
     if keyword in ('initial', 'inherit'):

--- a/weasyprint/css/validation/properties.py
+++ b/weasyprint/css/validation/properties.py
@@ -21,6 +21,7 @@ from ..utils import (
 PREFIX = '-weasy-'
 PROPRIETARY = set()
 UNSTABLE = set()
+MULTIVAL_PROPERTIES = set()
 
 # Yes/no validators for non-shorthand properties
 # Maps property names to functions taking a property name and a value list,
@@ -33,7 +34,7 @@ PROPERTIES = {}
 # Validators
 
 def property(property_name=None, proprietary=False, unstable=False,
-             wants_base_url=False):
+             multiple_values=False, wants_base_url=False):
     """Decorator adding a function to the ``PROPERTIES``.
 
     The name of the property covered by the decorated function is set to
@@ -69,6 +70,8 @@ def property(property_name=None, proprietary=False, unstable=False,
             PROPRIETARY.add(name)
         if unstable:
             UNSTABLE.add(name)
+        if multiple_values:
+            MULTIVAL_PROPERTIES.add(name)
         return function
     return decorator
 
@@ -89,7 +92,7 @@ def validate_non_shorthand(base_url, name, tokens, required=False):
     if not required and name not in PROPERTIES:
         raise InvalidValues('property not supported yet')
 
-    if name != 'content':
+    if name not in MULTIVAL_PROPERTIES:
         for token in tokens:
             var_function = check_var_function(token)
             if var_function:
@@ -455,7 +458,7 @@ def clip(token):
         return ()
 
 
-@property(wants_base_url=True)
+@property(multiple_values=True, wants_base_url=True)
 def content(tokens, base_url):
     """``content`` property validation."""
     # See https://www.w3.org/TR/css-content-3/#content-property

--- a/weasyprint/document.py
+++ b/weasyprint/document.py
@@ -12,6 +12,7 @@ import shutil
 import warnings
 
 import cairocffi as cairo
+
 from weasyprint.layout import LayoutContext
 
 from . import CSS

--- a/weasyprint/layout/preferred.py
+++ b/weasyprint/layout/preferred.py
@@ -718,7 +718,7 @@ def flex_max_content_width(context, box, outer=True):
 
 def trailing_whitespace_size(context, box):
     """Return the size of the trailing whitespace of ``box``."""
-    from .inlines import split_text_box, split_first_line
+    from .inlines import split_first_line, split_text_box
 
     while isinstance(box, (boxes.InlineBox, boxes.LineBox)):
         if not box.children:

--- a/weasyprint/tests/test_boxes.py
+++ b/weasyprint/tests/test_boxes.py
@@ -98,7 +98,7 @@ def assert_tree(box, expected):
     assert isinstance(box, boxes.BlockBox)
     assert box.element_tag == 'body'
 
-    assert serialize(box.children) == expected
+    assert serialize(box.children) == expected, '%s != %s' % (serialize(box.children), expected,)
 
 
 def _sanity_checks(box):

--- a/weasyprint/tests/test_boxes.py
+++ b/weasyprint/tests/test_boxes.py
@@ -98,7 +98,7 @@ def assert_tree(box, expected):
     assert isinstance(box, boxes.BlockBox)
     assert box.element_tag == 'body'
 
-    assert serialize(box.children) == expected, '%s != %s' % (serialize(box.children), expected,)
+    assert serialize(box.children) == expected
 
 
 def _sanity_checks(box):

--- a/weasyprint/tests/test_counters.py
+++ b/weasyprint/tests/test_counters.py
@@ -245,14 +245,18 @@ def test_counters_8():
 def test_counter_styles_1():
     assert_tree(parse_all('''
       <style>
-        body { counter-reset: p -12 }
+        body { --var: 'Counter'; counter-reset: p -12 }
         p { counter-increment: p }
         p:nth-child(1):before { content: '-' counter(p, none) '-'; }
         p:nth-child(2):before { content: counter(p, disc); }
         p:nth-child(3):before { content: counter(p, circle); }
         p:nth-child(4):before { content: counter(p, square); }
         p:nth-child(5):before { content: counter(p); }
+        p:nth-child(6):before { content: var(--var) ':' counter(p); }
+        p:nth-child(7):before { content: counter(p) ':' var(--var); }
       </style>
+      <p></p>
+      <p></p>
       <p></p>
       <p></p>
       <p></p>
@@ -263,7 +267,7 @@ def test_counter_styles_1():
             ('p', 'Line', [
                 ('p::before', 'Inline', [
                     ('p::before', 'Text', counter)])])])
-        for counter in '--  •  ◦  ◾  -7'.split()])
+        for counter in '--  •  ◦  ◾  -7 Counter:-6 -5:Counter'.split()])
 
 
 @assert_no_logs

--- a/weasyprint/tests/test_variables.py
+++ b/weasyprint/tests/test_variables.py
@@ -11,6 +11,8 @@ import pytest
 from ..css.properties import KNOWN_PROPERTIES
 from .test_boxes import render_pages as parse
 
+SIDES = ('top', 'right', 'bottom', 'left')
+
 
 def test_variable_simple():
     page, = parse('''
@@ -81,6 +83,23 @@ def test_variable_chain():
     body, = html.children
     paragraph, = body.children
     assert paragraph.width == 10
+
+
+def test_variable_partial_1():
+    page, = parse('''
+      <style>
+        html { --var: 10px }
+        div { margin: 0 0 0 var(--var) }
+      </style>
+      <div></div>
+    ''')
+    html, = page.children
+    body, = html.children
+    div, = body.children
+    assert div.margin_top == 0
+    assert div.margin_right == 0
+    assert div.margin_bottom == 0
+    assert div.margin_left == 10
 
 
 def test_variable_initial():


### PR DESCRIPTION
Concatenation of `var()` functions in content declarations does not work. Currently, a variable in content declaration gets resolved correctly, however it disregards the remaining value of a content declaration. E.g.:

```
body { --var: 'Paragraph'; counter-reset: p }
p { counter-increment: p }
p:before { content: var(--var) ': ' counter(p); }
```
resolves `p:before` to `Paragraph`, and not to as you would expect; `Paragraph: 1`.

This bug is fixed in the changes in this PR.

Linked to my comment in #898.