### PR TITLE
include missing test data (#1247)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,8 @@ packages =
   weasyprint.formatting_structure
   weasyprint.layout
   weasyprint.tests
+  weasyprint.tests.test_draw
+  weasyprint.tests.test_layout
   weasyprint.tools
 zip_safe = false
 setup_requires = pytest-runner
@@ -71,6 +73,7 @@ console-scripts = weasyprint = weasyprint.__main__:main
 [options.package_data]
 weasyprint = VERSION
 weasyprint.tests = resources/*.*, resources/*/*
+weasyprint.tests.test_draw = results/*.*
 weasyprint.css = *.css
 
 [options.extras_require]


### PR DESCRIPTION
pypi tarballs are currently missing some resources required to run the test suite.