### PR TITLE
Add new dll names

### DIFF
--- a/weasyprint/fonts.py
+++ b/weasyprint/fonts.py
@@ -23,8 +23,8 @@ fontconfig = dlopen(
     ffi, 'fontconfig-1', 'fontconfig', 'libfontconfig', 'libfontconfig-1.dll',
     'libfontconfig.so.1', 'libfontconfig-1.dylib')
 pangoft2 = dlopen(
-    ffi, 'pangoft2-1.0-0', 'pangoft2-1.0', 'libpangoft2-1.0-0', 'libpangoft2-1.0.so',
-    'libpangoft2-1.0.dylib')
+    ffi, 'pangoft2-1.0-0', 'pangoft2-1.0', 'libpangoft2-1.0-0',
+    'libpangoft2-1.0.so', 'libpangoft2-1.0.dylib')
 
 ffi.cdef('''
     // FontConfig

--- a/weasyprint/fonts.py
+++ b/weasyprint/fonts.py
@@ -20,10 +20,10 @@ from .text import dlopen, ffi, get_font_features, gobject
 from .urls import FILESYSTEM_ENCODING, fetch
 
 fontconfig = dlopen(
-    ffi, 'fontconfig', 'libfontconfig', 'libfontconfig-1.dll',
+    ffi, 'fontconfig-1', 'fontconfig', 'libfontconfig', 'libfontconfig-1.dll',
     'libfontconfig.so.1', 'libfontconfig-1.dylib')
 pangoft2 = dlopen(
-    ffi, 'pangoft2-1.0', 'libpangoft2-1.0-0', 'libpangoft2-1.0.so',
+    ffi, 'pangoft2-1.0-0', 'pangoft2-1.0', 'libpangoft2-1.0-0', 'libpangoft2-1.0.so',
     'libpangoft2-1.0.dylib')
 
 ffi.cdef('''

--- a/weasyprint/text.py
+++ b/weasyprint/text.py
@@ -315,12 +315,13 @@ def dlopen(ffi, *names):
     return ffi.dlopen(names[0])  # pragma: no cover
 
 
-gobject = dlopen(ffi, 'gobject-2.0-0','gobject-2.0', 'libgobject-2.0-0', 'libgobject-2.0.so.0',
-                 'libgobject-2.0.dylib')
-pango = dlopen(ffi, 'pango-1.0-0', 'pango-1.0', 'libpango-1.0-0', 'libpango-1.0.so.0',
-               'libpango-1.0.dylib')
-harfbuzz = dlopen(ffi, 'harfbuzz', 'harfbuzz-0.0', 'libharfbuzz-0', 'libharfbuzz.so.0',
-                  'libharfbuzz.so.0', 'libharfbuzz.0.dylib')
+gobject = dlopen(ffi, 'gobject-2.0-0', 'gobject-2.0', 'libgobject-2.0-0',
+                 'libgobject-2.0.so.0', 'libgobject-2.0.dylib')
+pango = dlopen(ffi, 'pango-1.0-0', 'pango-1.0', 'libpango-1.0-0',
+               'libpango-1.0.so.0', 'libpango-1.0.dylib')
+harfbuzz = dlopen(
+    ffi, 'harfbuzz', 'harfbuzz-0.0', 'libharfbuzz-0',
+    'libharfbuzz.so.0', 'libharfbuzz.so.0', 'libharfbuzz.0.dylib')
 
 gobject.g_type_init()
 

--- a/weasyprint/text.py
+++ b/weasyprint/text.py
@@ -315,11 +315,11 @@ def dlopen(ffi, *names):
     return ffi.dlopen(names[0])  # pragma: no cover
 
 
-gobject = dlopen(ffi, 'gobject-2.0', 'libgobject-2.0-0', 'libgobject-2.0.so.0',
+gobject = dlopen(ffi, 'gobject-2.0-0','gobject-2.0', 'libgobject-2.0-0', 'libgobject-2.0.so.0',
                  'libgobject-2.0.dylib')
-pango = dlopen(ffi, 'pango-1.0', 'libpango-1.0-0', 'libpango-1.0.so.0',
+pango = dlopen(ffi, 'pango-1.0-0', 'pango-1.0', 'libpango-1.0-0', 'libpango-1.0.so.0',
                'libpango-1.0.dylib')
-harfbuzz = dlopen(ffi, 'harfbuzz-0.0', 'libharfbuzz-0', 'libharfbuzz.so.0',
+harfbuzz = dlopen(ffi, 'harfbuzz', 'harfbuzz-0.0', 'libharfbuzz-0', 'libharfbuzz.so.0',
                   'libharfbuzz.so.0', 'libharfbuzz.0.dylib')
 
 gobject.g_type_init()


### PR DESCRIPTION
When building Pango with meson I get the following `DLL` files as output.
So adding it.
If interested I will add [this](https://github.com/naveen521kk/pango-build) to docs for installing on Windows, at least would help for someone. Or I myself, would make a [`chocolatey`](https://chocolatey.org/) package if needed, but that need's to be there in docs, for choco package to be done.