### PR TITLE
docs: fix simple typo, wether -> weather

### DIFF
--- a/weasyprint/layout/blocks.py
+++ b/weasyprint/layout/blocks.py
@@ -698,7 +698,7 @@ def collapse_margin(adjoining_margins):
 
 
 def establishes_formatting_context(box):
-    """Return wether a box establishes a block formatting context.
+    """Return weather a box establishes a block formatting context.
 
     See http://www.w3.org/TR/CSS2/visuren.html#block-formatting
 


### PR DESCRIPTION
There is a small typo in weasyprint/layout/blocks.py.

Should read `weather` rather than `wether`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md