### PR TITLE
SVG: Allow stroke-dasharray:none

### DIFF
--- a/weasyprint/svg/__init__.py
+++ b/weasyprint/svg/__init__.py
@@ -573,7 +573,7 @@ class SVG:
 
         # Apply dash array
         dash_array = tuple(
-            float(value) for value in
+            -1 if value == 'none' else float(value) for value in
             normalize(node.get('stroke-dasharray')).split())
         dash_condition = (
             dash_array and


### PR DESCRIPTION
Fixes a crash when a SVG contains `style="stroke-dasharray:none"`.
Also see SVG spec on this: https://www.w3.org/TR/SVG11/painting.html#StrokeDasharrayProperty

Not sure this is the most elegant way of fixing it, but I guess you get the idea 😄 