### PR TITLE
Fix #1412: pump pillow version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
   'tinycss2 >=1.0.0',
   'cssselect2 >=0.1',
   'Pyphen >=0.9.1',
-  'Pillow >=4.0.0',
+  'Pillow >=8.3.1',
   'fonttools[woff] >=4.0.0',
 ]
 classifiers = [


### PR DESCRIPTION
As test shown at https://github.com/Kozea/WeasyPrint/issues/1412 the version 7.0.0 of pillow is not enough to run weasyprint v53 and the documentation says that 4.0.0 should be enough.

I am pumping to the most recent of v8 family released on Jul 6, 2021.