### PR TITLE
Fix marker-start being drawn on mid vertices

### DIFF
--- a/weasyprint/svg/__init__.py
+++ b/weasyprint/svg/__init__.py
@@ -572,7 +572,7 @@ class SVG:
                 self.draw_node(child, font_size, fill_stroke)
                 self.stream.pop_state()
 
-        position = 'mid' if angles else 'start'
+            position = 'mid' if angles else 'start'
 
     @staticmethod
     def get_paint(value):


### PR DESCRIPTION
Expected behaviour (Firefox 91):
![image](https://user-images.githubusercontent.com/1201065/131603326-ef674f05-d791-429c-baed-2f96f580b376.png)

WeasyPrint 53.2:
![image](https://user-images.githubusercontent.com/1201065/131603310-c3aff200-86d2-4e83-b1dd-0b61b7a64212.png)

WeasyPrint with fix:
![image](https://user-images.githubusercontent.com/1201065/131603453-7bf0fd17-4fd2-45f0-8bb2-4091d78f0e0a.png)

Example:
```html
<svg viewBox="0 0 200 400" width="200">
  <g>
    <defs>
      <marker
        id="arrow"
        viewBox="0 0 10 10"
        refX="0"
        refY="5"
        markerWidth="4"
        markerHeight="4"
        orient="auto"
        fill="red"
        stroke="none"
      >
        <path d="M 0 0 L 10 5 L 0 10 z"></path>
      </marker>
    </defs>
    <path
      d="M 10 100 l 50, 10 l 50 0 l 50 -20"
      fill="none"
      stroke="black"
      stroke-width="2"
      marker-start="url(#arrow)"
    />
    <path
      d="M 10 200 l 50, 10 l 50 0 l 50 -20"
      fill="none"
      stroke="black"
      stroke-width="2"
      marker-end="url(#arrow)"
    />
    <path
      d="M 10 300 l 50, 10 l 50 0 l 50 -20"
      fill="none"
      stroke="black"
      stroke-width="2"
      marker-mid="url(#arrow)"
    />
  </g>
</svg>
```