### PR TITLE
Bump html5lib version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ license = {file = 'LICENSE'}
 dependencies = [
   'pydyf >=0.0.3',
   'cffi >=0.6',
-  'html5lib >=1.0.1',
+  'html5lib >=1.1',
   'tinycss2 >=1.0.0',
   'cssselect2 >=0.1',
   'Pyphen >=0.9.1',


### PR DESCRIPTION
The previus version of html5lib throw a llitle warning

    from weasyprint import HTML, default_url_fetcher
  File "/home/pablo/.pyenv/versions/3.8.5/envs/myproject/lib/python3.8/site-packages/weasyprint/__init__.py", line 16, in <module>
    import html5lib
  File "/home/pablo/.pyenv/versions/3.8.5/envs/myproject/lib/python3.8/site-packages/html5lib/__init__.py", line 25, in <module>
    from .html5parser import HTMLParser, parse, parseFragment
  File "/home/pablo/.pyenv/versions/3.8.5/envs/myproject/lib/python3.8/site-packages/html5lib/html5parser.py", line 8, in <module>
    from . import _tokenizer
  File "/home/pablo/.pyenv/versions/3.8.5/envs/myproject/lib/python3.8/site-packages/html5lib/_tokenizer.py", line 16, in <module>
    from ._trie import Trie
  File "/home/pablo/.pyenv/versions/3.8.5/envs/myproject/lib/python3.8/site-packages/html5lib/_trie/__init__.py", line 3, in <module>
    from .py import Trie as PyTrie
  File "/home/pablo/.pyenv/versions/3.8.5/envs/myproject/lib/python3.8/site-packages/html5lib/_trie/py.py", line 6, in <module>
    from ._base import Trie as ABCTrie
  File "/home/pablo/.pyenv/versions/3.8.5/envs/myproject/lib/python3.8/site-packages/html5lib/_trie/_base.py", line 3, in <module>
    from collections import Mapping
  File "<frozen importlib._bootstrap>", line 1039, in _handle_fromlist
  File "/home/pablo/.pyenv/versions/3.8.5/lib/python3.8/collections/__init__.py", line 49, in __getattr__
    warnings.warn("Using or importing the ABCs from 'collections' instead "
DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working