### PR TITLE
Make sure url is relative before joining base_url

### DIFF
--- a/weasyprint/css/utils.py
+++ b/weasyprint/css/utils.py
@@ -10,6 +10,7 @@
 import functools
 import math
 from urllib.parse import unquote, urljoin
+from pathlib import Path
 
 from tinycss2.color3 import parse_color
 
@@ -145,6 +146,10 @@ def safe_urljoin(base_url, url):
     if url_is_absolute(url):
         return iri_to_uri(url)
     elif base_url:
+        # Make sure url is relative before joining base_url
+        url_path = Path(url)
+        if url_path.is_absolute():
+            url = str(url_path.relative_to(url_path.root))
         return iri_to_uri(urljoin(base_url, url))
     else:
         raise InvalidValues(


### PR DESCRIPTION
I have a nuxt project that results in a pdf missing fonts.

The project that produces css like this:
```
@font-face {
  font-family: ForkAwesome;
  src: url(/_nuxt/fonts/forkawesome-webfont.2668138.eot);
  src: url(/_nuxt/fonts/forkawesome-webfont.2668138.eot?#iefix&v=1.2.0)
      format("embedded-opentype"),
    url(/_nuxt/fonts/forkawesome-webfont.fafb863.woff2) format("woff2"),
    url(/_nuxt/fonts/forkawesome-webfont.2350c61.woff) format("woff"),
    url(/_nuxt/fonts/forkawesome-webfont.94d78a2.ttf) format("truetype"),
    url(/_nuxt/img/forkawesome-webfont.86fe294.svg#forkawesomeregular)
      format("svg");
  font-weight: 400;
  font-style: normal;
  font-display: block;
}
```

The URLs are absolute with root being the `./dist` directory generated by nuxt.

```
weasyprint.CSS(filename='./dist/_nuxt/css/25a755f.css', base_url='./dist', font_config=font_config)
```

would result in 
```
urljoin('/path/to/dist/', '/_nuxt/fonts/forkawesome-webfont.fafb863.woff2')
```
which would return `/_nuxt/fonts/forkawesome-webfont.fafb863.woff2'` rather than joining with the base_url.

This MR converts absolute path URLs to relative: `_nuxt/fonts/forkawesome-webfont.fafb863.woff2` before calling joinurl.