### PR TITLE
Skip font processing based on hash of source

### DIFF
--- a/weasyprint/css/__init__.py
+++ b/weasyprint/css/__init__.py
@@ -1012,7 +1012,7 @@ def preprocess_stylesheet(device_media_type, base_url, stylesheet_rules,
                 if font_config is not None:
                     font_filename = font_config.add_font_face(
                         rule_descriptors, url_fetcher)
-                    if font_filename:
+                    if font_filename and font_filename not in fonts:
                         fonts.append(font_filename)
 
         elif (rule.type == 'at-rule' and


### PR DESCRIPTION
A lot of my runtime was taken up by decompressing `woff2` files that had previously been loaded.

This change writes the result of `fetch(url_fetcher, url)` to a file named by its `sha256` hash, skipping based on whether the file already exists.

It does the same with the fontconfig xml, I don't know enough about fontconfig to know if this is completely unnecessary.

Replaces #1495