### PR TITLE
Support "overflow-wrap: anywhere"

### DIFF
--- a/weasyprint/css/validation/properties.py
+++ b/weasyprint/css/validation/properties.py
@@ -1176,7 +1176,7 @@ def white_space(keyword):
 @single_keyword
 def overflow_wrap(keyword):
     """``overflow-wrap`` property validation."""
-    return keyword in ('normal', 'break-word')
+    return keyword in ('anywhere', 'normal', 'break-word')
 
 
 @property()

--- a/weasyprint/text/line_break.py
+++ b/weasyprint/text/line_break.py
@@ -536,7 +536,8 @@ def split_first_line(text, style, context, max_width, justification_spacing,
     first_line_width, _ = line_size(first_line, style)
     space = max_width - first_line_width
     # If we can break words and the first line is too long
-    if not minimum and overflow_wrap == 'break-word' and space < 0:
+    if space < 0 and (overflow_wrap == 'anywhere' or
+                      (overflow_wrap == 'break-word' and not minimum)):
         # Is it really OK to remove hyphenation for word-break ?
         hyphenated = False
         # TODO: Modify code to preserve W3C condition:


### PR DESCRIPTION
This supports the `overflow-wrap` value `anywhere`: `anywhere` is like `break-word`, but the soft breaks it allows *are* considered when calculating min-content intrinsic sizes.

This can help alleviate the problems identified in https://github.com/Kozea/WeasyPrint/issues/1153#issuecomment-982235394, but obviously doesn't close that issue.

I'm a little unsure on the test: if you have preferred ways to test this behavior, feel free to remove these tests. (Additionally, the `break-word` and `normal` tests would *seem* as though they should be 120px wide, not 100, but I can't figure out why they have their current values: I'd be interested in thoughts there.