### PR TITLE
fix #1007 Make 'inherit' value work correctly for shorthand properties

### DIFF
--- a/tests/test_css_validation.py
+++ b/tests/test_css_validation.py
@@ -132,6 +132,11 @@ def test_spacing_invalid(rule):
     ('text-decoration-line: overline', {'text_decoration_line': {'overline'}}),
     ('text-decoration-line: overline blink line-through', {
         'text_decoration_line': {'blink', 'line-through', 'overline'}}),
+    ('text-decoration: none', {
+        'text_decoration_line': 'none',
+        'text_decoration_color': 'currentColor',
+        'text_decoration_style': 'solid'}),
+    ('text-decoration: inherit', { 'text_decoration': 'inherit'}),
 ))
 def test_decoration_line(rule, result):
     assert expand_to_dict(rule) == result

--- a/weasyprint/css/validation/expanders.py
+++ b/weasyprint/css/validation/expanders.py
@@ -357,7 +357,11 @@ def expand_text_decoration(base_url, name, tokens):
 
     for token in tokens:
         keyword = get_keyword(token)
-        if keyword in (
+
+        if keyword == 'inherit':
+            yield 'text_decoration', tokens[0].lower_value
+            return
+        elif keyword in (
                 'none', 'underline', 'overline', 'line-through', 'blink'):
             text_decoration_line.add(keyword)
         elif keyword in ('solid', 'double', 'dotted', 'dashed', 'wavy'):


### PR DESCRIPTION
* skip shorthand expansion for 'inherit' tokens, hereby applying parent styles

This is my first contribution to WeasyPrint - I am not sure if this actually fixes the issue or just makes the error message go away.

