### PR TITLE
Handle 'inherit' value for shorthand properties

### DIFF
--- a/tests/test_css_validation.py
+++ b/tests/test_css_validation.py
@@ -1104,6 +1104,7 @@ def test_page_break_invalid(rule):
 @assert_no_logs
 @pytest.mark.parametrize('rule, result', (
     ('page-break-inside: avoid', {'break_inside': 'avoid'}),
+    ('page-break-inside: inherit', {'break_inside': 'inherit'}),
 ))
 def test_page_break_inside(rule, result):
     assert expand_to_dict(rule) == result

--- a/tests/test_css_validation.py
+++ b/tests/test_css_validation.py
@@ -1076,6 +1076,8 @@ def test_function_symbols(rule):
 @pytest.mark.parametrize('rule, result', (
     ('page-break-after: left', {'break_after': 'left'}),
     ('page-break-before: always', {'break_before': 'page'}),
+    ('page-break-after: inherit', {'break_after': 'inherit'}),
+    ('page-break-before: inherit', {'break_before': 'inherit'}),
 ))
 def test_page_break(rule, result):
     assert expand_to_dict(rule) == result

--- a/tests/test_css_validation.py
+++ b/tests/test_css_validation.py
@@ -1049,6 +1049,10 @@ def test_flex_invalid(rule):
         'flex_direction': 'row',
         'flex_wrap': 'wrap',
     }),
+    ('flex-flow: inherit', {
+        'flex_direction': 'inherit',
+        'flex_wrap': 'inherit',
+    }),
 ))
 def test_flex_flow(rule, result):
     assert expand_to_dict(rule) == result

--- a/tests/test_css_validation.py
+++ b/tests/test_css_validation.py
@@ -864,6 +864,8 @@ def test_overflow_wrap():
         'overflow_wrap': 'normal'}
     assert expand_to_dict('overflow-wrap: break-word') == {
         'overflow_wrap': 'break-word'}
+    assert expand_to_dict('overflow-wrap: inherit') == {
+        'overflow_wrap': 'inherit'}
     assert_invalid('overflow-wrap: none')
     assert_invalid('overflow-wrap: normal, break-word')
 
@@ -874,6 +876,8 @@ def test_expand_word_wrap():
         'overflow_wrap': 'normal'}
     assert expand_to_dict('word-wrap: break-word') == {
         'overflow_wrap': 'break-word'}
+    assert expand_to_dict('word-wrap: inherit') == {
+        'overflow_wrap': 'inherit'}
     assert_invalid('word-wrap: none')
     assert_invalid('word-wrap: normal, break-word')
 

--- a/tests/test_css_validation.py
+++ b/tests/test_css_validation.py
@@ -1017,6 +1017,11 @@ def test_radial_gradient():
         'flex_shrink': 1,
         'flex_basis': 'auto',
     }),
+    ('flex: inherit', {
+        'flex_grow': 'inherit',
+        'flex_shrink': 'inherit',
+        'flex_basis': 'inherit',
+    }),
 ))
 def test_flex(rule, result):
     assert expand_to_dict(rule) == result

--- a/tests/test_css_validation.py
+++ b/tests/test_css_validation.py
@@ -615,6 +615,12 @@ def test_expand_background_position():
         'border_bottom_right_radius': ((3, '%'), (3, '%')),
         'border_bottom_left_radius': ((4, 'rem'), (4, 'rem')),
     }),
+    ('border-radius: inherit', {
+        'border_top_left_radius': 'inherit',
+        'border_top_right_radius': 'inherit',
+        'border_bottom_right_radius': 'inherit',
+        'border_bottom_left_radius': 'inherit',
+    }),
 ))
 def test_expand_border_radius(rule, result):
     assert expand_to_dict(rule) == result
@@ -625,6 +631,9 @@ def test_expand_border_radius(rule, result):
     ('border-radius: 1px 1px 1px 1px 1px', '1 to 4 token'),
     ('border-radius: 1px 1px 1px 1px 1px / 1px', '1 to 4 token'),
     ('border-radius: 1px / 1px / 1px', 'only one "/"'),
+    ('border-radius: 12deg', 'invalid'),
+    ('border-radius: 1px 1px 1px 12deg', 'invalid'),
+    ('border-radius: super', 'invalid'),
     ('border-radius: 1px, 1px', 'invalid'),
     ('border-radius: 1px /', 'value after "/"'),
 ))

--- a/tests/test_css_validation.py
+++ b/tests/test_css_validation.py
@@ -10,6 +10,7 @@ import math
 
 import pytest
 import tinycss2
+from tinycss2.color3 import parse_color
 from weasyprint.css import preprocess_declarations
 from weasyprint.css.computed_values import ZERO_PIXELS
 from weasyprint.css.properties import INITIAL_VALUES
@@ -153,15 +154,15 @@ def test_decoration_style(rule, result):
     ('text-decoration: none', {'text_decoration_line': 'none'}),
     ('text-decoration: overline', {'text_decoration_line': {'overline'}}),
     ('text-decoration: overline blink line-through', {
-        'text_decoration_line': {'blink', 'line-through', 'overline'}}),
-    ('text-decoration: red', {'text_decoration_color': (1, 0, 0, 1)}),
+        'text_decoration_line': {'blink', 'line-through', 'overline'},
+    }),
+    ('text-decoration: red', {'text_decoration_color': parse_color('red')}),
+    ('text-decoration: inherit', {
+        f'text_decoration_{key}': 'inherit'
+        for key in ('color', 'line', 'style')}),
 ))
 def test_decoration(rule, result):
-    default = {
-        key: value for key, value in INITIAL_VALUES.items()
-        if key.startswith('text_decoration_')}
-    real_result = {**default, **result}
-    assert expand_to_dict(rule) == real_result
+    assert expand_to_dict(rule) == result
 
 
 @assert_no_logs

--- a/tests/test_css_validation.py
+++ b/tests/test_css_validation.py
@@ -1172,3 +1172,30 @@ def test_line_clamp(rule, result):
 ))
 def test_line_clamp_invalid(rule, reason):
     assert_invalid(rule, reason)
+
+
+@assert_no_logs
+@pytest.mark.parametrize('rule, result', (
+    ('text-align: start', {
+        'text_align_all': 'start', 'text_align_last': 'start'}),
+    ('text-align: right', {
+        'text_align_all': 'right', 'text_align_last': 'right'}),
+    ('text-align: justify', {
+        'text_align_all': 'justify', 'text_align_last': 'start'}),
+    ('text-align: justify-all', {
+        'text_align_all': 'justify', 'text_align_last': 'justify'}),
+    ('text-align: inherit', {
+        'text_align_all': 'inherit', 'text_align_last': 'inherit'}),
+))
+def test_text_align(rule, result):
+    assert expand_to_dict(rule) == result
+
+
+@assert_no_logs
+@pytest.mark.parametrize('rule, reason', (
+    ('text-align: none', 'invalid'),
+    ('text-align: start end', 'invalid'),
+    ('text-align: 1', 'invalid'),
+))
+def test_text_align_invalid(rule, reason):
+    assert_invalid(rule, reason)

--- a/tests/test_css_validation.py
+++ b/tests/test_css_validation.py
@@ -1146,6 +1146,9 @@ def test_columns_invalid(rule, reason):
     ('line-clamp: 3 "…"', {
         'max_lines': 3, 'continue': 'discard',
         'block_ellipsis': ('string', '…')}),
+    ('line-clamp: inherit', {
+        'max_lines': 'inherit', 'continue': 'inherit',
+        'block_ellipsis': 'inherit'}),
 ))
 def test_line_clamp(rule, result):
     assert expand_to_dict(rule) == result

--- a/weasyprint/css/validation/expanders.py
+++ b/weasyprint/css/validation/expanders.py
@@ -27,11 +27,6 @@ from .properties import (
 EXPANDERS = {}
 
 
-class AutoFakeToken:
-    type = 'ident'
-    lower_value = 'auto'
-
-
 def expander(property_name):
     """Decorator adding a function to the ``EXPANDERS``."""
     def expander_decorator(function):
@@ -389,9 +384,7 @@ def expand_text_decoration(name, tokens):
         yield '-style', text_decoration_style
 
 
-@expander('page-break-after')
-@expander('page-break-before')
-def expand_page_break_before_after(base_url, name, tokens):
+def expand_page_break_before_after(name, tokens):
     """Expand legacy ``page-break-before`` and ``page-break-after`` properties.
 
     See https://www.w3.org/TR/css-break-3/#page-break-properties
@@ -400,11 +393,35 @@ def expand_page_break_before_after(base_url, name, tokens):
     keyword = get_single_keyword(tokens)
     new_name = name.split('-', 1)[1]
     if keyword in ('auto', 'left', 'right', 'avoid'):
-        yield new_name, keyword
+        yield new_name, tokens
     elif keyword == 'always':
-        yield new_name, 'page'
+        token = IdentToken(
+            tokens[0].source_line, tokens[0].source_column, 'page')
+        yield new_name, [token]
     else:
         raise InvalidValues
+
+
+@expander('page-break-after')
+@generic_expander('break-after')
+def expand_page_break_after(name, tokens):
+    """Expand legacy ``page-break-after`` property.
+
+    See https://www.w3.org/TR/css-break-3/#page-break-properties
+
+    """
+    return expand_page_break_before_after(name, tokens)
+
+
+@expander('page-break-before')
+@generic_expander('break-before')
+def expand_page_break_before(name, tokens):
+    """Expand legacy ``page-break-before`` property.
+
+    See https://www.w3.org/TR/css-break-3/#page-break-properties
+
+    """
+    return expand_page_break_before_after(name, tokens)
 
 
 @expander('page-break-inside')

--- a/weasyprint/css/validation/expanders.py
+++ b/weasyprint/css/validation/expanders.py
@@ -526,17 +526,19 @@ def expand_font(name, tokens):
 
 
 @expander('word-wrap')
-def expand_word_wrap(base_url, name, tokens):
+@generic_expander('overflow-wrap')
+def expand_word_wrap(name, tokens):
     """Expand the ``word-wrap`` legacy property.
 
-    See http://http://www.w3.org/TR/css3-text/#overflow-wrap
+    See http://www.w3.org/TR/css3-text/#overflow-wrap
 
     """
     keyword = overflow_wrap(tokens)
     if keyword is None:
         raise InvalidValues
 
-    yield 'overflow-wrap', keyword
+    if len(tokens) == 1:
+        yield 'overflow-wrap', tokens
 
 
 @expander('flex')

--- a/weasyprint/css/validation/expanders.py
+++ b/weasyprint/css/validation/expanders.py
@@ -610,26 +610,27 @@ def expand_flex(base_url, name, tokens):
 
 
 @expander('flex-flow')
-def expand_flex_flow(base_url, name, tokens):
+@generic_expander('flex-direction', 'flex-wrap')
+def expand_flex_flow(name, tokens):
     """Expand the ``flex-flow`` property."""
     if len(tokens) == 2:
         for sorted_tokens in tokens, tokens[::-1]:
             direction = flex_direction([sorted_tokens[0]])
             wrap = flex_wrap([sorted_tokens[1]])
             if direction and wrap:
-                yield 'flex-direction', direction
-                yield 'flex-wrap', wrap
+                yield 'flex-direction', [sorted_tokens[0]]
+                yield 'flex-wrap', [sorted_tokens[1]]
                 break
         else:
             raise InvalidValues
     elif len(tokens) == 1:
         direction = flex_direction([tokens[0]])
         if direction:
-            yield 'flex-direction', direction
+            yield 'flex-direction', [tokens[0]]
         else:
             wrap = flex_wrap([tokens[0]])
             if wrap:
-                yield 'flex-wrap', wrap
+                yield 'flex-wrap', [tokens[0]]
             else:
                 raise InvalidValues
     else:

--- a/weasyprint/css/validation/expanders.py
+++ b/weasyprint/css/validation/expanders.py
@@ -637,18 +637,29 @@ def expand_flex_flow(base_url, name, tokens):
 
 
 @expander('line-clamp')
-def expand_line_clamp(base_url, name, tokens):
+@generic_expander('max-lines', 'continue', 'block-ellipsis')
+def expand_line_clamp(name, tokens):
     """Expand the ``line-clamp`` property."""
     if len(tokens) == 1:
         keyword = get_single_keyword(tokens)
         if keyword == 'none':
-            yield 'max_lines', 'none'
-            yield 'continue', 'auto'
-            yield 'block-ellipsis', 'none'
+            none_token = IdentToken(
+                tokens[0].source_line, tokens[0].source_column, 'none')
+            auto_token = IdentToken(
+                tokens[0].source_line, tokens[0].source_column, 'auto')
+            discard_token = IdentToken(
+                tokens[0].source_line, tokens[0].source_column, 'auto')
+            yield 'max-lines', [none_token]
+            yield 'continue', [auto_token]
+            yield 'block-ellipsis', [none_token]
         elif tokens[0].type == 'number' and tokens[0].int_value is not None:
-            yield 'max_lines', tokens[0].int_value
-            yield 'continue', 'discard'
-            yield 'block-ellipsis', 'auto'
+            auto_token = IdentToken(
+                tokens[0].source_line, tokens[0].source_column, 'auto')
+            discard_token = IdentToken(
+                tokens[0].source_line, tokens[0].source_column, 'discard')
+            yield 'max-lines', [tokens[0]]
+            yield 'continue', [discard_token]
+            yield 'block-ellipsis', [auto_token]
         else:
             raise InvalidValues
     elif len(tokens) == 2:
@@ -656,9 +667,11 @@ def expand_line_clamp(base_url, name, tokens):
             max_lines = tokens[0].int_value
             ellipsis = block_ellipsis([tokens[1]])
             if max_lines and ellipsis is not None:
-                yield 'max_lines', tokens[0].value
-                yield 'continue', 'discard'
-                yield 'block-ellipsis', ellipsis
+                discard_token = IdentToken(
+                    tokens[0].source_line, tokens[0].source_column, 'discard')
+                yield 'max-lines', [tokens[0]]
+                yield 'continue', [discard_token]
+                yield 'block-ellipsis', [tokens[1]]
             else:
                 raise InvalidValues
         else:

--- a/weasyprint/css/validation/expanders.py
+++ b/weasyprint/css/validation/expanders.py
@@ -690,13 +690,22 @@ def expand_line_clamp(name, tokens):
 
 
 @expander('text-align')
-def expand_text_align(base_url, name, tokens):
+@generic_expander('-all', '-last')
+def expand_text_align(name, tokens):
     """Expand the ``text-align`` property."""
     if len(tokens) == 1:
         keyword = get_single_keyword(tokens)
-        align_all = 'justify' if keyword == 'justify-all' else keyword
-        yield 'text_align_all', align_all
-        align_last = 'start' if keyword == 'justify' else align_all
-        yield 'text_align_last', align_last
+        if keyword == 'justify-all':
+            line, column = tokens[0].source_line, tokens[0].source_column
+            align_all = IdentToken(line, column, 'justify')
+        else:
+            align_all = tokens[0]
+        yield '-all', [align_all]
+        if keyword == 'justify':
+            line, column = tokens[0].source_line, tokens[0].source_column
+            align_last = IdentToken(line, column, 'start')
+        else:
+            align_last = align_all
+        yield '-last', [align_last]
     else:
         raise InvalidValues

--- a/weasyprint/css/validation/expanders.py
+++ b/weasyprint/css/validation/expanders.py
@@ -8,6 +8,7 @@
 
 import functools
 
+from tinycss2.ast import IdentToken
 from tinycss2.color3 import parse_color
 
 from ..properties import INITIAL_VALUES, Dimension
@@ -437,7 +438,9 @@ def expand_columns(name, tokens):
         yield name, [token]
     if len(tokens) == 1:
         name = 'column-width' if name == 'column-count' else 'column-count'
-        yield name, [AutoFakeToken()]
+        token = IdentToken(
+            tokens[0].source_line, tokens[0].source_column, 'auto')
+        yield name, [token]
 
 
 @expander('font-variant')

--- a/weasyprint/css/validation/expanders.py
+++ b/weasyprint/css/validation/expanders.py
@@ -426,7 +426,8 @@ def expand_page_break_before(name, tokens):
 
 
 @expander('page-break-inside')
-def expand_page_break_inside(base_url, name, tokens):
+@generic_expander('break-inside')
+def expand_page_break_inside(name, tokens):
     """Expand the legacy ``page-break-inside`` property.
 
     See https://www.w3.org/TR/css-break-3/#page-break-properties
@@ -434,7 +435,7 @@ def expand_page_break_inside(base_url, name, tokens):
     """
     keyword = get_single_keyword(tokens)
     if keyword in ('auto', 'avoid'):
-        yield 'break-inside', keyword
+        yield 'break-inside', tokens
     else:
         raise InvalidValues
 


### PR DESCRIPTION
Fix #1007.

The first commit b18b67a fixes `inherit` for `text-decoration`.

Using `@generic_expander` is a good idea, because it handles a lot of things, including `inherit` and `initial` automatically, and could handle other values like [`unset`](https://www.w3.org/TR/css-cascade-4/#inherit-initial) and [`revert`](https://www.w3.org/TR/css-cascade-4/#default). Using `@generic_expander` requires to yield tokens, not computed values, but that’s a fair trade-off and we should use it everywhere it’s possible.

We can then test the `inherit` value for all the expanders, as it’s now done for `text-decoration`.

If anyone (@ckepper?) is interested in updating this PR to handle other expanders, don’t hesitate to add a comment!

Here are the properties that aren’t / weren’t supported:

- [x] `text-decoration` (b18b67a)
- [x] `word-wrap` (#1525)
- [x] `page-break-after/before`
- [x] `border-radius`
- [x] `page-break-inside`
- [x] `line-clamp`
- [x] `flex-flow`
- [x] `flex`
- [x] `text-align`
