### PR TITLE
Improve tests’ speed

### DIFF
--- a/weasyprint/css/__init__.py
+++ b/weasyprint/css/__init__.py
@@ -1041,10 +1041,10 @@ def preprocess_stylesheet(device_media_type, base_url, stylesheet_rules,
                 'symbols': None,
                 'additive_symbols': None,
             }
-            rule_descriptors = dict(
-                preprocess_descriptors('counter-style', base_url, content))
+            rule_descriptors = preprocess_descriptors(
+                'counter-style', base_url, content)
 
-            for descriptor_name, descriptor_value in rule_descriptors.items():
+            for descriptor_name, descriptor_value in rule_descriptors:
                 counter[descriptor_name] = descriptor_value
 
             if counter['system'] is None:

--- a/weasyprint/css/counters.py
+++ b/weasyprint/css/counters.py
@@ -9,8 +9,6 @@
 
 """
 
-from copy import deepcopy
-
 from .utils import remove_whitespace
 
 
@@ -298,4 +296,5 @@ class CounterStyle(dict):
         return prefix + value + suffix
 
     def copy(self):
-        return CounterStyle(deepcopy(self))
+        # Values are dicts but they are never modified, no need to deepcopy
+        return CounterStyle(super().copy())

--- a/weasyprint/document.py
+++ b/weasyprint/document.py
@@ -1349,7 +1349,8 @@ class Document:
                     ttfont = TTFont(full_font, fontNumber=fonts[0].index)
                     options = subset.Options(
                         retain_gids=True, passthrough_tables=True,
-                        ignore_missing_glyphs=True, notdef_glyph=True)
+                        ignore_missing_glyphs=True, hinting=False)
+                    options.drop_tables += ['GSUB', 'GPOS']
                     subsetter = subset.Subsetter(options)
                     subsetter.populate(gids=cmap)
                     subsetter.subset(ttfont)


### PR DESCRIPTION
The goal of this pull request is to improve WeasyPrint’s speed, using tests for profiling. Tests are a good way to improve small documents’ rendering speed, as most of the unit tests render very small documents.

The main improvements of this pull request are:
- removed some font tables that are useless in PDF files, to save a small amount of file size but possibly a large amount of time (because fonts are subset, see #1457)
- avoid useless deep copy of page counters for each document

This pull request saves between 10% and 20% of the total time spent in tests.