### PR TITLE
Avoid invalid PDF operators when drawing SVG text

### DIFF
--- a/weasyprint/draw.py
+++ b/weasyprint/draw.py
@@ -10,7 +10,7 @@ import contextlib
 import operator
 from colorsys import hsv_to_rgb, rgb_to_hsv
 from io import BytesIO
-from math import ceil, floor, pi, sqrt, tan
+from math import ceil, cos, floor, pi, sin, sqrt, tan
 from xml.etree import ElementTree
 
 from PIL import Image
@@ -1031,8 +1031,11 @@ def draw_emojis(stream, font_size, x, y, emojis):
             stream.pop_state()
 
 
-def draw_first_line(stream, textbox, text_overflow, block_ellipsis, x, y):
+def draw_first_line(stream, textbox, text_overflow, block_ellipsis, x, y,
+                    angle=0):
     """Draw the given ``textbox`` line to the document ``stream``."""
+    from .document import Matrix
+
     pango.pango_layout_set_single_paragraph_mode(
         textbox.pango_layout.layout, True)
 
@@ -1083,7 +1086,11 @@ def draw_first_line(stream, textbox, text_overflow, block_ellipsis, x, y):
     while runs[-1].next != ffi.NULL:
         runs.append(runs[-1].next)
 
-    stream.text_matrix(font_size, 0, 0, -font_size, x, y)
+    matrix = Matrix(font_size, 0, 0, -font_size, x, y)
+    if angle:
+        matrix = Matrix(a=cos(angle), b=-sin(angle),
+                        c=sin(angle), d=cos(angle)) @ matrix
+    stream.text_matrix(*matrix.values)
     last_font = None
     string = ''
     fonts = stream.get_fonts()


### PR DESCRIPTION
This was causing display problems and warning messages in some PDF software.

## Example HTML
```html
<p>SVG with text:</p>
<svg width="300" height="50">
    <rect width="300" height="50" fill="none" stroke="red" />
    <text rotate="10" x="10" y="25" letter-spacing="3" font-size="30" font-family="Noto Sans">This is text</text>
</svg>
```

## Before

PDF X-Change Viewer[1] doesn't render SVG text:
![before-pdfxchange](https://user-images.githubusercontent.com/1201065/151292214-76724840-b3a7-443c-bef9-28c2ab03d5de.png)

Adobe Acrobat Reader DC [2] renders SVG text:
![before-adobe](https://user-images.githubusercontent.com/1201065/151292451-4e5f35e3-a15a-41b0-bfe7-9fe3c42a3342.png)
but displays this warning message after printing (printing to a virtual printer is sufficient):
![before-adobe-print](https://user-images.githubusercontent.com/1201065/151292494-2a5713f1-bf99-4d07-9cc7-cac92c513fc8.png)

## After
PDF X-Change Viewer renders SVG text:
![after-pdfxchange](https://user-images.githubusercontent.com/1201065/151292739-75c2b199-0549-449e-aeaf-69beca2bb42f.png)

Adobe Acrobat Reader DC now prints with no warning messages.

## Root cause

I managed to narrow this down to the PDF content stream that's being emitted for the SVG text. I used [pikepdf](https://pikepdf.readthedocs.io/en/latest/topics/content_streams.html) to parse it.

SVG text PDF content stream before (invalid operators marked with `**`):
```
BT []
**q []
**m [10, 25]
**cm [1, 0, 0, 1, 10, 25]
**cm [Decimal('0.984808'), Decimal('0.173648'), Decimal('-0.173648'), Decimal('0.984808'), 0, 0]
**cm [1, 0, 0, 1, -10, -25]
rg [0, 0, 0]
gs [pikepdf.Name("/a1.0")]
w [1]
J [0]
j [0]
M [4]
Tr [0]
Tm [30, 0, 0, -30, 10, 25]
Tf [pikepdf.Name("/JDIZPJ"), 1]
TJ [pikepdf.Array([ "7" ])]
**Q []
ET []
```
According to the [PDF specification](https://www.adobe.com/content/dam/acom/en/devnet/pdf/pdfs/pdf_reference_archives/PDFReference.pdf), "special graphics state" operators (q, Q, cm) and "path construction" operators (m) aren't permitted while a text object is being drawn. See page 134-135, Table 4.1 Operator categories, and Figure 4.1 Graphics objects.

PDF readers seem to be quite tolerant of invalid content streams in general, but apparently this was too much!

Content stream after:
```
BT []
rg [0, 0, 0]
gs [pikepdf.Name("/a1.0")]
w [1]
J [0]
j [0]
M [4]
Tr [0]
Tm [Decimal('29.544233'), Decimal('5.209445'), Decimal('5.209445'), Decimal('-29.544233'), 10, 25]
Tf [pikepdf.Name("/BBQVNM"), 1]
TJ [pikepdf.Array([ "7" ])]
ET []
```

[1] PDF-XChange Viewer 2.5 (Build 322.10) - https://www.tracker-software.com/product/pdf-xchange-viewer
[2] Adobe Acrobat Reader DC 2021.011.20039