### PR TITLE
fix svg image mem leak (in case of using image cache)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,7 +5,7 @@ Changelog
 Version 54.0
 ------------
 
-Not released yet.
+Released on 2022-01-08.
 
 This version also includes the changes from unstable b1 version listed
 below.

--- a/weasyprint/__init__.py
+++ b/weasyprint/__init__.py
@@ -16,7 +16,7 @@ import cssselect2
 import html5lib
 import tinycss2
 
-VERSION = __version__ = '54.0b1'
+VERSION = __version__ = '54.0'
 
 __all__ = [
     'HTML', 'CSS', 'Attachment', 'Document', 'Page', 'default_url_fetcher',

--- a/weasyprint/svg/__init__.py
+++ b/weasyprint/svg/__init__.py
@@ -338,27 +338,38 @@ class SVG:
     def draw(self, stream, concrete_width, concrete_height, base_url,
              url_fetcher, context):
         """Draw image on a stream."""
-        self.stream = stream
+        try:
+            self.stream = stream
 
-        self.concrete_width = concrete_width
-        self.concrete_height = concrete_height
-        self.normalized_diagonal = (
-            hypot(concrete_width, concrete_height) / sqrt(2))
+            self.concrete_width = concrete_width
+            self.concrete_height = concrete_height
+            self.normalized_diagonal = (
+                hypot(concrete_width, concrete_height) / sqrt(2))
 
-        viewbox = self.get_viewbox()
-        if viewbox:
-            self.inner_width, self.inner_height = viewbox[2], viewbox[3]
-        else:
-            self.inner_width = self.concrete_width
-            self.inner_height = self.concrete_height
-        self.inner_diagonal = (
-            hypot(self.inner_width, self.inner_height) / sqrt(2))
+            viewbox = self.get_viewbox()
+            if viewbox:
+                self.inner_width, self.inner_height = viewbox[2], viewbox[3]
+            else:
+                self.inner_width = self.concrete_width
+                self.inner_height = self.concrete_height
+            self.inner_diagonal = (
+                hypot(self.inner_width, self.inner_height) / sqrt(2))
 
-        self.base_url = base_url
-        self.url_fetcher = url_fetcher
-        self.context = context
+            self.base_url = base_url
+            self.url_fetcher = url_fetcher
+            self.context = context
 
-        self.draw_node(self.tree, size('12pt'))
+            self.draw_node(self.tree, size('12pt'))
+        finally:
+            del self.stream
+            del self.concrete_width
+            del self.concrete_height
+            del self.normalized_diagonal
+            del self.inner_width
+            del self.inner_height
+            del self.base_url
+            del self.url_fetcher
+            del self.context
 
     def draw_node(self, node, font_size, fill_stroke=True):
         """Draw a node."""


### PR DESCRIPTION
fix #1496 (maybe partial)

How to reproduce bug (dont forget download any big svg image file, see comments):

```python
import os
import tracemalloc
import gc

from weasyprint import HTML

imageCache = {}

def do_print():
    # not: image.svg is very big svg (>20MiB)
    ast = HTML(string="""<html>
    <body>
        <img src='./image.svg'></img>
    </body></html>""", base_url=os.getcwd()
    )
    ast.write_pdf(target="/tmp/result.pdf", 
        image_cache=imageCache
    )

print('burn start')
do_print()
print('burn done')

gc.collect()
print(f'(1) Please check current mem usage of process: {os.getpid()}')
input('PRESS ENTER TO START TEST')

tracemalloc.start()
gc.collect()
snapshot1 = tracemalloc.take_snapshot()

for i in range(3):
    print(f'print print #{i}')
    do_print()
    print(f'print print #{i}')

gc.collect()
snapshot2 = tracemalloc.take_snapshot()
top_stats = snapshot2.compare_to(snapshot1, 'lineno')
tracemalloc.stop()

print("[ Top 20 differences ]")
for stat in top_stats[:20]:
    print(stat)

print('test DONE')
print(f'(2) Please check current mem usage of process: {os.getpid()}')
input('DONE')
```