### PR TITLE
fix: don't output footnotes before their call sites

### DIFF
--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -158,6 +158,27 @@ def serialize(box_list):
             for box in box_list]
 
 
+def tree_position(box_list, matcher):
+    """Return a list identifying the first matching box's tree position.
+
+    Given a list of Boxes, this function returns a list containing the first
+    (depth-first) Box that the matcher function identifies. This list can then
+    be compared to another similarly-obtained list to assert that one Box is in
+    the document tree before or after another.
+
+    box_list: a list of Box objects, possibly PageBoxes
+    matcher: a function that takes a Box and returns truthy when it matches
+
+    """
+    for i, box in enumerate(box_list):
+        if matcher(box):
+            return [i]
+        elif hasattr(box, 'children'):
+            position = tree_position(box.children, matcher)
+            if position:
+                return [i] + position
+
+
 def _parse_base(html_content, base_url=BASE_URL):
     document = FakeHTML(string=html_content, base_url=base_url)
     counter_style = CounterStyle()

--- a/weasyprint/layout/__init__.py
+++ b/weasyprint/layout/__init__.py
@@ -323,23 +323,30 @@ class LayoutContext:
                 return store[name][previous_page][-1]
 
     def layout_footnote(self, footnote):
+        """Add a footnote to the layout for this page."""
         self.footnotes.remove(footnote)
         self.current_page_footnotes.append(footnote)
-        if self.current_footnote_area.height != 'auto':
-            self.page_bottom += self.current_footnote_area.margin_height()
-        self.current_footnote_area.children = self.current_page_footnotes
-        footnote_area = build.create_anonymous_boxes(
-            self.current_footnote_area.deepcopy())
-        footnote_area, _, _, _, _ = block_level_layout(
-            self, footnote_area, -inf, None, self.current_footnote_area.page,
-            True, [], [], [], False)
-        self.current_footnote_area.height = footnote_area.height
-        self.page_bottom -= footnote_area.margin_height()
+        self._update_footnote_area()
+
+    def unlayout_footnote(self, footnote):
+        """Remove a footnote from the layout and return it to the waitlist."""
+        self.footnotes.append(footnote)
+        if footnote in self.current_page_footnotes:
+            self.current_page_footnotes.remove(footnote)
+        else:
+            self.reported_footnotes.remove(footnote)
+        self._update_footnote_area()
 
     def report_footnote(self, footnote):
+        """Mark a footnote as being moved to the next page."""
         self.current_page_footnotes.remove(footnote)
         self.reported_footnotes.append(footnote)
-        self.page_bottom += self.current_footnote_area.margin_height()
+        self._update_footnote_area()
+
+    def _update_footnote_area(self):
+        """Update the page bottom size and our footnote area height."""
+        if self.current_footnote_area.height != 'auto':
+            self.page_bottom += self.current_footnote_area.margin_height()
         self.current_footnote_area.children = self.current_page_footnotes
         if self.current_footnote_area.children:
             footnote_area = build.create_anonymous_boxes(

--- a/weasyprint/layout/table.py
+++ b/weasyprint/layout/table.py
@@ -301,7 +301,8 @@ def table_layout(context, table, bottom_space, skip_stack, containing_block,
                     page_break = block_level_page_break(previous_row, row)
                     if page_break == 'avoid':
                         earlier_page_break = find_earlier_page_break(
-                            new_group_children, absolute_boxes, fixed_boxes)
+                            context, new_group_children, absolute_boxes,
+                            fixed_boxes)
                         if earlier_page_break:
                             new_group_children, resume_at = earlier_page_break
                             break
@@ -390,7 +391,8 @@ def table_layout(context, table, bottom_space, skip_stack, containing_block,
                     page_break = block_level_page_break(previous_group, group)
                     if page_break == 'avoid':
                         earlier_page_break = find_earlier_page_break(
-                            new_table_children, absolute_boxes, fixed_boxes)
+                            context, new_table_children, absolute_boxes,
+                            fixed_boxes)
                         if earlier_page_break is not None:
                             new_table_children, resume_at = earlier_page_break
                             break


### PR DESCRIPTION
If a footnote has been output but we then decide to cancel the line it was output on, we should cancel the output of the footnote itself.

This requires a bit of extra bookkeeping, so we know which footnotes are relevant, but otherwise largely works using the existing remove_placeholders code.

Includes a minor refactor of footnote area management in LayoutContext, and a new testing utility: `tree_position`.

Closes #1564.