### PR TITLE
fix: more robustly handle unlayout'ing a footnote

### DIFF
--- a/tests/layout/test_footnotes.py
+++ b/tests/layout/test_footnotes.py
@@ -343,6 +343,7 @@ def test_reported_footnote_3():
     ('p { break-inside: avoid }', '<br>e<br>f'),
     ('p { widows: 4 }', '<br>e<br>f'),
     ('p + p { break-before: avoid }', '</p><p>e<br>f'),
+    ('p + p { break-before: avoid }', '<span>y</span><span>z</span></p><p>e'),
 ))
 def test_footnote_area_after_call(css, tail):
     pages = render_pages('''

--- a/weasyprint/layout/__init__.py
+++ b/weasyprint/layout/__init__.py
@@ -330,12 +330,16 @@ class LayoutContext:
 
     def unlayout_footnote(self, footnote):
         """Remove a footnote from the layout and return it to the waitlist."""
-        self.footnotes.append(footnote)
-        if footnote in self.current_page_footnotes:
-            self.current_page_footnotes.remove(footnote)
-        else:
-            self.reported_footnotes.remove(footnote)
-        self._update_footnote_area()
+
+        # Handle unlayouting a footnote that hasn't been laid out yet (or has
+        # already been unlayout'd):
+        if footnote not in self.footnotes:
+            self.footnotes.append(footnote)
+            if footnote in self.current_page_footnotes:
+                self.current_page_footnotes.remove(footnote)
+            elif footnote in self.reported_footnotes:
+                self.reported_footnotes.remove(footnote)
+            self._update_footnote_area()
 
     def report_footnote(self, footnote):
         """Mark a footnote as being moved to the next page."""


### PR DESCRIPTION
This fixes a bug accidentally introduced in #1566, where we would try to unlayout a footnote that had not yet been laid out, if the algorithm decided that there would be insufficient space on a page before laying out a further footnote.

(The fix is to check to see whether we've actually laid it out yet - or, equivalently, put things back as if we haven't. Otherwise we get a ValueError from trying to remove from `self.reported_footnotes` and a duplicated entry in `self.footnotes`.)