### PR TITLE
perf: cache calculations for 'ch' and 'ex' units

### DIFF
--- a/weasyprint/css/__init__.py
+++ b/weasyprint/css/__init__.py
@@ -34,8 +34,8 @@ PSEUDO_ELEMENTS = (
     'footnote-call', 'footnote-marker')
 
 DEFAULT_CACHE = {
-    'length_ch': {},
-    'length_ex': {},
+    'ratio_ch': {},
+    'ratio_ex': {},
 }
 
 

--- a/weasyprint/css/__init__.py
+++ b/weasyprint/css/__init__.py
@@ -33,6 +33,11 @@ PSEUDO_ELEMENTS = (
     None, 'before', 'after', 'marker', 'first-line', 'first-letter',
     'footnote-call', 'footnote-marker')
 
+DEFAULT_CACHE = {
+    'length_ch': {},
+    'length_ex': {},
+}
+
 
 PageType = namedtuple('PageType', ['side', 'blank', 'first', 'index', 'name'])
 
@@ -600,6 +605,10 @@ class AnonymousStyle(dict):
         })
         self.parent_style = parent_style
         self.specified = self
+        if parent_style:
+            self.cache = parent_style.cache
+        else:
+            self.cache = DEFAULT_CACHE.copy()
 
     def copy(self):
         copy = AnonymousStyle(self.parent_style)
@@ -629,6 +638,10 @@ class ComputedStyle(dict):
         self.pseudo_type = pseudo_type
         self.root_style = root_style
         self.base_url = base_url
+        if parent_style:
+            self.cache = parent_style.cache
+        else:
+            self.cache = DEFAULT_CACHE.copy()
 
     def copy(self):
         copy = ComputedStyle(

--- a/weasyprint/layout/inline.py
+++ b/weasyprint/layout/inline.py
@@ -4,7 +4,9 @@ import unicodedata
 from math import inf
 
 from ..css import computed_from_cascaded
-from ..css.computed_values import ex_ratio, strut_layout
+from ..css.computed_values import length as computed_length
+from ..css.computed_values import strut_layout
+from ..css.properties import Dimension
 from ..formatting_structure import boxes
 from ..text.line_break import can_break_text, create_layout, split_first_line
 from .absolute import AbsolutePlaceholder, absolute_layout
@@ -1048,7 +1050,9 @@ def inline_box_verticality(box, top_bottom_subtrees, baseline_y):
         if vertical_align == 'baseline':
             child_baseline_y = baseline_y
         elif vertical_align == 'middle':
-            one_ex = box.style['font_size'] * ex_ratio(box.style)
+            one_ex = computed_length(
+                box.style, 'height', Dimension(1, 'em'),
+                box.style['font_size'], pixels_only=True)
             top = baseline_y - (one_ex + child.margin_height()) / 2
             child_baseline_y = top + child.baseline
         elif vertical_align == 'text-top':


### PR DESCRIPTION
I get a ~30% speedup from caching this calculation on a relatively large (~300 page) test document. We use a fair number of ch-based lengths, but not an absurd amount. Regardless, this seems to provide a significant speedup as measured by hyperfine:

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| Original | 67.992 ± 1.279 | 66.966 | 71.106 | 1.46 ± 0.04 |
| Cached | 46.707 ± 1.056 | 45.688 | 49.402 | 1.00 |

It wasn't immediately clear to me where a cache for these would be best, but this has it anchored at any style root rather than globally, as arguably the fonts might change between documents. (That said, actually handling `@font-face` fonts seems to be a TODO here at the moment anyway.)