### PR TITLE
fix: support position: absolute in footnotes

### DIFF
--- a/tests/draw/test_footnotes.py
+++ b/tests/draw/test_footnotes.py
@@ -132,3 +132,40 @@ def test_footnote_margin():
         }
     </style>
     <div>abc<span>d</span></div>''')
+
+
+@assert_no_logs
+def test_footnote_with_absolute():
+    assert_pixels('footnote_with_absolute', 9, 7, '''
+        _RRRR____
+        _RRRR____
+        _________
+        _RRRR____
+        _RRRR____
+        BB_______
+        BB_______
+    ''', '''
+    <style>
+        @font-face {src: url(weasyprint.otf); font-family: weasyprint}
+        @page {
+            size: 9px 7px;
+            background: white;
+            margin: 0 1px 2px;
+        }
+        div {
+            color: red;
+            font-family: weasyprint;
+            font-size: 2px;
+            line-height: 1;
+        }
+        span {
+            float: footnote;
+        }
+        mark {
+            display: block;
+            position: absolute;
+            left: -1px;
+            color: blue;
+        }
+    </style>
+    <div>a<span><mark>d</mark></span></div>''')

--- a/weasyprint/layout/page.py
+++ b/weasyprint/layout/page.py
@@ -589,6 +589,12 @@ def make_page(context, root_box, page_type, resume_at, page_number,
     assert root_box
     root_box.children = out_of_flow_boxes + root_box.children
 
+    footnote_area = build.create_anonymous_boxes(footnote_area.deepcopy())
+    footnote_area, _, _, _, _ = block_level_layout(
+        context, footnote_area, -inf, None, footnote_area.page, True,
+        positioned_boxes, positioned_boxes, [], False)
+    footnote_area.translate(dy=-footnote_area.margin_height())
+
     page.fixed_boxes = [
         placeholder._box for placeholder in positioned_boxes
         if placeholder._box.style['position'] == 'fixed']
@@ -596,12 +602,6 @@ def make_page(context, root_box, page_type, resume_at, page_number,
         absolute_layout(
             context, absolute_box, page, positioned_boxes, bottom_space=0,
             skip_stack=None)
-
-    footnote_area = build.create_anonymous_boxes(footnote_area.deepcopy())
-    footnote_area, _, _, _, _ = block_level_layout(
-        context, footnote_area, -inf, None, footnote_area.page, True, [], [],
-        [], False)
-    footnote_area.translate(dy=-footnote_area.margin_height())
 
     context.finish_block_formatting_context(root_box)
 


### PR DESCRIPTION
Previously, this would throw an error because absolute_layout hadn't had a chance to lay out the boxes. Now we do the block level layout for footnotes *before* doing layout for absolute boxes (or fixed boxes) and add any positioned boxes to positioned_boxes so they can be put onto the page correctly.