### PR TITLE
perf: improve column handling speed, fix infinite loops

### DIFF
--- a/tests/layout/test_column.py
+++ b/tests/layout/test_column.py
@@ -176,6 +176,38 @@ def test_columns_multipage():
 
 
 @assert_no_logs
+def test_column_breaks():
+    page1, page2 = render_pages('''
+      <style>
+        @font-face { src: url(weasyprint.otf); font-family: weasyprint }
+        div { columns: 2; column-gap: 1px }
+        body { margin: 0; font-family: weasyprint;
+               font-size: 1px; line-height: 1px }
+        @page { margin: 0; size: 3px 2px }
+        section { break-before: always; }
+      </style>
+      <div>a<section>b</section><section>c</section></div>
+    ''')
+    html, = page1.children
+    body, = html.children
+    div, = body.children
+    columns = div.children
+    assert len(columns) == 2
+    assert len(columns[0].children) == 1
+    assert len(columns[1].children) == 1
+    columns[0].children[0].children[0].children[0].text == 'a'
+    columns[1].children[0].children[0].children[0].text == 'b'
+
+    html, = page2.children
+    body, = html.children
+    div, = body.children
+    columns = div.children
+    assert len(columns) == 1
+    assert len(columns[0].children) == 1
+    columns[0].children[0].children[0].children[0].text == 'c'
+
+
+@assert_no_logs
 def test_columns_not_enough_content():
     page, = render_pages('''
       <style>


### PR DESCRIPTION
The primary change here is that the column calculation algorithm now attempts to render columns as if they were the full remaining height on the page, rather than to render the entire content regardless of how long the page is.

The worst-case behavior is effectively the same as that of the previous algorithm (as at least one additional pass would be required to determine how high balanced columns should be, but this applies in both cases), but if content would not fit on the page, this can bail and set the page immediately, rather than continuing significantly more calculations.

As an associated benefit, this closes #1020, as we now handle multiple column breaks (which would force a page break) correctly. A test for this behavior is included.

In unscientific tests, this appears to be a significant speedup in worst-case column calculations, for example taking a 100+ page multi-column render from 45 minutes to under two minutes. A more realistic document render time was cut by about 50% (from a starting point of ~five minutes).

It is certainly plausible that there exist better algorithms for determining column heights (such as calculating possible breakpoints for children), but this provides significantly improved execution time over the current algorithm in both pathological and real-world tests, with minimal algorithmic changes. I certainly won't be offended if this gets entirely rewritten in the path to v55/56, but it might be nice to have in the meantime.