### PR TITLE
fix: calculate ex ratio correctly

### DIFF
--- a/weasyprint/css/computed_values.py
+++ b/weasyprint/css/computed_values.py
@@ -781,7 +781,7 @@ def character_ratio(style, character):
     ink_extents = ffi.new('PangoRectangle *')
     pango.pango_layout_line_get_extents(line, ink_extents, ffi.NULL)
     if character == 'x':
-        measure = units_to_double(ink_extents.y)
+        measure = -units_to_double(ink_extents.y)
     else:
         measure = units_to_double(ink_extents.width)
     ffi.release(ink_extents)


### PR DESCRIPTION
We had lost a negative sign accidentally in 4833bf69c8d9d278d66aef9e1e856f02122d42c8. Sorry about that!

I couldn't come up with a good way to test this off the top of my head especially given that it seems we can't necessarily rely on the testing font being available for use since we don't yet support `@font-face` in these computed values.