### PR TITLE
fix: calculate advance width for ch correctly

### DIFF
--- a/weasyprint/css/computed_values.py
+++ b/weasyprint/css/computed_values.py
@@ -779,12 +779,14 @@ def character_ratio(style, character):
     line, _ = layout.get_first_line()
 
     ink_extents = ffi.new('PangoRectangle *')
-    pango.pango_layout_line_get_extents(line, ink_extents, ffi.NULL)
+    logical_extents = ffi.new('PangoRectangle *')
+    pango.pango_layout_line_get_extents(line, ink_extents, logical_extents)
     if character == 'x':
         measure = -units_to_double(ink_extents.y)
     else:
-        measure = units_to_double(ink_extents.width)
+        measure = units_to_double(logical_extents.width)
     ffi.release(ink_extents)
+    ffi.release(logical_extents)
 
     # Zero means some kind of failure, fallback is 0.5.
     # We round to try keeping exact values that were altered by Pango.


### PR DESCRIPTION
The "ch" value uses the advance width - not the ink width - of the "0" character.

This gets us closer to the results from line_break's line_size method, the only thing missing would be adding in the value of `style['letter_spacing']`. This method already avoids touching that because it could cause recursion, but it's not clear that it should be included anyway: [the relevant spec](https://www.w3.org/TR/css-values-4/#ch) seems to say only:

> The advance measure of a glyph depends on writing-mode and text-orientation as well as font settings, text-transform, and any other properties that affect **glyph** selection or orientation.

(emphasis added)

Which would seem to indicate that perhaps we don't actually want to care about the letter spacing purely as part of the `ch` measurement.