### PR TITLE
fix: sequential footnotes could disappear when overflowing

### DIFF
--- a/tests/layout/test_footnotes.py
+++ b/tests/layout/test_footnotes.py
@@ -317,6 +317,43 @@ def test_reported_footnote_3():
 
 
 @assert_no_logs
+def test_reported_sequential_footnote():
+    pages = render_pages('''
+        <style>
+            @font-face {src: url(weasyprint.otf); font-family: weasyprint}
+            @page {
+                size: 9px 7px;
+            }
+            div {
+                font-family: weasyprint;
+                font-size: 2px;
+                line-height: 1;
+            }
+            span {
+                float: footnote;
+            }
+        </style>
+        <div>
+            a<span>b</span><span>c</span><span>d</span><span>e</span>
+        </div>''')
+    line = tree_position(
+        pages, lambda box: type(box).__name__ == 'TextBox' and box.text == 'a')
+    fn_1 = tree_position(
+        pages, lambda box: type(box).__name__ == 'TextBox' and box.text == 'b')
+    fn_2 = tree_position(
+        pages, lambda box: type(box).__name__ == 'TextBox' and box.text == 'c')
+    fn_3 = tree_position(
+        pages, lambda box: type(box).__name__ == 'TextBox' and box.text == 'd')
+    fn_4 = tree_position(
+        pages, lambda box: type(box).__name__ == 'TextBox' and box.text == 'e')
+
+    assert line < fn_1
+    assert fn_1 < fn_2
+    assert fn_2 < fn_3
+    assert fn_3 < fn_4
+
+
+@assert_no_logs
 @pytest.mark.parametrize('css, tail', (
     ('p { break-inside: avoid }', '<br>e<br>f'),
     ('p { widows: 4 }', '<br>e<br>f'),

--- a/weasyprint/layout/block.py
+++ b/weasyprint/layout/block.py
@@ -355,15 +355,22 @@ def _linebox_layout(context, box, index, child, new_children, page_is_empty,
                         bottom_space, new_position_y + offset_y))
                 if overflow:
                     context.report_footnote(footnote)
-                    if footnote.style['footnote_policy'] == 'line':
-                        abort, stop, resume_at = _break_line(
-                            context, box, line, new_children, lines_iterator,
-                            page_is_empty, index, skip_stack, resume_at,
-                            absolute_boxes, fixed_boxes)
-                        break_linebox = True
-                    elif footnote.style['footnote_policy'] == 'block':
-                        abort = break_linebox = True
-                    break
+                    # If we've put other content on this page, then we may want
+                    # to push this line or block to the next page. Otherwise,
+                    # we can't (and would loop forever if we tried), so don't
+                    # even try.
+                    if new_children or not page_is_empty:
+                        if footnote.style['footnote_policy'] == 'line':
+                            abort, stop, resume_at = _break_line(
+                                context, box, line, new_children,
+                                lines_iterator, page_is_empty, index,
+                                skip_stack, resume_at, absolute_boxes,
+                                fixed_boxes)
+                            break_linebox = True
+                            break
+                        elif footnote.style['footnote_policy'] == 'block':
+                            abort = break_linebox = True
+                            break
             if break_linebox:
                 break
 


### PR DESCRIPTION
Previously, if a footnote triggered an overflow (that is, it was too large for the containing space), but footnote-policy didn't make us push down the line containing it, any subsequent footnotes in the same linebox would not be set into a footnote area, because they would never be passed to layout_footnote and report_footnote. (Their call sites would be set, but their content would not be.)

This also fixes a potential infinite loop where using footnote-policy could have forced the first line of a page to be pushed to the next page: that will just result in an infinite loop, so instead we set the line and move on if we are on the first line of a page. (This behavior is not specified in GCPM, but no other behavior seems practical: the only alternative would be to expand the page, which is almost certainly less desirable.)