### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/doconfly.yml
+++ b/.github/workflows/doconfly.yml
@@ -6,8 +6,13 @@ on:
     tags:
       - "*"
  
+permissions:
+  contents: read
+
 jobs:
   doconfly:
+    permissions:
+      contents: none
     name: doconfly job
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/test_samples.yml
+++ b/.github/workflows/test_samples.yml
@@ -4,6 +4,9 @@ on: [push, pull_request]
 env:
   REPORTS_FOLDER: 'report'
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: ${{ matrix.os }} - ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,9 @@
 name: WeasyPrint's tests
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: ${{ matrix.os }} - ${{ matrix.python-version }}


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
