### PR TITLE
Update the text-transform "capitalize" behaviour

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
   'Pyphen >=0.9.1',
   'Pillow >=4.0.0',
   'fonttools[woff] >=4.0.0',
+  'regex >= 2022.7.25',
 ]
 classifiers = [
   'Development Status :: 5 - Production/Stable',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ dependencies = [
   'Pyphen >=0.9.1',
   'Pillow >=4.0.0',
   'fonttools[woff] >=4.0.0',
-  'regex >= 2022.7.25',
 ]
 classifiers = [
   'Development Status :: 5 - Production/Stable',

--- a/weasyprint/formatting_structure/build.py
+++ b/weasyprint/formatting_structure/build.py
@@ -5,6 +5,7 @@ This includes creating anonymous boxes and processing whitespace as necessary.
 """
 
 import re
+import regex
 import unicodedata
 
 import tinycss2.color3
@@ -1252,8 +1253,7 @@ def process_text_transform(box):
             box.text = {
                 'uppercase': lambda text: text.upper(),
                 'lowercase': lambda text: text.lower(),
-                # Python’s unicode.captitalize is not the same.
-                'capitalize': lambda text: text.title(),
+                'capitalize': lambda text: capitalize(text),
                 'full-width': lambda text: text.translate(ASCII_TO_WIDE),
             }[text_transform](box.text)
         if box.style['hyphens'] == 'none':
@@ -1263,6 +1263,19 @@ def process_text_transform(box):
         for child in box.children:
             if isinstance(child, (boxes.TextBox, boxes.InlineBox)):
                 process_text_transform(child)
+
+
+def capitalize(text):
+    """Capitalize the first unicode "typographic_letter_unit" for each word whilst
+    leaving all other characters untouched.
+
+    This behaviour matches the CSS capitalize text transform.
+
+    Python's "capitalize" and "title" methods do not provide this functionality
+    """
+    CAPITALIZE_RE = regex.compile(r"\b([\p{L}\p{N}])", regex.WORD)
+
+    return CAPITALIZE_RE.sub(lambda x: x.group(1).upper(), text)
 
 
 def inline_in_block(box):

--- a/weasyprint/formatting_structure/build.py
+++ b/weasyprint/formatting_structure/build.py
@@ -5,7 +5,6 @@ This includes creating anonymous boxes and processing whitespace as necessary.
 """
 
 import re
-import regex
 import unicodedata
 
 import tinycss2.color3
@@ -1265,17 +1264,29 @@ def process_text_transform(box):
                 process_text_transform(child)
 
 
-def capitalize(text):
+def capitalize(text: str) -> str:
     """Capitalize the first unicode "typographic_letter_unit" for each word whilst
     leaving all other characters untouched.
 
-    This behaviour matches the CSS capitalize text transform.
+    This matches the CSS "text transform: capitalize" behaviour
 
-    Python's "capitalize" and "title" methods do not provide this functionality
     """
-    CAPITALIZE_RE = regex.compile(r"\b([\p{L}\p{N}])", regex.WORD)
+    letter_found = False
+    output_text = list(text)
 
-    return CAPITALIZE_RE.sub(lambda x: x.group(1).upper(), text)
+    gc_text = [unicodedata.category(char) for char in text]
+
+    for i, cat in enumerate(gc_text):
+        if not letter_found:
+            if cat[0] in ("L", "N"):
+                letter_found = True
+                output_text[i] = output_text[i].upper()
+                pass
+
+        if cat[0] == "Z":
+            letter_found = False
+
+    return "".join(output_text)
 
 
 def inline_in_block(box):


### PR DESCRIPTION
Transform the first typographic letter unit of each word to uppercase
without modifying other characters

See issue Kozea#1612