### PR TITLE
Use partial font instead of font face to create font cache keys

### DIFF
--- a/docs/first_steps.rst
+++ b/docs/first_steps.rst
@@ -49,9 +49,8 @@ Ubuntu_, Fedora_, Archlinux_, Gentoo_…
 
 If WeasyPrint is not available on your distribution, or if you want to use a
 more recent version of WeasyPrint, you have to be sure that Python_ (at least
-version 3.7.0) and Pango_ (at least version 1.44.0, 1.46.0 or newer is
-preferred to get smaller documents) are installed on your system. You can
-verify this by launching::
+version 3.7.0) and Pango_ (at least version 1.44.0) are installed on your
+system. You can verify this by launching::
 
   python3 --version
   pango-view --version

--- a/weasyprint/pdf/stream.py
+++ b/weasyprint/pdf/stream.py
@@ -319,11 +319,12 @@ class Stream(pydyf.Stream):
 
     @lru_cache()
     def add_font(self, pango_font):
-        if pango.pango_version() > 14600:
-            pango_face = pango.pango_font_get_face(pango_font)
-            description = pango.pango_font_face_describe(pango_face)
-        else:
-            description = pango.pango_font_describe(pango_font)
+        description = pango.pango_font_describe(pango_font)
+        mask = (
+            pango.PANGO_FONT_MASK_SIZE +
+            pango.PANGO_FONT_MASK_GRAVITY +
+            pango.PANGO_FONT_MASK_VARIATIONS)
+        pango.pango_font_description_unset_fields(description, mask)
         key = pango.pango_font_description_hash(description)
         pango.pango_font_description_free(description)
         if key not in self._fonts:

--- a/weasyprint/text/ffi.py
+++ b/weasyprint/text/ffi.py
@@ -45,7 +45,6 @@ ffi.cdef('''
     typedef ... PangoAttrList;
     typedef ... PangoAttrClass;
     typedef ... PangoFont;
-    typedef ... PangoFontFace;
     typedef guint PangoGlyph;
     typedef gint PangoGlyphUnit;
 
@@ -71,6 +70,12 @@ ffi.cdef('''
         PANGO_WEIGHT_HEAVY = 900,
         PANGO_WEIGHT_ULTRAHEAVY = 1000
     } PangoWeight;
+
+    typedef enum {
+        PANGO_FONT_MASK_SIZE = 1 << 5,
+        PANGO_FONT_MASK_GRAVITY = 1 << 6,
+        PANGO_FONT_MASK_VARIATIONS = 1 << 7
+    } PangoFontMask;
 
     typedef enum {
         PANGO_STRETCH_ULTRA_CONDENSED,
@@ -249,6 +254,9 @@ ffi.cdef('''
         const PangoFontDescription* desc);
     int pango_font_description_get_size (PangoFontDescription *desc);
 
+    void pango_font_description_unset_fields (
+        PangoFontDescription* desc, PangoFontMask to_unset);
+
     int pango_glyph_string_get_width (PangoGlyphString *glyphs);
     char * pango_font_description_to_string (
         const PangoFontDescription *desc);
@@ -280,8 +288,6 @@ ffi.cdef('''
     void pango_font_get_glyph_extents (
         PangoFont *font, PangoGlyph glyph, PangoRectangle *ink_rect,
         PangoRectangle *logical_rect);
-    PangoFontFace* pango_font_get_face (PangoFont* font);
-    PangoFontDescription* pango_font_face_describe (PangoFontFace* face);
 
     void pango_context_set_round_glyph_positions (
         PangoContext *context, gboolean round_positions);


### PR DESCRIPTION
The font face introduced by Pango 1.46 was appealing, but its description seems to be broken. No easy way to know whether it’s broken in Pango, in FontConfig, in our custom FontConfig configuration, or elsewhere. As it only happens with @font-face rules, we can easily blame our FontConfig configuration.

Let’s try something else again! This key changes in each version…

Font descriptions have a nice way to unset values, allowing us to only keep fields that should be unique by font file. This will probably lead us to other subtle and frightening problems in the future, but we’ll let our dear users and customers find them for us.

And we don’t require Pango 1.46 anymore to get smaller PDFs. So cool.

Fix #1778.