### PR TITLE
Adds a fuzz testing harness

### DIFF
--- a/tests/fuzz_weasyprint.py
+++ b/tests/fuzz_weasyprint.py
@@ -1,0 +1,22 @@
+#!/usr/bin/python3
+
+import atheris
+
+with atheris.instrument_imports():
+    from weasyprint import HTML, CSS
+    from weasyprint.css.utils import InvalidValues
+    import sys
+
+
+def TestOneInput(data):
+    fdp = atheris.FuzzedDataProvider(data)
+    try:
+        html = HTML(string=fdp.ConsumeBytes(fdp.ConsumeIntInRange(0, 4000)))
+        css = CSS(string=fdp.ConsumeBytes(fdp.ConsumeIntInRange(0, 4000)))
+        html.write_pdf(stylesheets=[css])
+    except (InvalidValues, ValueError):
+        pass
+
+
+atheris.Setup(sys.argv, TestOneInput)
+atheris.Fuzz()


### PR DESCRIPTION
This PR adds a basic fuzz test that targets HTML, CSS and write_pdf. It appears to have found at least two non-critical bugs so far, so I hope this will be of help to you. I will be uploading the inputs created by the fuzzer that caused the crashes. 
I have opened an issue that explains the benefits of fuzz testing here: https://github.com/Kozea/WeasyPrint/issues/1821