### PR TITLE
Draft: Do line breaking in WeasyPrint using Harfbuzz data

### DIFF
--- a/weasyprint/formatting_structure/boxes.py
+++ b/weasyprint/formatting_structure/boxes.py
@@ -82,6 +82,10 @@ class Box:
     cached_counter_values = None
     missing_link = None
 
+    # Positioning
+    position_x = 0
+    position_y = 0
+
     # Default, overriden on some subclasses
     def all_children(self):
         return ()

--- a/weasyprint/layout/__init__.py
+++ b/weasyprint/layout/__init__.py
@@ -219,6 +219,7 @@ class LayoutContext:
         self.style_for = style_for
         self.get_image_from_uri = partial(get_image_from_uri, context=self)
         self.font_config = font_config
+        self.pango_context = None # Not initialized yet
         self.counter_style = counter_style
         self.target_collector = target_collector
         self._excluded_shapes_lists = []
@@ -238,6 +239,8 @@ class LayoutContext:
 
         # Cache
         self.strut_layouts = {}
+        self.pango_font_descs = {}
+        self.pango_font_feats = {}
         self.font_features = {}
         self.tables = {}
         self.dictionaries = {}

--- a/weasyprint/pdf/stream.py
+++ b/weasyprint/pdf/stream.py
@@ -160,6 +160,7 @@ class Stream(pydyf.Stream):
         self.length = ffi.new('unsigned int *')
         self.ink_rect = ffi.new('PangoRectangle *')
         self.logical_rect = ffi.new('PangoRectangle *')
+        self.hb_extents = ffi.new('hb_glyph_extents_t *')
 
     @property
     def ctm(self):

--- a/weasyprint/text/ffi.py
+++ b/weasyprint/text/ffi.py
@@ -8,11 +8,188 @@ ffi = cffi.FFI()
 ffi.cdef('''
     // HarfBuzz
 
-    typedef ... hb_font_t;
-    typedef ... hb_face_t;
     typedef ... hb_blob_t;
+    typedef int hb_bool_t;
+    typedef ... hb_buffer_t;
     typedef uint32_t hb_codepoint_t;
+    typedef ... hb_face_t;
+    typedef ... hb_font_t;
+    typedef uint32_t hb_mask_t;
+    typedef int32_t hb_position_t;
+    typedef uint32_t hb_tag_t;
+
+    typedef union _hb_var_int_t {
+        uint32_t u32;
+        int32_t i32;
+        uint16_t u16[2];
+        int16_t i16[2];
+        uint8_t u8[4];
+        int8_t i8[4];
+    } hb_var_int_t;
+
+    typedef enum {
+        HB_BUFFER_CLUSTER_LEVEL_MONOTONE_GRAPHEMES  = 0,
+        HB_BUFFER_CLUSTER_LEVEL_MONOTONE_CHARACTERS = 1,
+        HB_BUFFER_CLUSTER_LEVEL_CHARACTERS          = 2,
+        HB_BUFFER_CLUSTER_LEVEL_DEFAULT = HB_BUFFER_CLUSTER_LEVEL_MONOTONE_GRAPHEMES
+    } hb_buffer_cluster_level_t;
+
+    typedef enum {
+        HB_BUFFER_CONTENT_TYPE_INVALID = 0,
+        HB_BUFFER_CONTENT_TYPE_UNICODE,
+        HB_BUFFER_CONTENT_TYPE_GLYPHS
+    } hb_buffer_content_type_t;
+
+    typedef enum { /*< flags >*/
+        HB_BUFFER_FLAG_DEFAULT                      = 0x00000000u,
+        HB_BUFFER_FLAG_BOT                          = 0x00000001u,
+        HB_BUFFER_FLAG_EOT                          = 0x00000002u,
+        HB_BUFFER_FLAG_PRESERVE_DEFAULT_IGNORABLES  = 0x00000004u,
+        HB_BUFFER_FLAG_REMOVE_DEFAULT_IGNORABLES    = 0x00000008u,
+        HB_BUFFER_FLAG_DO_NOT_INSERT_DOTTED_CIRCLE  = 0x00000010u,
+        HB_BUFFER_FLAG_VERIFY                       = 0x00000020u,
+        HB_BUFFER_FLAG_PRODUCE_UNSAFE_TO_CONCAT     = 0x00000040u,
+        HB_BUFFER_FLAG_DEFINED                      = 0x0000007Fu
+    } hb_buffer_flags_t;
+
+    typedef enum {
+        HB_BUFFER_SERIALIZE_FORMAT_TEXT,
+        HB_BUFFER_SERIALIZE_FORMAT_JSON,
+        HB_BUFFER_SERIALIZE_FORMAT_INVALID
+    } hb_buffer_serialize_format_t;
+
+    typedef enum {
+        HB_BUFFER_SERIALIZE_FLAG_DEFAULT        = 0x00000000u,
+        HB_BUFFER_SERIALIZE_FLAG_NO_CLUSTERS    = 0x00000001u,
+        HB_BUFFER_SERIALIZE_FLAG_NO_POSITIONS   = 0x00000002u,
+        HB_BUFFER_SERIALIZE_FLAG_NO_GLYPH_NAMES = 0x00000004u,
+        HB_BUFFER_SERIALIZE_FLAG_GLYPH_EXTENTS  = 0x00000008u,
+        HB_BUFFER_SERIALIZE_FLAG_GLYPH_FLAGS    = 0x00000010u,
+        HB_BUFFER_SERIALIZE_FLAG_NO_ADVANCES    = 0x00000020u,
+        HB_BUFFER_SERIALIZE_FLAG_DEFINED        = 0x0000003Fu
+    } hb_buffer_serialize_flags_t;
+
+    typedef enum {
+        HB_DIRECTION_INVALID = 0,
+        HB_DIRECTION_LTR = 4,
+        HB_DIRECTION_RTL,
+        HB_DIRECTION_TTB,
+        HB_DIRECTION_BTT
+    } hb_direction_t;
+
+    typedef enum {
+        HB_OT_LAYOUT_BASELINE_TAG_ROMAN                     = 0x726f6d6eu,
+        HB_OT_LAYOUT_BASELINE_TAG_HANGING                   = 0x68616e67u,
+        HB_OT_LAYOUT_BASELINE_TAG_IDEO_FACE_BOTTOM_OR_LEFT  = 0x69636662u,
+        HB_OT_LAYOUT_BASELINE_TAG_IDEO_FACE_TOP_OR_RIGHT    = 0x69636674u,
+        HB_OT_LAYOUT_BASELINE_TAG_IDEO_FACE_CENTRAL         = 0x49636663u,
+        HB_OT_LAYOUT_BASELINE_TAG_IDEO_EMBOX_BOTTOM_OR_LEFT = 0x6964656fu,
+        HB_OT_LAYOUT_BASELINE_TAG_IDEO_EMBOX_TOP_OR_RIGHT   = 0x69647470u,
+        HB_OT_LAYOUT_BASELINE_TAG_IDEO_EMBOX_CENTRAL        = 0x49646365u,
+        HB_OT_LAYOUT_BASELINE_TAG_MATH                      = 0x6d617468u
+    } hb_ot_layout_baseline_tag_t;
+
+    typedef struct {
+        hb_tag_t      tag;
+        uint32_t      value;
+        unsigned int  start;
+        unsigned int  end;
+    } hb_feature_t;
+
+    typedef struct {
+        hb_position_t ascender;
+        hb_position_t descender;
+        hb_position_t line_gap;
+        /*< private >*/
+        hb_position_t reserved9;
+        hb_position_t reserved8;
+        hb_position_t reserved7;
+        hb_position_t reserved6;
+        hb_position_t reserved5;
+        hb_position_t reserved4;
+        hb_position_t reserved3;
+        hb_position_t reserved2;
+        hb_position_t reserved1;
+    } hb_font_extents_t;
+
+    typedef struct {
+        hb_position_t x_bearing;
+        hb_position_t y_bearing;
+        hb_position_t width;
+        hb_position_t height;
+    } hb_glyph_extents_t;
+
+    typedef enum {
+        HB_GLYPH_FLAG_UNSAFE_TO_BREAK   = 0x00000001,
+        HB_GLYPH_FLAG_UNSAFE_TO_CONCAT  = 0x00000002,
+        HB_GLYPH_FLAG_DEFINED           = 0x00000003
+    } hb_glyph_flags_t;
+
+    typedef struct hb_glyph_info_t {
+        hb_codepoint_t codepoint;
+        /*< private >*/
+        hb_mask_t      mask;
+        /*< public >*/
+        uint32_t       cluster;
+
+        /*< private >*/
+        hb_var_int_t   var1;
+        hb_var_int_t   var2;
+    } hb_glyph_info_t;
+
+    typedef struct {
+        hb_position_t  x_advance;
+        hb_position_t  y_advance;
+        hb_position_t  x_offset;
+        hb_position_t  y_offset;
+        /*< private >*/
+        hb_var_int_t   var;
+    } hb_glyph_position_t;
+
+    hb_buffer_t * hb_buffer_create (void);
+    void hb_buffer_destroy (hb_buffer_t *buffer);
+    void hb_buffer_add (
+        hb_buffer_t *buffer, hb_codepoint_t codepoint, unsigned int cluster);
+    void hb_buffer_append (
+        hb_buffer_t *buffer, const hb_buffer_t *source, unsigned int start,
+        unsigned int end);
+    hb_glyph_info_t * hb_buffer_get_glyph_infos (
+        hb_buffer_t *buffer, unsigned int *length);
+    hb_glyph_position_t * hb_buffer_get_glyph_positions (
+        hb_buffer_t *buffer, unsigned int *length);
+    unsigned int hb_buffer_get_length (const hb_buffer_t *buffer);
+    hb_bool_t hb_buffer_pre_allocate (
+        hb_buffer_t *buffer, unsigned int size);
+    unsigned int hb_buffer_serialize (
+        hb_buffer_t *buffer, unsigned int start, unsigned int end, char *buf,
+        unsigned int buf_size, unsigned int *buf_consumed, hb_font_t *font,
+        hb_buffer_serialize_format_t format,
+        hb_buffer_serialize_flags_t flags);
+    hb_buffer_serialize_format_t hb_buffer_serialize_format_from_string(
+        const char *str, int len);
+    void hb_buffer_set_cluster_level (
+        hb_buffer_t *buffer, hb_buffer_cluster_level_t cluster_level);
+    void hb_buffer_set_content_type (
+        hb_buffer_t *buffer, hb_buffer_content_type_t content_type);
+    void hb_buffer_set_direction (
+        hb_buffer_t *buffer, hb_direction_t direction);
+    void hb_buffer_set_flags (
+        hb_buffer_t *buffer, hb_buffer_flags_t flags);
+
+    void hb_shape (
+        hb_font_t *font, hb_buffer_t *buffer, const hb_feature_t *features,
+        unsigned int num_features);
+
+    void hb_font_get_extents_for_direction (
+        hb_font_t *font, hb_direction_t direction, hb_font_extents_t *extents);
     hb_face_t * hb_font_get_face (hb_font_t *font);
+    hb_bool_t hb_font_get_glyph_extents (
+        hb_font_t *font, hb_codepoint_t glyph, hb_glyph_extents_t *extents);
+    void hb_font_get_ppem (
+        hb_font_t *font, unsigned int *x_ppem, unsigned int *y_ppem);
+    float hb_font_get_ptem (hb_font_t *font);
+    void hb_font_get_scale (hb_font_t *font, int *x_scale, int *y_scale);
+
     hb_blob_t * hb_face_reference_blob (hb_face_t *face);
     unsigned int hb_face_get_index (const hb_face_t *face);
     unsigned int hb_face_get_upem (const hb_face_t *face);
@@ -41,6 +218,7 @@ ffi.cdef('''
     typedef ... PangoTabArray;
     typedef ... PangoFontDescription;
     typedef ... PangoLayoutIter;
+    typedef ... PangoAttrIterator;
     typedef ... PangoAttrList;
     typedef ... PangoAttrClass;
     typedef ... PangoFont;
@@ -49,6 +227,16 @@ ffi.cdef('''
 
     const guint PANGO_GLYPH_EMPTY = 0x0FFFFFFF;
     const guint PANGO_GLYPH_UNKNOWN_FLAG = 0x10000000;
+
+    typedef enum {
+        PANGO_DIRECTION_LTR,
+        PANGO_DIRECTION_RTL,
+        PANGO_DIRECTION_TTB_LTR, // Deprecated, use _RTL
+        PANGO_DIRECTION_TTB_RTL, // Deprecated, use _LTR
+        PANGO_DIRECTION_WEAK_LTR,
+        PANGO_DIRECTION_WEAK_RTL,
+        PANGO_DIRECTION_NEUTRAL
+    } PangoDirection;
 
     typedef enum {
         PANGO_STYLE_NORMAL,
@@ -98,6 +286,12 @@ ffi.cdef('''
         PANGO_ELLIPSIZE_MIDDLE,
         PANGO_ELLIPSIZE_END
     } PangoEllipsizeMode;
+
+    typedef struct GList {
+        gpointer data;
+        struct GList* next;
+        struct GList* prev;
+    } GList;
 
     typedef struct GSList {
        gpointer data;
@@ -277,10 +471,35 @@ ffi.cdef('''
         PangoAttrList *list, PangoAttribute *attr);
     void pango_attr_list_change (
         PangoAttrList *list, PangoAttribute *attr);
+    PangoAttribute * pango_attr_font_desc_new (
+        const PangoFontDescription *desc);
     PangoAttribute * pango_attr_font_features_new (const gchar *features);
     PangoAttribute * pango_attr_letter_spacing_new (int letter_spacing);
     PangoAttribute * pango_attr_insert_hyphens_new (gboolean insert_hyphens);
     void pango_attribute_destroy (PangoAttribute *attr);
+
+    PangoGlyphString * pango_glyph_string_new ();
+    void pango_glyph_string_free (PangoGlyphString * string);
+    void pango_glyph_string_extents_range (
+        PangoGlyphString * glyphs, int start, int end, PangoFont* font,
+        PangoRectangle * ink_rect, PangoRectangle * logical_rect);
+    void pango_glyph_string_get_logical_widths (
+        PangoGlyphString * glyphs, const char * text, int length,
+        int embedding_level, int * logical_widths);
+
+    GList * pango_itemize_with_base_dir (
+        PangoContext *context, PangoDirection base_dir,
+        const char *text, int start_index, int length,
+        PangoAttrList *attrs, PangoAttrIterator *cached_iter);
+
+    void pango_shape_full (
+        const char * item_text, int item_length,
+        const char * paragraph_text, int paragraph_length,
+        const PangoAnalysis * analysis, PangoGlyphString * glyphs);
+
+    void pango_default_break (
+        const char * text, int length, PangoAnalysis * analysis,
+        PangoLogAttr * attrs, int attrs_len);
 
     PangoTabArray * pango_tab_array_new_with_positions (
         gint size, gboolean positions_in_pixels, PangoTabAlign first_alignment,
@@ -416,6 +635,7 @@ gobject.g_type_init()
 
 units_to_double = pango.pango_units_to_double
 units_from_double = pango.pango_units_from_double
+PANGO_SCALE = pango.pango_units_from_double(1.0)
 
 
 def unicode_to_char_p(string):
@@ -426,3 +646,17 @@ def unicode_to_char_p(string):
     """
     bytestring = string.encode().replace(b'\x00', b'')
     return ffi.new('char[]', bytestring), bytestring
+
+
+def glist_to_list(glist, obj_type):
+    """Return a Python list from ``glist`` casted to ``type``."""
+    # Get to the head of the list if we're not there yet.
+    while glist.prev != ffi.NULL:
+        glist = glist.prev
+
+    obj_list = [ffi.cast(obj_type, glist.data)]
+    while glist.next != ffi.NULL:
+        glist = glist.next
+        obj_list.append(ffi.cast(obj_type, glist.data))
+
+    return obj_list


### PR DESCRIPTION
This is a *very* preliminary attempt at doing line breaking in WeasyPrint rather than using Pango to do line breaking. It can do very rudimentary HTML conversion, but is far from complete.

In particular, it uses Pango to itemize content (handle bidi levels, identify the relevant fonts, etc.) and identify some character properties, and then uses Harfbuzz to handle shaping the characters into glyphs. Once we've got both, we can iterate over each of them to identify where to break lines. I've tried to be moderately efficient about only itemizing and shaping once per block, so we save a ton of time previously spent in Pango when doing split_first_line calls. This necessitated a bunch of FFI additions, but because Pango is already a dependency and it requires Harfbuzz, it shouldn't actually add any dependencies to WeasyPrint in practice. (I did briefly consider getting rid of Pango entirely, but that would require significantly more effort: Pango provides a lot of value even with just its itemization and font-finding functionality.)

Many, many TODOs have been added throughout the code, and they barely even touch some aspects that will still need to be adjusted (in particular, an efficient way to find the natural size or minimum size of an inline box isn't something I've approached), or could be added (like proper bidi support). Resolving most of the added TODOs would probably be necessary to bring this into a state where it doesn't cause regressions if merged.

In particular, this code really only works with assumptions of "default" white-space, hyphenation, and wrapping settings, and doesn't support text decoration. (Not to mention, for example, hardcoding an inline_block_width for now, and the current apply_inline_box_sizes being extremely problematic, likely because I didn't understand the existing box model enough.) There's also a fairly massive loop in split_inline_box that could hopefully be cleaned up, possibly into multiple functions (at least for some parts?).

On the plus side, some very quick benchmarks with the WeasyPerf `jsonraw` benchmark show that it runs in about 43% of the time that 56.1 does with approximately the same memory usage, so there do seem to be some benefits to the code. I haven't done any profiling on it, and there are probably some relatively easy optimizations lurking around as well. An important caveat is that `jsonraw` is probably the best-case scenario for this change, and that fixing all of the open TODOs will probably slow it down a bit.

I wrote the vast majority of this code in 2022, and kept meaning to get around to fixing some of the more glaring issues but struggled to get the necessary motivation. I've cleaned it up enough to get it running satisfactorily with a fairly small test file I had been using just to make sure it can break lines and handle inline boxes, but it will need a ton of work to get it up to the point where it passes tests and can be merged properly. I'm filing this PR mostly as a way to mention that the code is here, but not with an expectation that the WeasyPrint team will necessarily take on that work. (If you're interested in working on it, I may also find some motivation to work on various parts, but if you're not, then it was a fun tech demo. I also won't be offended by a massive refactor - it's not in a great state right now, I was just trying to make things work with a small test file.)

You will also likely notice that it has been branched from 56.1, and I have not attempted a rebase. From occasional glances at the changelog it should be relatively feasible to pull in most updates since then without a lot of trouble, though things touching fonts in particular may need some tweaking.