### PR TITLE
Add "`calc()` not supported" in docs

### DIFF
--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -645,6 +645,8 @@ supported.
 The ``attr()`` functional notation is allowed in the ``content`` and
 ``string-set`` properties.
 
+The ``calc()`` function is **not** supported.
+
 Viewport-percentage lengths (``vw``, ``vh``, ``vmin``, ``vmax``) are **not**
 supported.
 


### PR DESCRIPTION
Added "`calc()` not supported" in `docs/api_reference.rst`.

This is as per liZe's recommendation (https://github.com/Kozea/WeasyPrint/issues/357#issuecomment-1429944988)