### PR TITLE
Use dictionary to store API options

### DIFF
--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -57,6 +57,7 @@ Python API
 .. autoclass:: CSS(input, **kwargs)
 .. autoclass:: Attachment(input, **kwargs)
 .. autofunction:: default_url_fetcher
+.. autodata:: DEFAULT_OPTIONS
 
 .. module:: weasyprint.document
 .. autoclass:: Document

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,15 +73,10 @@ def document_write_png(self, target=None, resolution=96, antialiasing=1,
             shutil.copyfileobj(png, fd)
 
 
-def html_write_png(self, target=None, stylesheets=None, resolution=96,
-                   presentational_hints=False,
-                   optimize_size=('fonts', 'hinting', 'pdf'), font_config=None,
-                   counter_style=None, image_cache=None):
-    return self.render(
-        stylesheets, presentational_hints=presentational_hints,
-        optimize_size=optimize_size, font_config=font_config,
-        counter_style=counter_style, image_cache=image_cache).write_png(
-            target, resolution)
+def html_write_png(self, target=None, font_config=None, counter_style=None,
+                   resolution=96, **options):
+    document = self.render(font_config, counter_style, **options)
+    return document.write_png(target, resolution)
 
 
 Document.write_png = document_write_png

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -537,8 +537,7 @@ def test_embed_images_from_pages():
         string='<img src="not-optimized.jpg">').render().pages
     document = Document(
         (page1, page2), metadata=DocumentMetadata(),
-        font_config=FontConfiguration(), url_fetcher=None,
-        optimize_size=()).write_pdf()
+        font_config=FontConfiguration(), url_fetcher=None).write_pdf()
     assert document.count(b'/Filter /DCTDecode') == 2
 
 

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -8,7 +8,7 @@ import sys
 import threading
 import wsgiref.simple_server
 
-from weasyprint import CSS, HTML, images
+from weasyprint import CSS, DEFAULT_OPTIONS, HTML, images
 from weasyprint.css import get_all_computed_styles
 from weasyprint.css.counters import CounterStyle
 from weasyprint.css.targets import TargetCollector
@@ -48,23 +48,20 @@ PROPER_CHILDREN = dict((key, tuple(map(tuple, value))) for key, value in {
 
 class FakeHTML(HTML):
     """Like weasyprint.HTML, but with a lighter UA stylesheet."""
+    def __init__(self, *args, force_uncompressed_pdf=True, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._force_uncompressed_pdf = force_uncompressed_pdf
+
     def _ua_stylesheets(self, forms=False):
         return [
             TEST_UA_STYLESHEET if stylesheet == HTML5_UA_STYLESHEET
             else stylesheet for stylesheet in super()._ua_stylesheets(forms)]
 
-    def write_pdf(self, target=None, stylesheets=None, zoom=1,
-                  attachments=None, finisher=None, presentational_hints=False,
-                  optimize_size=('fonts',), jpeg_quality=None, dpi=None,
-                  font_config=None, counter_style=None, image_cache=None,
-                  identifier=None, variant=None, version=None, forms=False,
-                  custom_metadata=False):
-        # Override function to set PDF size optimization to False by default
-        return super().write_pdf(
-            target, stylesheets, zoom, attachments, finisher,
-            presentational_hints, optimize_size, jpeg_quality, dpi,
-            font_config, counter_style, image_cache, identifier, variant,
-            version, forms, custom_metadata)
+    def write_pdf(self, target=None, zoom=1, finisher=None, **options):
+        # Override function to force the generation of uncompressed PDFs
+        if self._force_uncompressed_pdf:
+            options['uncompressed_pdf'] = True
+        return super().write_pdf(target, zoom, finisher, **options)
 
 
 def resource_filename(basename):
@@ -195,7 +192,7 @@ def _parse_base(html_content, base_url=BASE_URL):
     style_for = get_all_computed_styles(document, counter_style=counter_style)
     get_image_from_uri = functools.partial(
         images.get_image_from_uri, cache={}, url_fetcher=document.url_fetcher,
-        optimize_size=(), jpeg_quality=None, dpi=None)
+        options=DEFAULT_OPTIONS)
     target_collector = TargetCollector()
     footnotes = []
     return (

--- a/weasyprint/__init__.py
+++ b/weasyprint/__init__.py
@@ -15,9 +15,71 @@ import tinycss2
 
 VERSION = __version__ = '58.1'
 
+#: Default values for command-line and Python API options. See
+#: :func:`__main__.main` to learn more about specific options for
+#: command-line.
+#:
+#: :param list stylesheets:
+#:     An optional list of user stylesheets. The list can include
+#:     are :class:`CSS` objects, filenames, URLs, or file-like
+#:     objects. (See :ref:`Stylesheet Origins`.)
+#: :param str media_type:
+#:     Media type to use for @media.
+#: :param list attachments:
+#:     A list of additional file attachments for the generated PDF
+#:     document or :obj:`None`. The list's elements are
+#:     :class:`Attachment` objects, filenames, URLs or file-like objects.
+#: :param bytes pdf_identifier:
+#:     A bytestring used as PDF file identifier.
+#: :param str pdf_variant:
+#:     A PDF variant name.
+#: :param str pdf_version:
+#:     A PDF version number.
+#: :param bool pdf_forms:
+#:     Whether PDF forms have to be included.
+#: :param bool uncompressed_pdf:
+#:     Whether PDF content should be compressed.
+#: :param bool custom_metadata:
+#:     Whether custom HTML metadata should be stored in the generated PDF.
+#: :param bool presentational_hints:
+#:     Whether HTML presentational hints are followed.
+#: :param bool optimize_images:
+#:     Whether size of embedded images should be optimized, with no quality
+#:     loss.
+#: :param int jpeg_quality:
+#:     JPEG quality between 0 (worst) to 95 (best).
+#: :param int dpi:
+#:     Maximum resolution of images embedded in the PDF.
+#: :param bool full_fonts:
+#:     Whether unmodified font files should be embedded when possible.
+#: :param bool hinting:
+#:     Whether hinting information should be kept in embedded fonts.
+#: :type image_cache: :obj:`dict` or :obj:`str`
+#: :param cache_folder:
+#:     A dictionary used to cache images, or a folder path where images
+#:     are temporarily stored.
+DEFAULT_OPTIONS = {
+    'stylesheets': None,
+    'media_type': 'print',
+    'attachments': None,
+    'pdf_identifier': None,
+    'pdf_variant': None,
+    'pdf_version': None,
+    'pdf_forms': None,
+    'uncompressed_pdf': False,
+    'custom_metadata': False,
+    'presentational_hints': False,
+    'optimize_images': False,
+    'jpeg_quality': None,
+    'dpi': None,
+    'full_fonts': False,
+    'hinting': False,
+    'cache_folder': None,
+}
+
 __all__ = [
-    'HTML', 'CSS', 'Attachment', 'Document', 'Page', 'default_url_fetcher',
-    'VERSION', '__version__']
+    'HTML', 'CSS', 'DEFAULT_OPTIONS', 'Attachment', 'Document', 'Page',
+    'default_url_fetcher', 'VERSION', '__version__']
 
 
 # Import after setting the version, as the version is used in other modules
@@ -53,12 +115,15 @@ class HTML:
     Alternatively, use **one** named argument so that no guessing is involved:
 
     :type filename: str or pathlib.Path
-    :param filename: A filename, relative to the current directory, or
-        absolute.
-    :param str url: An absolute, fully qualified URL.
+    :param filename:
+        A filename, relative to the current directory, or absolute.
+    :param str url:
+        An absolute, fully qualified URL.
     :type file_obj: :term:`file object`
-    :param file_obj: Any object with a ``read`` method.
-    :param str string: A string of HTML source.
+    :param file_obj:
+        Any object with a ``read`` method.
+    :param str string:
+        A string of HTML source.
 
     Specifying multiple inputs is an error:
     ``HTML(filename="foo.html", url="localhost://bar.html")``
@@ -66,20 +131,22 @@ class HTML:
 
     You can also pass optional named arguments:
 
-    :param str encoding: Force the source character encoding.
-    :param str base_url: The base used to resolve relative URLs
-        (e.g. in ``<img src="../foo.png">``). If not provided, try to use
-        the input filename, URL, or ``name`` attribute of :term:`file objects
-        <file object>`.
-    :type url_fetcher: :term:`function`
-    :param url_fetcher: A function or other callable
-        with the same signature as :func:`default_url_fetcher` called to
-        fetch external resources such as stylesheets and images.
-        (See :ref:`URL Fetchers`.)
-    :param str media_type: The media type to use for ``@media``.
-        Defaults to ``'print'``. **Note:** In some cases like
-        ``HTML(string=foo)`` relative URLs will be invalid if ``base_url``
-        is not provided.
+    :param str encoding:
+        Force the source character encoding.
+    :param str base_url:
+        The base used to resolve relative URLs (e.g. in
+        ``<img src="../foo.png">``). If not provided, try to use the input
+        filename, URL, or ``name`` attribute of
+        :term:`file objects <file object>`.
+    :type url_fetcher: :term:`callable`
+    :param url_fetcher:
+        A function or other callable with the same signature as
+        :func:`default_url_fetcher` called to fetch external resources such as
+        stylesheets and images. (See :ref:`URL Fetchers`.)
+    :param str media_type:
+        The media type to use for ``@media``. Defaults to ``'print'``.
+        **Note:** In some cases like ``HTML(string=foo)`` relative URLs will be
+        invalid if ``base_url`` is not provided.
 
     """
     def __init__(self, guess=None, filename=None, url=None, file_obj=None,
@@ -117,49 +184,32 @@ class HTML:
     def _ph_stylesheets(self):
         return [HTML5_PH_STYLESHEET]
 
-    def render(self, stylesheets=None, presentational_hints=False,
-               optimize_size=('fonts', 'hinting', 'pdf'), jpeg_quality=None,
-               dpi=None, font_config=None, counter_style=None,
-               image_cache=None, forms=False):
+    def render(self, font_config=None, counter_style=None, **options):
         """Lay out and paginate the document, but do not (yet) export it.
 
         This returns a :class:`document.Document` object which provides
         access to individual pages and various meta-data.
         See :meth:`write_pdf` to get a PDF directly.
 
-        :param list stylesheets:
-            An optional list of user stylesheets. List elements are
-            :class:`CSS` objects, filenames, URLs, or file
-            objects. (See :ref:`Stylesheet Origins`.)
-        :param bool presentational_hints:
-            Whether HTML presentational hints are followed.
-        :param tuple optimize_size:
-            Optimize size of generated PDF. Can contain "images", "fonts",
-            "hinting" and "pdf".
-        :param int jpeg_quality: JPEG quality between 0 (worst) to 95 (best).
-        :param int dpi: Maximum resolution of images embedded in the PDF.
         :type font_config: :class:`text.fonts.FontConfiguration`
-        :param font_config: A font configuration handling ``@font-face`` rules.
+        :param font_config:
+            A font configuration handling ``@font-face`` rules.
         :type counter_style: :class:`css.counters.CounterStyle`
-        :param counter_style: A dictionary storing ``@counter-style`` rules.
-        :param image_cache:
-            A dictionary used to cache images, or a folder path where images
-            are temporarily stored.
-        :type image_cache: :obj:`dict` or :obj:`str`
-        :param bool forms: Whether PDF forms have to be included.
+        :param counter_style:
+            A dictionary storing ``@counter-style`` rules.
+        :param options:
+            The ``options`` parameter includes by default the
+            :data:`DEFAULT_OPTIONS` values.
         :returns: A :class:`document.Document` object.
 
         """
-        return Document._render(
-            self, stylesheets, presentational_hints, optimize_size,
-            jpeg_quality, dpi, font_config, counter_style, image_cache, forms)
+        new_options = DEFAULT_OPTIONS.copy()
+        new_options.update(options)
+        options = new_options
+        return Document._render(self, font_config, counter_style, options)
 
-    def write_pdf(self, target=None, stylesheets=None, zoom=1,
-                  attachments=None, finisher=None, presentational_hints=False,
-                  optimize_size=('fonts', 'hinting', 'pdf'), jpeg_quality=None,
-                  dpi=None, font_config=None, counter_style=None,
-                  image_cache=None, identifier=None, variant=None,
-                  version=None, forms=False, custom_metadata=False):
+    def write_pdf(self, target=None, zoom=1, finisher=None,
+                  font_config=None, counter_style=None, **options):
         """Render the document to a PDF file.
 
         This is a shortcut for calling :meth:`render`, then
@@ -170,55 +220,37 @@ class HTML:
         :param target:
             A filename where the PDF file is generated, a file object, or
             :obj:`None`.
-        :param list stylesheets:
-            An optional list of user stylesheets. The list's elements
-            are :class:`CSS` objects, filenames, URLs, or file-like
-            objects. (See :ref:`Stylesheet Origins`.)
         :param float zoom:
             The zoom factor in PDF units per CSS units.  **Warning**:
             All CSS units are affected, including physical units like
             ``cm`` and named sizes like ``A4``.  For values other than
             1, the physical CSS units will thus be "wrong".
-        :param list attachments: A list of additional file attachments for the
-            generated PDF document or :obj:`None`. The list's elements are
-            :class:`Attachment` objects, filenames, URLs or file-like objects.
-        :param finisher: A finisher function, that accepts the document and a
-            :class:`pydyf.PDF` object as parameters, can be passed to perform
+        :type finisher: :term:`callable`
+        :param finisher:
+            A finisher function or callable that accepts the document and a
+            :class:`pydyf.PDF` object as parameters. Can be passed to perform
             post-processing on the PDF right before the trailer is written.
-        :param bool presentational_hints: Whether HTML presentational hints are
-            followed.
-        :param tuple optimize_size:
-            Optimize size of generated PDF. Can contain "images", "fonts",
-            "hinting" and "pdf".
-        :param int jpeg_quality: JPEG quality between 0 (worst) to 95 (best).
-        :param int dpi: Maximum resolution of images embedded in the PDF.
         :type font_config: :class:`text.fonts.FontConfiguration`
-        :param font_config: A font configuration handling ``@font-face`` rules.
+        :param font_config:
+            A font configuration handling ``@font-face`` rules.
         :type counter_style: :class:`css.counters.CounterStyle`
-        :param counter_style: A dictionary storing ``@counter-style`` rules.
-        :param image_cache:
-            A dictionary used to cache images, or a folder path where images
-            are temporarily stored.
-        :type image_cache: :obj:`dict` or :obj:`str`
-        :param bytes identifier: A bytestring used as PDF file identifier.
-        :param str variant: A PDF variant name.
-        :param str version: A PDF version number.
-        :param bool forms: Whether PDF forms have to be included.
-        :param bool custom_metadata: Whether custom HTML metadata should be
-            stored in the generated PDF.
+        :param counter_style:
+            A dictionary storing ``@counter-style`` rules.
+        :param options:
+            The ``options`` parameter includes by default the
+            :data:`DEFAULT_OPTIONS` values.
         :returns:
             The PDF as :obj:`bytes` if ``target`` is not provided or
             :obj:`None`, otherwise :obj:`None` (the PDF is written to
             ``target``).
 
         """
+        new_options = DEFAULT_OPTIONS.copy()
+        new_options.update(options)
+        options = new_options
         return (
-            self.render(
-                stylesheets, presentational_hints, optimize_size, jpeg_quality,
-                dpi, font_config, counter_style, image_cache, forms)
-            .write_pdf(
-                target, zoom, attachments, finisher, identifier, variant,
-                version, custom_metadata))
+            self.render(font_config, counter_style, **options)
+            .write_pdf(target, zoom, finisher, **options))
 
 
 class CSS:
@@ -274,8 +306,9 @@ class Attachment:
     supported. An optional description can be provided with the ``description``
     argument.
 
-    :param description: A description of the attachment to be included in the
-        PDF document. May be :obj:`None`.
+    :param description:
+        A description of the attachment to be included in the PDF document.
+        May be :obj:`None`.
 
     """
     def __init__(self, guess=None, filename=None, url=None, file_obj=None,

--- a/weasyprint/html.py
+++ b/weasyprint/html.py
@@ -45,9 +45,6 @@ HTML_SPACE_SEPARATED_TOKENS_RE = re.compile(f'[^{HTML_WHITESPACE}]+')
 def ascii_lower(string):
     r"""Transform (only) ASCII letters to lower case: A-Z is mapped to a-z.
 
-    :param string: An Unicode string.
-    :returns: A new Unicode string.
-
     This is used for `ASCII case-insensitive
     <https://whatwg.org/C#ascii-case-insensitive>`_ matching.
 
@@ -66,15 +63,9 @@ def ascii_lower(string):
 
 
 def element_has_link_type(element, link_type):
-    """
-    Return whether the given element has a ``rel`` attribute with the
-    given link type.
-
-    :param link_type: Must be a lower-case string.
-
-    """
-    return any(ascii_lower(token) == link_type for token in
-               HTML_SPACE_SEPARATED_TOKENS_RE.findall(element.get('rel', '')))
+    """Return whether element has a ``rel`` attribute with given link type."""
+    tokens = HTML_SPACE_SEPARATED_TOKENS_RE.findall(element.get('rel', ''))
+    return any(ascii_lower(token) == link_type for token in tokens)
 
 
 # Maps HTML tag names to function taking an HTML element and returning a Box.

--- a/weasyprint/layout/__init__.py
+++ b/weasyprint/layout/__init__.py
@@ -105,10 +105,12 @@ def layout_document(html, root_box, context, max_loops=8):
     This includes line breaks, page breaks, absolute size and position for all
     boxes. Page based counters might require multiple passes.
 
-    :param root_box: root of the box tree (formatting structure of the html)
-                     the pages' boxes are created from that tree, i.e. this
-                     structure is not lost during pagination
-    :returns: a list of laid out Page objects.
+    :param root_box:
+        Root of the box tree (formatting structure of the HTML). The page boxes
+        are created from that tree, this structure is not lost during
+        pagination.
+    :returns:
+        A list of laid out Page objects.
 
     """
     initialize_page_maker(context, root_box)
@@ -287,13 +289,18 @@ class LayoutContext:
         Value depends on current page.
         https://drafts.csswg.org/css-gcpm/#funcdef-string
 
-        :param store: dictionary where the resolved value is stored.
-        :param page: current page.
-        :param name: name of the named string or running element.
-        :param keyword: indicates which value of the named string or running
-                        element to use. Default is the first assignment on the
-                        current page else the most recent assignment.
-        :returns: text for string set, box for running element
+        :param dict store:
+            Dictionary where the resolved value is stored.
+        :param page:
+            Current page.
+        :param str name:
+            Name of the named string or running element.
+        :param str keyword:
+            Indicates which value of the named string or running element to
+            use. Default is the first assignment on the current page else the
+            most recent assignment.
+        :returns:
+            Text for string set, box for running element.
 
         """
         if self.current_page in store[name]:

--- a/weasyprint/layout/page.py
+++ b/weasyprint/layout/page.py
@@ -174,20 +174,21 @@ def compute_fixed_dimension(context, box, outer, vertical, top_or_left):
 
 
 def compute_variable_dimension(context, side_boxes, vertical, outer_sum):
-    """
-    Compute and set a margin box fixed dimension on ``box``, as described in:
-    https://drafts.csswg.org/css-page-3/#margin-dimension
+    """Compute and set a margin box fixed dimension on ``box``
 
-    :param side_boxes: Three boxes on a same side (as opposed to a corner.)
+    Described in: https://drafts.csswg.org/css-page-3/#margin-dimension
+
+    :param side_boxes:
+        Three boxes on a same side (as opposed to a corner).
         A list of:
         - A @*-left or @*-top margin box
         - A @*-center or @*-middle margin box
         - A @*-right or @*-bottom margin box
     :param vertical:
-        True to set height, margin-top and margin-bottom; False for width,
-        margin-left and margin-right
+        ``True`` to set height, margin-top and margin-bottom;
+        ``False`` for width, margin-left and margin-right.
     :param outer_sum:
-        The target total outer dimension (max box width or height)
+        The target total outer dimension (max box width or height).
 
     """
     box_class = VerticalBox if vertical else HorizontalBox
@@ -310,8 +311,10 @@ def make_margin_boxes(context, page, state):
 
         Return ``None`` if this margin box should not be generated.
 
-        :param at_keyword: which margin box to return, eg. '@top-left'
-        :param containing_block: as expected by :func:`resolve_percentages`.
+        :param at_keyword:
+            Which margin box to return, e.g. '@top-left'
+        :param containing_block:
+            As expected by :func:`resolve_percentages`.
 
         """
         style = context.style_for(page.page_type, at_keyword)
@@ -507,9 +510,11 @@ def make_page(context, root_box, page_type, resume_at, page_number,
     and ``resume_at`` indicates where in the document to start the next page,
     or is ``None`` if this was the last page.
 
-    :param page_number: integer, start at 1 for the first page
-    :param resume_at: as returned by ``make_page()`` for the previous page,
-                      or ``None`` for the first page.
+    :param int page_number:
+        Page number, starts at 1 for the first page.
+    :param resume_at:
+        As returned by ``make_page()`` for the previous page, or ``None`` for
+        the first page.
 
     """
     style = context.style_for(page_type)

--- a/weasyprint/pdf/fonts.py
+++ b/weasyprint/pdf/fonts.py
@@ -7,8 +7,7 @@ import pydyf
 from ..logger import LOGGER
 
 
-def build_fonts_dictionary(pdf, fonts, optimize_size):
-    compress = 'pdf' in optimize_size
+def build_fonts_dictionary(pdf, fonts, compress_pdf, subset, hinting):
     pdf_fonts = pydyf.Dictionary()
     fonts_by_file_hash = {}
     for font in fonts.values():
@@ -22,10 +21,9 @@ def build_fonts_dictionary(pdf, fonts, optimize_size):
 
         # Clean font, optimize and handle emojis
         cmap = {}
-        if 'fonts' in optimize_size and not font.used_in_forms:
+        if subset and not font.used_in_forms:
             for file_font in file_fonts:
                 cmap = {**cmap, **file_font.cmap}
-        hinting = 'hinting' not in optimize_size
         font.clean(cmap, hinting)
 
         # Include font
@@ -34,15 +32,12 @@ def build_fonts_dictionary(pdf, fonts, optimize_size):
         else:
             font_extra = pydyf.Dictionary({'Length1': len(font.file_content)})
         font_stream = pydyf.Stream(
-            [font.file_content], font_extra, compress=compress)
+            [font.file_content], font_extra, compress=compress_pdf)
         pdf.add_object(font_stream)
         font_references_by_file_hash[file_hash] = font_stream.reference
 
     for font in fonts.values():
-        optimize = (
-            'fonts' in optimize_size and
-            font.ttfont and not font.used_in_forms)
-        if optimize:
+        if subset and font.ttfont and not font.used_in_forms:
             # Only store widths and map for used glyphs
             font_widths = font.widths
             cmap = font.cmap
@@ -82,7 +77,7 @@ def build_fonts_dictionary(pdf, fonts, optimize_size):
             b'1 begincodespacerange',
             b'<0000> <ffff>',
             b'endcodespacerange',
-            f'{len(cmap)} beginbfchar'.encode()], compress=compress)
+            f'{len(cmap)} beginbfchar'.encode()], compress=compress_pdf)
         for glyph, text in cmap.items():
             unicode_codepoints = ''.join(
                 f'{letter.encode("utf-16-be").hex()}' for letter in text)
@@ -104,7 +99,7 @@ def build_fonts_dictionary(pdf, fonts, optimize_size):
 
         if font.bitmap:
             _build_bitmap_font_dictionary(
-                font_dictionary, pdf, font, widths, optimize_size)
+                font_dictionary, pdf, font, widths, compress_pdf, subset)
         else:
             font_descriptor = pydyf.Dictionary({
                 'Type': '/FontDescriptor',
@@ -128,7 +123,7 @@ def build_fonts_dictionary(pdf, fonts, optimize_size):
                     bits[cid] = '1'
                 stream = pydyf.Stream(
                     (int(''.join(bits), 2).to_bytes(padded_width, 'big'),),
-                    compress=compress)
+                    compress=compress_pdf)
                 pdf.add_object(stream)
                 font_descriptor['CIDSet'] = stream.reference
             if font.type == 'otf':
@@ -158,12 +153,11 @@ def build_fonts_dictionary(pdf, fonts, optimize_size):
 
 
 def _build_bitmap_font_dictionary(font_dictionary, pdf, font, widths,
-                                  optimize_size):
-    compress = 'pdf' in optimize_size
+                                  compress_pdf, subset):
     # https://docs.microsoft.com/typography/opentype/spec/ebdt
     font_dictionary['FontBBox'] = pydyf.Array([0, 0, 1, 1])
     font_dictionary['FontMatrix'] = pydyf.Array([1, 0, 0, 1, 0, 0])
-    if 'fonts' in optimize_size:
+    if subset:
         chars = tuple(sorted(font.cmap))
     else:
         chars = tuple(range(256))
@@ -312,7 +306,7 @@ def _build_bitmap_font_dictionary(font_dictionary, pdf, font, widths,
             b'/BPC 1',
             b'/D [1 0]',
             b'ID', bitmap, b'EI'
-        ], compress=compress)
+        ], compress=compress_pdf)
         pdf.add_object(bitmap_stream)
         char_procs[glyph_id] = bitmap_stream.reference
 

--- a/weasyprint/text/line_break.py
+++ b/weasyprint/text/line_break.py
@@ -235,15 +235,7 @@ class Layout:
 
 
 def create_layout(text, style, context, max_width, justification_spacing):
-    """Return an opaque Pango layout with default Pango line-breaks.
-
-    :param text: Unicode
-    :param style: a style dict of computed values
-    :param max_width:
-        The maximum available width in the same unit as ``style['font_size']``,
-        or ``None`` for unlimited width.
-
-    """
+    """Return an opaque Pango layout with default Pango line-breaks."""
     layout = Layout(context, style, justification_spacing, max_width)
 
     # Make sure that max_width * Pango.SCALE == max_width * 1024 fits in a

--- a/weasyprint/urls.py
+++ b/weasyprint/urls.py
@@ -175,9 +175,12 @@ def default_url_fetcher(url, timeout=10, ssl_context=None):
     ``url_fetcher`` argument to :class:`HTML` or :class:`CSS`.
     (See :ref:`URL Fetchers`.)
 
-    :param str url: The URL of the resource to fetch.
-    :param int timeout: The number of seconds before HTTP requests are dropped.
-    :param ssl.SSLContext ssl_context: An SSL context used for HTTP requests.
+    :param str url:
+        The URL of the resource to fetch.
+    :param int timeout:
+        The number of seconds before HTTP requests are dropped.
+    :param ssl.SSLContext ssl_context:
+        An SSL context used for HTTP requests.
     :raises: An exception indicating failure, e.g. :obj:`ValueError` on
         syntactically invalid URL.
     :returns: A :obj:`dict` with the following keys:


### PR DESCRIPTION
This commit uses an "option" dictionary to store various API options that were used as arguments in many public and private functions. This change allows to easily document default values, to reduce the number of arguments and to avoid many repetitions in documentation and signatures.

The changes to the public API are minimal, and should only have an impact for users who passed unnamed arguments.