### PR TITLE
Remove duplicate compression of attachments

### DIFF
--- a/weasyprint/pdf/anchors.py
+++ b/weasyprint/pdf/anchors.py
@@ -2,7 +2,6 @@
 
 import hashlib
 import io
-import zlib
 from os.path import basename
 from urllib.parse import unquote, urlsplit
 

--- a/weasyprint/pdf/anchors.py
+++ b/weasyprint/pdf/anchors.py
@@ -261,23 +261,18 @@ def write_pdf_attachment(pdf, attachment, url_fetcher):
             uncompressed_length = 0
             stream = b''
             md5 = hashlib.md5()
-            compress = zlib.compressobj()
             for data in iter(lambda: source.read(4096), b''):
                 uncompressed_length += len(data)
                 md5.update(data)
-                compressed = compress.compress(data)
-                stream += compressed
-            compressed = compress.flush(zlib.Z_FINISH)
-            stream += compressed
+                stream += data
             file_extra = pydyf.Dictionary({
                 'Type': '/EmbeddedFile',
-                'Filter': '/FlateDecode',
                 'Params': pydyf.Dictionary({
                     'CheckSum': f'<{md5.hexdigest()}>',
                     'Size': uncompressed_length,
                 })
             })
-            file_stream = pydyf.Stream([stream], file_extra, compress)
+            file_stream = pydyf.Stream([stream], file_extra, compress=True)
             pdf.add_object(file_stream)
 
     except URLFetchingError as exception:


### PR DESCRIPTION
Attachments are compressed twice on the current master branch. This results in the attachment not opening properly. At least Evince only uncompresses once. 
The function at fault is `write_pdf_attachment` in [anchors.py](https://github.com/Kozea/WeasyPrint/tree/master/weasyprint/pdf/anchors.py).

The function already compresses the attachment internally and then passes it to `Stream`, along with the `compress` argument set to `compress`. This is evaluated as `True` and the attachment is compressed again by `Stream`.

This pull request removes compression inside `write_pdf_attachment` and leaves compression to `Stream`