### PR TITLE
Refactor compute_variable_dimension function to specifications

### DIFF
--- a/weasyprint/layout/page.py
+++ b/weasyprint/layout/page.py
@@ -27,7 +27,8 @@ class OrientedBox:
     @outer.setter
     def outer(self, new_outer_width):
         self.inner = min(
-            max(self.min_content_size, new_outer_width - self.sugar), self.max_content_size)
+            max(self.min_content_size, new_outer_width - self.sugar),
+            self.max_content_size)
 
     @property
     def outer_min_content_size(self):
@@ -210,9 +211,12 @@ def compute_variable_dimension(context, side_boxes, vertical, available_size):
             if available_size > (
                     box_a.outer_max_content_size +
                     box_c.outer_max_content_size):
-                # sum of the outer max-content widths is less than the available width
-                flex_space = (available_size -
-                    box_a.outer_max_content_size - box_c.outer_max_content_size)
+                # sum of the outer max-content widths
+                # is less than the available width
+                flex_space = (
+                    available_size -
+                    box_a.outer_max_content_size -
+                    box_c.outer_max_content_size)
                 flex_factor_a = box_a.outer_max_content_size
                 flex_factor_c = box_c.outer_max_content_size
                 flex_factor_sum = flex_factor_a + flex_factor_c
@@ -225,11 +229,12 @@ def compute_variable_dimension(context, side_boxes, vertical, available_size):
             elif available_size > (
                     box_a.outer_min_content_size +
                     box_c.outer_min_content_size):
-                # sum of the outer min-content widths is less than the available width
-                flex_space = (available_size -
-                    box_a.outer_min_content_size - box_c.outer_min_content_size)
-                box_a.inner = box_a.min_content_size
-                box_c.inner = box_c.min_content_size
+                # sum of the outer min-content widths
+                # is less than the available width
+                flex_space = (
+                    available_size -
+                    box_a.outer_min_content_size -
+                    box_c.outer_min_content_size)
                 flex_factor_a = (
                     box_a.max_content_size - box_a.min_content_size)
                 flex_factor_c = (
@@ -238,15 +243,15 @@ def compute_variable_dimension(context, side_boxes, vertical, available_size):
                 if flex_factor_sum == 0:
                     flex_factor_sum = 1
                 box_a.outer = box_a.min_content_size + (
-                   flex_space * flex_factor_a / flex_factor_sum)
+                    flex_space * flex_factor_a / flex_factor_sum)
                 box_c.outer = box_c.min_content_size + (
-                   flex_space * flex_factor_c / flex_factor_sum)
+                    flex_space * flex_factor_c / flex_factor_sum)
             else:
                 # otherwise
-                flex_space = (available_size -
-                    box_a.outer_min_content_size - box_c.outer_min_content_size)
-                box_a.inner = box_a.min_content_size
-                box_c.inner = box_c.min_content_size
+                flex_space = (
+                    available_size -
+                    box_a.outer_min_content_size -
+                    box_c.outer_min_content_size)
                 flex_factor_a = box_a.min_content_size
                 flex_factor_c = box_c.min_content_size
                 flex_factor_sum = flex_factor_a + flex_factor_c
@@ -268,9 +273,11 @@ def compute_variable_dimension(context, side_boxes, vertical, available_size):
             ac_max_content_size = 2 * max(
                 box_a.outer_max_content_size, box_c.outer_max_content_size)
             if available_size > (
-                box_b.outer_max_content_size + ac_max_content_size):
-                flex_space = (available_size -
-                    box_b.outer_max_content_size - ac_max_content_size)
+                    box_b.outer_max_content_size + ac_max_content_size):
+                flex_space = (
+                    available_size -
+                    box_b.outer_max_content_size -
+                    ac_max_content_size)
                 flex_factor_b = box_b.outer_max_content_size
                 flex_factor_ac = ac_max_content_size
                 flex_factor_sum = flex_factor_b + flex_factor_ac
@@ -282,9 +289,11 @@ def compute_variable_dimension(context, side_boxes, vertical, available_size):
                 ac_min_content_size = 2 * max(
                     box_a.outer_min_content_size, box_c.outer_min_content_size)
                 if available_size > (
-                    box_b.outer_min_content_size + ac_min_content_size):
-                    flex_space = (available_size -
-                        box_b.outer_min_content_size - ac_min_content_size)
+                        box_b.outer_min_content_size + ac_min_content_size):
+                    flex_space = (
+                        available_size -
+                        box_b.outer_min_content_size -
+                        ac_min_content_size)
                     flex_factor_b = (
                         box_b.max_content_size - box_b.min_content_size)
                     flex_factor_ac = ac_max_content_size - ac_min_content_size
@@ -294,8 +303,10 @@ def compute_variable_dimension(context, side_boxes, vertical, available_size):
                     box_b.outer = box_b.min_content_size + (
                         flex_space * flex_factor_b / flex_factor_sum)
                 else:
-                    flex_space = (available_size -
-                        box_b.outer_min_content_size - ac_min_content_size)
+                    flex_space = (
+                        available_size -
+                        box_b.outer_min_content_size -
+                        ac_min_content_size)
                     flex_factor_b = box_b.min_content_size
                     flex_factor_ac = ac_min_content_size
                     flex_factor_sum = flex_factor_b + flex_factor_ac

--- a/weasyprint/layout/page.py
+++ b/weasyprint/layout/page.py
@@ -24,6 +24,11 @@ class OrientedBox:
     def outer(self):
         return self.sugar + self.inner
 
+    @outer.setter
+    def outer(self, new_outer_width):
+        self.inner = min(
+            max(self.min_content_size, new_outer_width - self.sugar), self.max_content_size)
+
     @property
     def outer_min_content_size(self):
         return self.sugar + (
@@ -33,10 +38,6 @@ class OrientedBox:
     def outer_max_content_size(self):
         return self.sugar + (
             self.max_content_size if self.inner == 'auto' else self.inner)
-
-    def shrink_to_fit(self, available):
-        self.inner = min(
-            max(self.min_content_size, available), self.max_content_size)
 
 
 class VerticalBox(OrientedBox):
@@ -173,7 +174,7 @@ def compute_fixed_dimension(context, box, outer, vertical, top_or_left):
     box.restore_box_attributes()
 
 
-def compute_variable_dimension(context, side_boxes, vertical, outer_sum):
+def compute_variable_dimension(context, side_boxes, vertical, available_size):
     """Compute and set a margin box fixed dimension on ``box``
 
     Described in: https://drafts.csswg.org/css-page-3/#margin-dimension
@@ -187,8 +188,8 @@ def compute_variable_dimension(context, side_boxes, vertical, outer_sum):
     :param vertical:
         ``True`` to set height, margin-top and margin-bottom;
         ``False`` for width, margin-left and margin-right.
-    :param outer_sum:
-        The target total outer dimension (max box width or height).
+    :param available_size:
+        The distance between the page box’s left right border edges
 
     """
     box_class = VerticalBox if vertical else HorizontalBox
@@ -201,68 +202,111 @@ def compute_variable_dimension(context, side_boxes, vertical, outer_sum):
         if box.margin_b == 'auto':
             box.margin_b = 0
 
-    if box_b.box.is_generated:
-        if box_b.inner == 'auto':
-            ac_max_content_size = 2 * max(
-                box_a.outer_max_content_size, box_c.outer_max_content_size)
-            if outer_sum >= (
-                    box_b.outer_max_content_size + ac_max_content_size):
-                box_b.inner = box_b.max_content_size
-            else:
-                ac_min_content_size = 2 * max(
-                    box_a.outer_min_content_size,
-                    box_c.outer_min_content_size)
-                box_b.inner = box_b.min_content_size
-                available = outer_sum - box_b.outer - ac_min_content_size
-                if available > 0:
-                    weight_ac = ac_max_content_size - ac_min_content_size
-                    weight_b = (
-                        box_b.max_content_size - box_b.min_content_size)
-                    weight_sum = weight_ac + weight_b
-                    # By definition of max_content_size and min_content_size,
-                    # weights can not be negative. weight_sum == 0 implies that
-                    # max_content_size == min_content_size for each box, in
-                    # which case the sum can not be both <= and > outer_sum
-                    # Therefore, one of the last two 'if' statements would not
-                    # have lead us here.
-                    assert weight_sum > 0
-                    box_b.inner += available * weight_b / weight_sum
-        if box_a.inner == 'auto':
-            box_a.shrink_to_fit((outer_sum - box_b.outer) / 2 - box_a.sugar)
-        if box_c.inner == 'auto':
-            box_c.shrink_to_fit((outer_sum - box_b.outer) / 2 - box_c.sugar)
-    else:
+    if not box_b.box.is_generated:
         # Non-generated boxes get zero for every box-model property
         assert box_b.inner == 0
         if box_a.inner == box_c.inner == 'auto':
-            if outer_sum >= (
+            # A and C both have 'width: auto'
+            if available_size > (
                     box_a.outer_max_content_size +
                     box_c.outer_max_content_size):
-                box_a.inner = box_a.max_content_size
-                box_c.inner = box_c.max_content_size
-            else:
+                # sum of the outer max-content widths is less than the available width
+                flex_space = (available_size -
+                    box_a.outer_max_content_size - box_c.outer_max_content_size)
+                flex_factor_a = box_a.outer_max_content_size
+                flex_factor_c = box_c.outer_max_content_size
+                flex_factor_sum = flex_factor_a + flex_factor_c
+                if flex_factor_sum == 0:
+                    flex_factor_sum = 1
+                box_a.outer = box_a.max_content_size + (
+                    flex_space * flex_factor_a / flex_factor_sum)
+                box_c.outer = box_c.max_content_size + (
+                    flex_space * flex_factor_c / flex_factor_sum)
+            elif available_size > (
+                    box_a.outer_min_content_size +
+                    box_c.outer_min_content_size):
+                # sum of the outer min-content widths is less than the available width
+                flex_space = (available_size -
+                    box_a.outer_min_content_size - box_c.outer_min_content_size)
                 box_a.inner = box_a.min_content_size
                 box_c.inner = box_c.min_content_size
-                available = outer_sum - box_a.outer - box_c.outer
-                if available > 0:
-                    weight_a = (
-                        box_a.max_content_size - box_a.min_content_size)
-                    weight_c = (
-                        box_c.max_content_size - box_c.min_content_size)
-                    weight_sum = weight_a + weight_c
-                    # By definition of max_content_size and min_content_size,
-                    # weights can not be negative. weight_sum == 0 implies that
-                    # max_content_size == min_content_size for each box, in
-                    # which case the sum can not be both <= and > outer_sum
-                    # Therefore, one of the last two 'if' statements would not
-                    # have lead us here.
-                    assert weight_sum > 0
-                    box_a.inner += available * weight_a / weight_sum
-                    box_c.inner += available * weight_c / weight_sum
-        elif box_a.inner == 'auto':
-            box_a.shrink_to_fit(outer_sum - box_c.outer - box_a.sugar)
-        elif box_c.inner == 'auto':
-            box_c.shrink_to_fit(outer_sum - box_a.outer - box_c.sugar)
+                flex_factor_a = (
+                    box_a.max_content_size - box_a.min_content_size)
+                flex_factor_c = (
+                    box_c.max_content_size - box_c.min_content_size)
+                flex_factor_sum = flex_factor_a + flex_factor_c
+                if flex_factor_sum == 0:
+                    flex_factor_sum = 1
+                box_a.outer = box_a.min_content_size + (
+                   flex_space * flex_factor_a / flex_factor_sum)
+                box_c.outer = box_c.min_content_size + (
+                   flex_space * flex_factor_c / flex_factor_sum)
+            else:
+                # otherwise
+                flex_space = (available_size -
+                    box_a.outer_min_content_size - box_c.outer_min_content_size)
+                box_a.inner = box_a.min_content_size
+                box_c.inner = box_c.min_content_size
+                flex_factor_a = box_a.min_content_size
+                flex_factor_c = box_c.min_content_size
+                flex_factor_sum = flex_factor_a + flex_factor_c
+                if flex_factor_sum == 0:
+                    flex_factor_sum = 1
+                box_a.outer = box_a.min_content_size + (
+                    flex_space * flex_factor_a / flex_factor_sum)
+                box_c.outer = box_c.min_content_size + (
+                    flex_space * flex_factor_c / flex_factor_sum)
+        else:
+            # only one box has 'width: auto'
+            if box_a.inner == 'auto':
+                box_a.outer = available_size - box_c.outer
+            elif box_c.inner == 'auto':
+                box_c.outer = available_size - box_a.outer
+    else:
+        if box_b.inner == 'auto':
+            # resolve any auto width of the middle box (B)
+            ac_max_content_size = 2 * max(
+                box_a.outer_max_content_size, box_c.outer_max_content_size)
+            if available_size > (
+                box_b.outer_max_content_size + ac_max_content_size):
+                flex_space = (available_size -
+                    box_b.outer_max_content_size - ac_max_content_size)
+                flex_factor_b = box_b.outer_max_content_size
+                flex_factor_ac = ac_max_content_size
+                flex_factor_sum = flex_factor_b + flex_factor_ac
+                if flex_factor_sum == 0:
+                    flex_factor_sum = 1
+                box_b.outer = box_b.max_content_size + (
+                    flex_space * flex_factor_b / flex_factor_sum)
+            else:
+                ac_min_content_size = 2 * max(
+                    box_a.outer_min_content_size, box_c.outer_min_content_size)
+                if available_size > (
+                    box_b.outer_min_content_size + ac_min_content_size):
+                    flex_space = (available_size -
+                        box_b.outer_min_content_size - ac_min_content_size)
+                    flex_factor_b = (
+                        box_b.max_content_size - box_b.min_content_size)
+                    flex_factor_ac = ac_max_content_size - ac_min_content_size
+                    flex_factor_sum = flex_factor_b + flex_factor_ac
+                    if flex_factor_sum == 0:
+                        flex_factor_sum = 1
+                    box_b.outer = box_b.min_content_size + (
+                        flex_space * flex_factor_b / flex_factor_sum)
+                else:
+                    flex_space = (available_size -
+                        box_b.outer_min_content_size - ac_min_content_size)
+                    flex_factor_b = box_b.min_content_size
+                    flex_factor_ac = ac_min_content_size
+                    flex_factor_sum = flex_factor_b + flex_factor_ac
+                    if flex_factor_sum == 0:
+                        flex_factor_sum = 1
+                    box_b.outer = box_b.min_content_size + (
+                        flex_space * flex_factor_b / flex_factor_sum)
+        if box_a.inner == 'auto':
+            box_a.outer = (available_size - box_b.outer) / 2
+        if box_c.inner == 'auto':
+            box_c.outer = (available_size - box_b.outer) / 2
 
     # And, we’re done!
     assert 'auto' not in [box.inner for box in side_boxes]


### PR DESCRIPTION
> In 2012, when @SimonSapin implemented the page-margins layout, the specification was this one:
https://www.w3.org/TR/2006/WD-css3-page-20061010/#margin-dimension
>
> [...]
>
> This proposition was accepted, probably with some changes (I don't remember, maybe Simon does). So the first step is to find what's different between the current specification and the current implementation in `compute_variable_dimension`, and then fix these differences.

_Originally posted by @liZe in https://github.com/Kozea/WeasyPrint/issues/58#issuecomment-511187829_

I think the proposition was accepted without changes(?) because all tests passed without changes even after refactoring the code to "more closely follow" the specifications layout terminologies and algorithm flow.