### PR TITLE
Fix named pages inheritence

### DIFF
--- a/tests/layout/test_page.py
+++ b/tests/layout/test_page.py
@@ -831,16 +831,26 @@ def test_page_names_10():
       <div id="running">running</div>
       <div id="fixed">fixed</div>
       <section>
-        text
+        <h1>text</h1>
         <div class="pagebreak"></div>
-        text
+        <article>text</article>
       </section>
     ''')
     page1, page2 = pages
 
     assert (page1.width, page1.height) == (100, 100)
+    html, runing = page1.children
+    body, = html.children
+    fixed, section, = body.children
+    h1, pagebreak = section.children
+    assert h1.element_tag == 'h1'
 
     assert (page2.width, page2.height) == (100, 100)
+    html, running = page2.children
+    fixed, body = html.children
+    section, = body.children
+    article, = section.children
+    assert article.element_tag == 'article'
 
 
 @assert_no_logs

--- a/tests/layout/test_page.py
+++ b/tests/layout/test_page.py
@@ -818,6 +818,32 @@ def test_page_names_9():
 
 
 @assert_no_logs
+def test_page_names_10():
+    pages = render_pages('''
+      <style>
+        #running { position: running(running); }
+        #fixed { position: fixed; }
+        @page { size: 200px 200px; @top-center { content: element(header); }}
+        section { page: small; }
+        @page small { size: 100px 100px; }
+        .pagebreak { break-after: page; }
+      </style>
+      <div id="running">running</div>
+      <div id="fixed">fixed</div>
+      <section>
+        text
+        <div class="pagebreak"></div>
+        text
+      </section>
+    ''')
+    page1, page2 = pages
+
+    assert (page1.width, page1.height) == (100, 100)
+
+    assert (page2.width, page2.height) == (100, 100)
+
+
+@assert_no_logs
 @pytest.mark.parametrize('style, line_counts', (
     ('orphans: 2; widows: 2', [4, 3]),
     ('orphans: 5; widows: 2', [0, 7]),

--- a/weasyprint/formatting_structure/boxes.py
+++ b/weasyprint/formatting_structure/boxes.py
@@ -377,13 +377,14 @@ class ParentBox(Box):
 
     def page_values(self):
         start_value, end_value = super().page_values()
-        if self.children:
-            if len(self.children) == 1:
-                page_values = self.children[0].page_values()
+        children = [c for c in self.children if not(c.is_absolutely_positioned() or c.is_running() or c.is_footnote())]
+        if children:
+            if len(children) == 1:
+                page_values = children[0].page_values()
                 start_value = page_values[0] or start_value
                 end_value = page_values[1] or end_value
             else:
-                start_box, end_box = self.children[0], self.children[-1]
+                start_box, end_box = children[0], children[-1]
                 start_value = start_box.page_values()[0] or start_value
                 end_value = end_box.page_values()[1] or end_value
         return start_value, end_value

--- a/weasyprint/formatting_structure/boxes.py
+++ b/weasyprint/formatting_structure/boxes.py
@@ -377,7 +377,10 @@ class ParentBox(Box):
 
     def page_values(self):
         start_value, end_value = super().page_values()
-        children = [c for c in self.children if not(c.is_absolutely_positioned() or c.is_running() or c.is_footnote())]
+        children = [
+            c for c in self.children
+            if not (c.is_absolutely_positioned() or c.is_running())
+        ]
         if children:
             if len(children) == 1:
                 page_values = children[0].page_values()


### PR DESCRIPTION
Fix #1897 

Hi!
I am not sure if this PR is sufficient to reliably fix the problem with named page inheritance, since I have not found how/where weasyprint calculates class A break points. However, these changes fix the page inheritance in my situation (and do not break other test cases).

Feel free add commits or point me in the right direction :)

