### PR TITLE
fix:prioritize GTK3 fontconfig dll over graphviz's

### DIFF
--- a/weasyprint/text/ffi.py
+++ b/weasyprint/text/ffi.py
@@ -436,8 +436,8 @@ harfbuzz = _dlopen(
     'libharfbuzz.so.0', 'libharfbuzz.so.0', 'libharfbuzz.0.dylib',
     'libharfbuzz-0.dll')
 fontconfig = _dlopen(
-    ffi, 'fontconfig-1', 'fontconfig', 'libfontconfig', 'libfontconfig.so.1',
-    'libfontconfig.1.dylib', 'libfontconfig-1.dll')
+    ffi, 'libfontconfig-1.dll', 'fontconfig-1', 'fontconfig', 'libfontconfig', 
+    'libfontconfig.so.1', 'libfontconfig.1.dylib')
 pangoft2 = _dlopen(
     ffi, 'pangoft2-1.0-0', 'pangoft2-1.0', 'libpangoft2-1.0-0',
     'libpangoft2-1.0.so.0', 'libpangoft2-1.0.dylib', 'libpangoft2-1.0-0.dll')

--- a/weasyprint/text/ffi.py
+++ b/weasyprint/text/ffi.py
@@ -436,7 +436,7 @@ harfbuzz = _dlopen(
     'libharfbuzz.so.0', 'libharfbuzz.so.0', 'libharfbuzz.0.dylib',
     'libharfbuzz-0.dll')
 fontconfig = _dlopen(
-    ffi, 'libfontconfig-1.dll', 'fontconfig-1', 'fontconfig', 'libfontconfig', 
+    ffi, 'libfontconfig-1.dll', 'fontconfig-1', 'fontconfig', 'libfontconfig',
     'libfontconfig.so.1', 'libfontconfig.1.dylib')
 pangoft2 = _dlopen(
     ffi, 'pangoft2-1.0-0', 'pangoft2-1.0', 'libpangoft2-1.0-0',


### PR DESCRIPTION
graphviz on Windows has `fontconfig` DLL file, so when it is installed, it takes the needed DLL file from it instead of getting it from GTK3 installed package. So, I have just sorted the list of expected DLL filenames to prioritize the current GTK3 fontconfig DLL file which is `libfontconfig-1.dll`. Now, no need to uninstall Graphviz from Windows to make it work.