### PR TITLE
[DOCS] Include POSIX compliant single quotes

### DIFF
--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -13,7 +13,7 @@ install WeasyPrint dependencies.
    git clone https://github.com/Kozea/WeasyPrint.git
    cd WeasyPrint
    python -m venv venv
-   venv/bin/pip install -e .[doc,test]
+   venv/bin/pip install -e '.[doc,test]'
 
 You can then launch Python to test your changes.
 


### PR DESCRIPTION
Resolves #1930 

Changes the _pip install_ instruction to surround the `-e` argument with POSIX-compliant single quotes.

```
   git clone https://github.com/Kozea/WeasyPrint.git
   cd WeasyPrint
   python -m venv venv
   venv/bin/pip install -e '.[doc,test]'
```
