### PR TITLE
 Fixed two span properties in one place

### DIFF
--- a/weasyprint/formatting_structure/boxes.py
+++ b/weasyprint/formatting_structure/boxes.py
@@ -601,9 +601,6 @@ class TableColumnGroupBox(ParentBox):
     internal_table_or_caption = True
     proper_parents = (TableBox, InlineTableBox)
 
-    # Default value. May be overriden on instances.
-    span = 1
-
     # Columns groups never have margins or paddings
     margin_top = 0
     margin_bottom = 0
@@ -637,9 +634,6 @@ class TableColumnBox(ParentBox):
     proper_table_child = True
     internal_table_or_caption = True
     proper_parents = (TableBox, InlineTableBox, TableColumnGroupBox)
-
-    # Default value. May be overriden on instances.
-    span = 1
 
     # Columns never have margins or paddings
     margin_top = 0


### PR DESCRIPTION
Hello,

There was an error that the span existed in two places in the Actions Workflow (ubuntu-latest - 3.11).
As far as I can see, it was a property that returned the set default value, so I deleted it.

Please check if there are any problems.