### PR TITLE
Handle y offset of glyphs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = '>=3.7'
 readme = {file = 'README.rst', content-type = 'text/x-rst'}
 license = {file = 'LICENSE'}
 dependencies = [
-  'pydyf >=0.6.0',
+  'pydyf >=0.8.0',
   'cffi >=0.6',
   'html5lib >=1.1',
   'tinycss2 >=1.0.0',

--- a/weasyprint/draw.py
+++ b/weasyprint/draw.py
@@ -1179,15 +1179,14 @@ def draw_first_line(stream, textbox, text_overflow, block_ellipsis, matrix):
             utf8_position = utf8_positions[i]
 
             offset = glyph_info.geometry.x_offset / font_size
-
-            offset_y = glyph_info.geometry.y_offset / font_size / textbox.height
-            if offset_y:
+            rise = glyph_info.geometry.y_offset / 1000
+            if rise:
                 if string[-1] == '<':
                     string = string[:-1]
                 else:
                     string += '>'
                 stream.show_text(string)
-                stream.set_text_rise(-offset_y)
+                stream.set_text_rise(-rise)
                 string = ''
                 if offset:
                     string = f'{-offset}'

--- a/weasyprint/draw.py
+++ b/weasyprint/draw.py
@@ -1179,9 +1179,27 @@ def draw_first_line(stream, textbox, text_overflow, block_ellipsis, matrix):
             utf8_position = utf8_positions[i]
 
             offset = glyph_info.geometry.x_offset / font_size
-            if offset:
-                string += f'>{-offset}<'
-            string += f'{glyph:02x}' if font.bitmap else f'{glyph:04x}'
+
+            offset_y = glyph_info.geometry.y_offset / font_size / textbox.height
+            if offset_y:
+                if string[-1] == '<':
+                    string = string[:-1]
+                else:
+                    string += '>'
+                stream.show_text(string)
+                stream.set_rise(-offset_y)
+                string = ''
+                if offset:
+                    string = f'{-offset}'
+                string += f'<{glyph:02x}>' if font.bitmap else f'<{glyph:04x}>'
+                stream.show_text(string)
+                stream.set_rise(0)
+                stream.set_rise(0)
+                string = '<'
+            else:
+                if offset:
+                    string += f'>{-offset}<'
+                string += f'{glyph:02x}' if font.bitmap else f'{glyph:04x}'
 
             # Ink bounding box and logical widths in font
             if glyph not in font.widths:

--- a/weasyprint/draw.py
+++ b/weasyprint/draw.py
@@ -1187,14 +1187,14 @@ def draw_first_line(stream, textbox, text_overflow, block_ellipsis, matrix):
                 else:
                     string += '>'
                 stream.show_text(string)
-                stream.set_rise(-offset_y)
+                stream.set_text_rise(-offset_y)
                 string = ''
                 if offset:
                     string = f'{-offset}'
                 string += f'<{glyph:02x}>' if font.bitmap else f'<{glyph:04x}>'
                 stream.show_text(string)
-                stream.set_rise(0)
-                stream.set_rise(0)
+                stream.set_text_rise(0)
+                stream.set_text_rise(0)
                 string = '<'
             else:
                 if offset:

--- a/weasyprint/draw.py
+++ b/weasyprint/draw.py
@@ -1194,7 +1194,6 @@ def draw_first_line(stream, textbox, text_overflow, block_ellipsis, matrix):
                 string += f'<{glyph:02x}>' if font.bitmap else f'<{glyph:04x}>'
                 stream.show_text(string)
                 stream.set_text_rise(0)
-                stream.set_text_rise(0)
                 string = '<'
             else:
                 if offset:


### PR DESCRIPTION
Initial attempt to [Handle y offset of glyphs](https://github.com/Kozea/WeasyPrint/issues/1958)

(This is a work in progress, I've opened the PR for to get some feedback. The calculation I have - `offset_y = glyph_info.geometry.y_offset / font_size / textbox.height` does not seem to be accurate - since if the line height is large, the glyphs show up lower then they should.)