### PR TITLE
Replace md1/sha1 with blake2b where possible

### DIFF
--- a/weasyprint/document.py
+++ b/weasyprint/document.py
@@ -2,7 +2,7 @@
 
 import functools
 import io
-from hashlib import md5
+from hashlib import blake2b
 from pathlib import Path
 
 from . import CSS, DEFAULT_OPTIONS
@@ -174,7 +174,7 @@ class DiskCache:
         self._disk_paths = set()
 
     def _path_from_key(self, key):
-        return self._path / md5(key.encode()).hexdigest()
+        return self._path / blake2b(key.encode(), digest_size=16).hexdigest()
 
     def __getitem__(self, key):
         if key in self._memory_cache:

--- a/weasyprint/images.py
+++ b/weasyprint/images.py
@@ -3,7 +3,7 @@
 import io
 import math
 import struct
-from hashlib import md5
+from hashlib import blake2b
 from io import BytesIO
 from itertools import cycle
 from math import inf
@@ -323,7 +323,7 @@ def get_image_from_uri(cache, url_fetcher, options, url, forced_mime_type=None,
                     raise ImageLoadingError.from_exception(raster_exception)
             else:
                 # Store image id to enable cache in Stream.add_image
-                image_id = md5(url.encode()).hexdigest()
+                image_id = blake2b(url.encode(), digest_size=16).hexdigest()
                 image = RasterImage(
                     pillow_image, image_id, string, filename, cache,
                     orientation, options)

--- a/weasyprint/pdf/stream.py
+++ b/weasyprint/pdf/stream.py
@@ -2,7 +2,7 @@
 
 import io
 from functools import lru_cache
-from hashlib import md5
+from hashlib import blake2b
 
 import pydyf
 from fontTools import subset
@@ -39,7 +39,7 @@ class Font:
         # Never use the built-in hash function here: it’s not stable
         self.hash = ''.join(
             chr(65 + letter % 26) for letter
-            in md5(description_string).digest()[:6])
+            in blake2b(description_string, digest_size=16).digest()[:6])
 
         # Name
         fields = description_string.split(b' ')

--- a/weasyprint/text/fonts.py
+++ b/weasyprint/text/fonts.py
@@ -1,6 +1,6 @@
 """Interface with external libraries managing fonts installed on the system."""
 
-from hashlib import sha1
+from hashlib import blake2b
 from io import BytesIO
 from pathlib import Path
 from shutil import rmtree
@@ -121,9 +121,9 @@ class FontConfiguration:
             rule_descriptors.get('font_weight', 'normal')]
         fontconfig_stretch = FONTCONFIG_STRETCH[
             rule_descriptors.get('font_stretch', 'normal')]
-        config_key = sha1((
+        config_key = blake2b((
             f'{rule_descriptors["font_family"]}-{fontconfig_style}-'
-            f'{fontconfig_weight}-{features_string}').encode()).hexdigest()
+            f'{fontconfig_weight}-{features_string}').encode(), digest_size=20).hexdigest()
         font_path = self._folder / config_key
         if font_path.exists():
             return


### PR DESCRIPTION
blake2b is faster and more secure than either, and has been generally available since python 3.6