### PR TITLE
Fix WeasyPrint value for input/textarea

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -482,15 +482,17 @@ def test_partial_pdf_custom_metadata():
     assert b'value' in stdout
 
 
-@pytest.mark.parametrize('html, field', (
-    (b'<input>', b'/Tx'),
-    (b'<input type="checkbox">', b'/Btn'),
-    (b'<textarea></textarea>', b'/Tx'),
+@pytest.mark.parametrize('html, fields', (
+    (b'<input>', [b'/Tx', b'/V ()']),
+    (b'<input value="">', [b'/Tx', b'/V ()']),
+    (b'<input type="checkbox">', [b'/Btn']),
+    (b'<textarea></textarea>', [b'/Tx', b'/V ()']),
 ))
-def test_pdf_inputs(html, field):
+def test_pdf_inputs(html, fields):
     stdout = _run('--pdf-forms --uncompressed-pdf - -', html)
     assert b'AcroForm' in stdout
-    assert field in stdout
+    for field in fields:
+        assert field in stdout
     stdout = _run('--uncompressed-pdf - -', html)
     assert b'AcroForm' not in stdout
 

--- a/weasyprint/pdf/anchors.py
+++ b/weasyprint/pdf/anchors.py
@@ -180,7 +180,13 @@ def add_inputs(inputs, matrix, pdf, page, resources, stream, font_map,
                 'F': 2 ** (3 - 1),  # Print flag
                 'P': page.reference,
                 'T': pydyf.String(input_name),
-                'V': pydyf.String(value),
+                # Previously if the input had no value or the value was an
+                # empty string, the V key was filled with a pydyf.String(None)
+                # object. This caused the PDF input/textarea to be filled with
+                # the string "None". Now if the input has no value or the
+                # value is an empty string, the V key is filled with a
+                # pydyf.String('') object.
+                'V': pydyf.String(value or ''),
                 'DA': pydyf.String(b' '.join(field_stream.stream)),
             })
             if element.tag == 'textarea':


### PR DESCRIPTION
Previously we were filling it with a `pydyf.String(None)` when the HTML had no value or even an empty string as value, which was rendering the field with a `None` starting value.

This PR fix this behavior using an empty string on the `/V` if the value is `None`.