### PR TITLE
Remove warnings for PDF/A, PDF/UA compatibility.

### DIFF
--- a/weasyprint/pdf/pdfa.py
+++ b/weasyprint/pdf/pdfa.py
@@ -14,17 +14,11 @@ from functools import partial
 
 import pydyf
 
-from ..logger import LOGGER
 from .metadata import add_metadata
 
 
 def pdfa(pdf, metadata, document, page_streams, compress, version):
     """Set metadata for PDF/A documents."""
-    LOGGER.warning(
-        'PDF/A support is experimental, '
-        'generated PDF files are not guaranteed to be valid. '
-        'Please open an issue if you have problems generating PDF/A files.')
-
     # Add ICC profile
     profile = pydyf.Stream(
         [read_binary(__package__, 'sRGB2014.icc')],

--- a/weasyprint/pdf/pdfua.py
+++ b/weasyprint/pdf/pdfua.py
@@ -2,17 +2,11 @@
 
 import pydyf
 
-from ..logger import LOGGER
 from .metadata import add_metadata
 
 
 def pdfua(pdf, metadata, document, page_streams, compress):
     """Set metadata for PDF/UA documents."""
-    LOGGER.warning(
-        'PDF/UA support is experimental, '
-        'generated PDF files are not guaranteed to be valid. '
-        'Please open an issue if you have problems generating PDF/UA files.')
-
     # Structure for PDF tagging
     content_mapping = pydyf.Dictionary({})
     pdf.add_object(content_mapping)


### PR DESCRIPTION
Avoids spamming production logs with PDF/A, PDF/UA compatibility warnings.