### PR TITLE
Support var() in shorthand and multiple-value functions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,10 +8,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.11']
+        python-version: ['3.12']
         include:
           - os: ubuntu-latest
-            python-version: '3.7'
+            python-version: '3.8'
           - os: ubuntu-latest
             python-version: 'pypy-3.8'
     steps:

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ WebKit or Gecko. The CSS layout engine is written in Python, designed for
 pagination, and meant to be easy to hack on.
 
 * Free software: BSD license
-* For Python 3.7+, tested on CPython and PyPy
+* For Python 3.8+, tested on CPython and PyPy
 * Documentation: https://doc.courtbouillon.org/weasyprint
 * Examples: https://weasyprint.org/#samples
 * Changelog: https://github.com/Kozea/WeasyPrint/releases

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -715,11 +715,9 @@ The `CSS Custom Properties for Cascading Variables Module Level 1`_ "introduces
 cascading variables as a new primitive value type that is accepted by all CSS
 properties, and custom properties for defining them."
 
-The custom properties are supported. The ``var()`` notation is `only supported
-in single-value properties`_.
+The custom properties and the ``var()`` notation are supported.
 
 .. _CSS Custom Properties for Cascading Variables Module Level 1: https://www.w3.org/TR/css-variables/
-.. _only supported in single-value properties: https://github.com/Kozea/WeasyPrint/issues/1219
 
 CSS Text Decoration Module Level 3
 ++++++++++++++++++++++++++++++++++

--- a/docs/first_steps.rst
+++ b/docs/first_steps.rst
@@ -9,7 +9,7 @@ Installation
 
 WeasyPrint |version| depends on:
 
-* Python_ ≥ 3.7.0
+* Python_ ≥ 3.8.0
 * Pango_ ≥ 1.44.0
 * pydyf_ ≥ 0.6.0
 * CFFI_ ≥ 0.6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = 'The Awesome Document Factory'
 keywords = ['html', 'css', 'pdf', 'converter']
 authors = [{name = 'Simon Sapin', email = 'simon.sapin@exyr.org'}]
 maintainers = [{name = 'CourtBouillon', email = 'contact@courtbouillon.org'}]
-requires-python = '>=3.7'
+requires-python = '>=3.8'
 readme = {file = 'README.rst', content-type = 'text/x-rst'}
 license = {file = 'LICENSE'}
 dependencies = [
@@ -29,11 +29,11 @@ classifiers = [
   'Programming Language :: Python',
   'Programming Language :: Python :: 3',
   'Programming Language :: Python :: 3 :: Only',
-  'Programming Language :: Python :: 3.7',
   'Programming Language :: Python :: 3.8',
   'Programming Language :: Python :: 3.9',
   'Programming Language :: Python :: 3.10',
   'Programming Language :: Python :: 3.11',
+  'Programming Language :: Python :: 3.12',
   'Programming Language :: Python :: Implementation :: CPython',
   'Programming Language :: Python :: Implementation :: PyPy',
   'Topic :: Internet :: WWW/HTTP',

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -417,14 +417,17 @@ def test_variable_in_function_multiple_values():
         <div></div>
         <h1></h1>
         <div></div>
+        <h1></h1>
+        <div style="--counter: var(--name), lower-roman"></div>
       </section>
     ''')
     html, = page.children
     body, = html.children
     section, = body.children
-    h11, div1, h12, div2 = section.children
+    h11, div1, h12, div2, h13, div3 = section.children
     assert div1.children[0].children[0].children[0].text == 'I'
     assert div2.children[0].children[0].children[0].text == 'II'
+    assert div3.children[0].children[0].children[0].text == 'iii'
 
 
 @assert_no_logs
@@ -440,14 +443,17 @@ def test_variable_in_variable_in_function():
         <div></div>
         <h1></h1>
         <div></div>
+        <h1></h1>
+        <div style="--counter: var(--name), lower-roman"></div>
       </section>
     ''')
     html, = page.children
     body, = html.children
     section, = body.children
-    h11, div1, h12, div2 = section.children
+    h11, div1, h12, div2, h13, div3 = section.children
     assert div1.children[0].children[0].children[0].text == 'I'
     assert div2.children[0].children[0].children[0].text == 'II'
+    assert div3.children[0].children[0].children[0].text == 'iii'
 
 
 def test_variable_in_function_missing():

--- a/weasyprint/css/__init__.py
+++ b/weasyprint/css/__init__.py
@@ -26,11 +26,11 @@ from . import counters, media_queries
 from .computed_values import (
     COMPUTER_FUNCTIONS, ZERO_PIXELS, compute_var, resolve_var)
 from .properties import INHERITED, INITIAL_NOT_COMPUTED, INITIAL_VALUES
-from .utils import check_var_function, get_url, remove_whitespace
+from .utils import (
+    InvalidValues, check_var_function, get_url, remove_whitespace)
 from .validation import preprocess_declarations
 from .validation.descriptors import preprocess_descriptors
 from .validation.expanders import PendingExpander
-from .validation.properties import validate_non_shorthand
 
 # Reject anything not in here:
 PSEUDO_ELEMENTS = (
@@ -732,6 +732,8 @@ class ComputedStyle(dict):
             return self[key]
 
         if isinstance(value, PendingExpander):
+            # Expander with pending values, validate them.
+            computed = False
             solved_tokens = []
             for token in value.tokens:
                 variable = check_var_function(token)
@@ -743,8 +745,19 @@ class ComputedStyle(dict):
                 else:
                     solved_tokens.append(token)
             original_key = key.replace('_', '-')
-            solved = value.solve(solved_tokens, original_key)
-            value = validate_non_shorthand(None, original_key, solved)[0][1]
+            try:
+                value = value.solve(solved_tokens, original_key)
+            except InvalidValues:
+                if key in INHERITED:
+                    # Values in parent_style are already computed.
+                    self[key] = value = parent_style[key]
+                    return value
+                else:
+                    value = INITIAL_VALUES[key]
+                    if key not in INITIAL_NOT_COMPUTED:
+                        # The value is the same as when computed.
+                        self[key] = value
+                        return value
 
         if not computed and key in COMPUTER_FUNCTIONS:
             # Value not computed yet: compute.

--- a/weasyprint/css/computed_values.py
+++ b/weasyprint/css/computed_values.py
@@ -150,7 +150,7 @@ COMPUTING_ORDER = _computing_order()
 COMPUTER_FUNCTIONS = {}
 
 
-def _resolve_var(computed, variable_name, default, parent_style):
+def resolve_var(computed, variable_name, default, parent_style):
     known_variable_names = [variable_name]
 
     computed_value = computed[variable_name]
@@ -246,7 +246,7 @@ def compute_var(name, computed_style, parent_style):
     validator = PROPERTIES[validation_name]
     for i, variable in variables.items():
         variable_name, default = variable
-        value = _resolve_var(
+        value = resolve_var(
             computed_style, variable_name, default, parent_style)
 
         if value is not None:

--- a/weasyprint/css/computed_values.py
+++ b/weasyprint/css/computed_values.py
@@ -246,7 +246,7 @@ def compute_var(name, computed_style, parent_style):
     validator = PROPERTIES[validation_name]
     for i, variable in variables.items():
         variable_name, default = variable
-        value = resolve_var(
+        resolved_value = value = resolve_var(
             computed_style, variable_name, default, parent_style)
 
         if value is not None:
@@ -263,8 +263,8 @@ def compute_var(name, computed_style, parent_style):
                 value = ''.join(token.serialize() for token in value)
             LOGGER.warning(
                 'Unsupported computed value "%s" set in variable %r '
-                'for property %r.', value, variable_name.replace('_', '-'),
-                validation_name)
+                'for property %r.', resolved_value,
+                variable_name.replace('_', '-'), validation_name)
             values[i] = (parent_style if inherited else INITIAL_VALUES)[name]
         elif multiple_values:
             # Replace original variable by possibly multiple validated values.

--- a/weasyprint/css/utils.py
+++ b/weasyprint/css/utils.py
@@ -2,10 +2,12 @@
 
 import functools
 import math
+from abc import ABC, abstractmethod
 from urllib.parse import unquote, urljoin
 
 from tinycss2.color3 import parse_color
 
+from .. import LOGGER
 from ..urls import iri_to_uri, url_is_absolute
 from .properties import Dimension
 
@@ -93,6 +95,41 @@ class CenterKeywordFakeToken:
     type = 'ident'
     lower_value = 'center'
     unit = None
+
+
+class Pending(ABC):
+    """Abstract class representing property value with pending validation."""
+    # See https://drafts.csswg.org/css-variables-2/#variables-in-shorthands.
+    def __init__(self, tokens, name):
+        self.tokens = tokens
+        self.name = name
+        self._reported_error = False
+
+    @abstractmethod
+    def validate(self, tokens, wanted_key):
+        """Get validated value for wanted key."""
+        raise NotImplementedError
+
+    def solve(self, tokens, wanted_key):
+        """Get validated value or raise error."""
+        try:
+            if not tokens:
+                # Having no tokens is allowed by grammar but refused by all
+                # properties and expanders.
+                raise InvalidValues('no value')
+            return self.validate(tokens, wanted_key)
+        except InvalidValues as exc:
+            if self._reported_error:
+                raise exc
+            source_line = self.tokens[0].source_line
+            source_column = self.tokens[0].source_column
+            value = ' '.join(token.serialize() for token in tokens)
+            message = (exc.args and exc.args[0]) or 'invalid value'
+            LOGGER.warning(
+                'Ignored `%s: %s` at %d:%d, %s.',
+                self.name, value, source_line, source_column, message)
+            self._reported_error = True
+            raise exc
 
 
 def split_on_comma(tokens):
@@ -496,18 +533,16 @@ def check_string_or_element_function(string_or_element, token):
 
 
 def check_var_function(token):
-    function = parse_function(token)
-    if function is None:
-        return
-    name, args = function
-    if name == 'var' and args:
-        ident = args.pop(0)
-        if ident.type != 'ident' or not ident.value.startswith('--'):
-            return
-
-        # TODO: we should check authorized tokens
-        # https://drafts.csswg.org/css-syntax-3/#typedef-declaration-value
-        return ('var()', (ident.value.replace('-', '_'), args))
+    if function := parse_function(token):
+        name, args = function
+        if name == 'var' and args:
+            ident = args.pop(0)
+            # TODO: we should check authorized tokens
+            # https://drafts.csswg.org/css-syntax-3/#typedef-declaration-value
+            return ident.type == 'ident' and ident.value.startswith('--')
+        for arg in args:
+            if check_var_function(arg):
+                return True
 
 
 def get_string(token):
@@ -699,11 +734,6 @@ def get_content_list_token(token, base_url):
     string = get_string(token)
     if string is not None:
         return string
-
-    # <var>
-    var = check_var_function(token)
-    if var is not None:
-        return var
 
     # contents
     if get_keyword(token) == 'contents':

--- a/weasyprint/css/utils.py
+++ b/weasyprint/css/utils.py
@@ -507,7 +507,7 @@ def check_var_function(token):
 
         # TODO: we should check authorized tokens
         # https://drafts.csswg.org/css-syntax-3/#typedef-declaration-value
-        return ('var()', (ident.value.replace('-', '_'), args or None))
+        return ('var()', (ident.value.replace('-', '_'), args))
 
 
 def get_string(token):

--- a/weasyprint/css/validation/__init__.py
+++ b/weasyprint/css/validation/__init__.py
@@ -166,7 +166,7 @@ def preprocess_declarations(base_url, declarations):
             validation_error('debug', 'prefixed selectors are ignored')
             continue
 
-        expander_ = EXPANDERS.get(name, validate_non_shorthand)
+        expander = EXPANDERS.get(name, validate_non_shorthand)
         tokens = remove_whitespace(declaration.value)
         try:
             # Having no tokens is allowed by grammar but refused by all
@@ -174,7 +174,7 @@ def preprocess_declarations(base_url, declarations):
             if not tokens:
                 raise InvalidValues('no value')
             # Use list() to consume generators now and catch any error.
-            result = list(expander_(name, tokens, base_url))
+            result = list(expander(name, tokens, base_url))
         except InvalidValues as exc:
             validation_error(
                 'warning',

--- a/weasyprint/css/validation/__init__.py
+++ b/weasyprint/css/validation/__init__.py
@@ -166,7 +166,7 @@ def preprocess_declarations(base_url, declarations):
             validation_error('debug', 'prefixed selectors are ignored')
             continue
 
-        expander = EXPANDERS.get(name, validate_non_shorthand)
+        validator = EXPANDERS.get(name, validate_non_shorthand)
         tokens = remove_whitespace(declaration.value)
         try:
             # Having no tokens is allowed by grammar but refused by all
@@ -174,7 +174,7 @@ def preprocess_declarations(base_url, declarations):
             if not tokens:
                 raise InvalidValues('no value')
             # Use list() to consume generators now and catch any error.
-            result = list(expander(tokens, name, base_url))
+            result = list(validator(tokens, name, base_url))
         except InvalidValues as exc:
             validation_error(
                 'warning',

--- a/weasyprint/css/validation/__init__.py
+++ b/weasyprint/css/validation/__init__.py
@@ -174,7 +174,7 @@ def preprocess_declarations(base_url, declarations):
             if not tokens:
                 raise InvalidValues('no value')
             # Use list() to consume generators now and catch any error.
-            result = list(expander(name, tokens, base_url))
+            result = list(expander(tokens, name, base_url))
         except InvalidValues as exc:
             validation_error(
                 'warning',

--- a/weasyprint/css/validation/descriptors.py
+++ b/weasyprint/css/validation/descriptors.py
@@ -198,7 +198,7 @@ def font_variant(tokens):
     for name, sub_tokens in expand_font_variant(tokens):
         try:
             values.append(properties.validate_non_shorthand(
-                f'font-variant{name}', sub_tokens, required=True))
+                sub_tokens, f'font-variant{name}', required=True))
         except InvalidValues:
             return None
     return values

--- a/weasyprint/css/validation/expanders.py
+++ b/weasyprint/css/validation/expanders.py
@@ -91,7 +91,7 @@ def generic_expander(*expanded_names, **kwargs):
     def generic_expander_decorator(wrapped):
         """Decorate the ``wrapped`` expander."""
         @functools.wraps(wrapped)
-        def generic_expander_wrapper(name, tokens, base_url):
+        def generic_expander_wrapper(tokens, name, base_url):
             """Wrap the expander."""
             expander = functools.partial(
                 generic_expander_wrapper, name=name, base_url=base_url)
@@ -132,7 +132,7 @@ def generic_expander(*expanded_names, **kwargs):
                     if not skip_validation:
                         # validate_non_shorthand returns ((name, value),)
                         (actual_new_name, value), = validate_non_shorthand(
-                            actual_new_name, value, base_url, required=True)
+                            value, actual_new_name, base_url, required=True)
                 else:
                     value = 'initial'
 
@@ -147,7 +147,7 @@ def generic_expander(*expanded_names, **kwargs):
 @expander('margin')
 @expander('padding')
 @expander('bleed')
-def expand_four_sides(name, tokens, base_url):
+def expand_four_sides(tokens, name, base_url):
     """Expand properties setting a token for the four sides of a box."""
     # Define expanded names.
     expanded_names = []
@@ -179,7 +179,7 @@ def expand_four_sides(name, tokens, base_url):
         # validate_non_shorthand returns ((name, value),), we want
         # to yield (name, value).
         result, = validate_non_shorthand(
-            new_name, [token], base_url, required=True)
+            [token], expanded_name, base_url, required=True)
         yield result
 
 
@@ -220,9 +220,9 @@ def border_radius(tokens, name, base_url):
                 f'Expected 1 to 4 token components got {len(values)}')
     corners = ('top-left', 'top-right', 'bottom-right', 'bottom-left')
     for corner, tokens in zip(corners, zip(horizontal, vertical)):
-        new_name = f'border-{corner}-radius'
-        validate_non_shorthand(new_name, tokens, base_url, required=True)
-        yield new_name, tokens
+        name = f'border-{corner}-radius'
+        validate_non_shorthand(tokens, name, base_url, required=True)
+        yield name, tokens
 
 
 @expander('list-style')
@@ -269,14 +269,14 @@ def expand_list_style(tokens, name, base_url):
 
 
 @expander('border')
-def expand_border(name, tokens, base_url):
+def expand_border(tokens, name, base_url):
     """Expand the ``border`` shorthand property.
 
     See https://www.w3.org/TR/CSS21/box.html#propdef-border
 
     """
     for suffix in ('-top', '-right', '-bottom', '-left'):
-        for new_prop in expand_border_side(name + suffix, tokens, base_url):
+        for new_prop in expand_border_side(tokens, name + suffix, base_url):
             yield new_prop
 
 
@@ -306,7 +306,7 @@ def expand_border_side(tokens, name):
 
 
 @expander('background')
-def expand_background(name, tokens, base_url):
+def expand_background(tokens, name, base_url):
     """Expand the ``background`` shorthand property.
 
     See https://drafts.csswg.org/css-backgrounds-3/#the-background

--- a/weasyprint/css/validation/expanders.py
+++ b/weasyprint/css/validation/expanders.py
@@ -26,30 +26,27 @@ EXPANDERS = {}
 class PendingExpander:
     """Expander with validation done when defining calculated values."""
     # See https://drafts.csswg.org/css-variables-2/#variables-in-shorthands.
-    def __init__(self, tokens, expander):
+    def __init__(self, tokens, validator):
         self.tokens = tokens
-        self.expander = expander
+        self.validator = validator
         self._reported_error = False
 
     def solve(self, tokens, wanted_key):
         """Get validated value for wanted key."""
         try:
-            for key, value in self.expander(tokens):
+            for key, value in self.validator(tokens):
                 if key.startswith('-'):
-                    key = f'{self.expander.keywords["name"]}{key}'
+                    key = f'{self.validator.keywords["name"]}{key}'
                 if key == wanted_key:
                     return value
         except InvalidValues as exc:
             if self._reported_error:
                 raise exc
-            source_line = tokens[0].source_line
-            source_column = tokens[0].source_column
-            prop = self.expander.keywords["name"]
+            prop = self.validator.keywords['name']
+            source_line = self.tokens[0].source_line
+            source_column = self.tokens[0].source_column
             value = ' '.join(token.serialize() for token in tokens)
-            if exc.args and exc.args[0]:
-                message = exc.args[0]
-            else:
-                message = 'invalid value'
+            message = (exc.args and exc.args[0]) or 'invalid value'
             LOGGER.warning(
                 'Ignored `%s: %s` at %d:%d, %s.',
                 prop, value, source_line, source_column, message)

--- a/weasyprint/css/validation/properties.py
+++ b/weasyprint/css/validation/properties.py
@@ -8,15 +8,14 @@ from math import inf
 
 from tinycss2.color3 import parse_color
 
-from ...logger import LOGGER
 from .. import computed_values
 from ..properties import KNOWN_PROPERTIES, Dimension
 from ..utils import (
-    InvalidValues, check_var_function, comma_separated_list, get_angle,
-    get_content_list, get_content_list_token, get_custom_ident, get_image,
-    get_keyword, get_length, get_resolution, get_single_keyword, get_url,
-    parse_2d_position, parse_function, parse_position, remove_whitespace,
-    single_keyword, single_token)
+    InvalidValues, Pending, check_var_function, comma_separated_list,
+    get_angle, get_content_list, get_content_list_token, get_custom_ident,
+    get_image, get_keyword, get_length, get_resolution, get_single_keyword,
+    get_url, parse_2d_position, parse_function, parse_position,
+    remove_whitespace, single_keyword, single_token)
 
 PREFIX = '-weasy-'
 PROPRIETARY = set()
@@ -30,25 +29,10 @@ UNSTABLE = set()
 PROPERTIES = {}
 
 
-class PendingProperty:
+class PendingProperty(Pending):
     """Property with validation done when defining calculated values."""
-    def __init__(self, tokens, name):
-        self.tokens = tokens
-        self.name = name
-
-    def solve(self, tokens, wanted_key):
-        """Get validated value."""
-        try:
-            return validate_non_shorthand(tokens, self.name)[0][1]
-        except InvalidValues as exc:
-            source_line = self.tokens[0].source_line
-            source_column = self.tokens[0].source_column
-            value = ' '.join(token.serialize() for token in tokens)
-            message = (exc.args and exc.args[0]) or 'invalid value'
-            LOGGER.warning(
-                'Ignored `%s: %s` at %d:%d, %s.',
-                self.name, value, source_line, source_column, message)
-            raise exc
+    def validate(self, tokens, wanted_key):
+        return validate_non_shorthand(tokens, self.name)[0][1]
 
 
 # Validators

--- a/weasyprint/css/validation/properties.py
+++ b/weasyprint/css/validation/properties.py
@@ -75,7 +75,7 @@ def property(property_name=None, proprietary=False, unstable=False,
     return decorator
 
 
-def validate_non_shorthand(name, tokens, base_url=None, required=False):
+def validate_non_shorthand(tokens, name, base_url=None, required=False):
     """Validator for non-shorthand properties."""
     if name.startswith('--'):
         # TODO: validate content

--- a/weasyprint/css/validation/properties.py
+++ b/weasyprint/css/validation/properties.py
@@ -49,6 +49,8 @@ def property(property_name=None, proprietary=False, unstable=False,
         the Candidate Recommandation stage. They can be used both
         vendor-prefixed or unprefixed.
         See https://www.w3.org/TR/CSS/#unstable-syntax
+    :param multiple_values:
+        Mark property as returning multiple values.
     :param wants_base_url:
         The function takes the stylesheet’s base URL as an additional
         parameter.
@@ -91,7 +93,18 @@ def validate_non_shorthand(tokens, name, base_url=None, required=False):
     if not required and name not in PROPERTIES:
         raise InvalidValues('property not supported yet')
 
-    if name not in MULTIVAL_PROPERTIES:
+    if name in MULTIVAL_PROPERTIES:
+        var_found = False
+        new_tokens = []
+        for token in tokens:
+            if var_function := check_var_function(token):
+                new_tokens.append(var_function)
+                var_found = True
+            else:
+                new_tokens.append(token)
+        if var_found:
+            return ((name, tuple(new_tokens)),)
+    else:
         for token in tokens:
             var_function = check_var_function(token)
             if var_function:
@@ -111,7 +124,7 @@ def validate_non_shorthand(tokens, name, base_url=None, required=False):
     return ((name, value),)
 
 
-@property()
+@property(multiple_values=True)
 @comma_separated_list
 @single_keyword
 def background_attachment(keyword):
@@ -164,7 +177,7 @@ def color(token):
         return result
 
 
-@property('background-image', wants_base_url=True)
+@property('background-image', multiple_values=True, wants_base_url=True)
 @comma_separated_list
 @single_token
 def background_image(token, base_url):
@@ -186,7 +199,7 @@ def list_style_image(token, base_url):
             return 'url', parsed_url[1][1]
 
 
-@property()
+@property(multiple_values=True)
 def transform_origin(tokens):
     """``transform-origin`` property validation."""
     if len(tokens) == 3:
@@ -195,21 +208,21 @@ def transform_origin(tokens):
     return parse_2d_position(tokens)
 
 
-@property()
+@property(multiple_values=True)
 @comma_separated_list
 def background_position(tokens):
     """``background-position`` property validation."""
     return parse_position(tokens)
 
 
-@property()
+@property(multiple_values=True)
 @comma_separated_list
 def object_position(tokens):
     """``object-position`` property validation."""
     return parse_position(tokens)
 
 
-@property()
+@property(multiple_values=True)
 @comma_separated_list
 def background_repeat(tokens):
     """``background-repeat`` property validation."""
@@ -226,7 +239,7 @@ def background_repeat(tokens):
         return keywords
 
 
-@property()
+@property(multiple_values=True)
 @comma_separated_list
 def background_size(tokens):
     """Validation for ``background-size``."""
@@ -252,8 +265,8 @@ def background_size(tokens):
             return tuple(values)
 
 
-@property('background-clip')
-@property('background-origin')
+@property('background-clip', multiple_values=True)
+@property('background-origin', multiple_values=True)
 @comma_separated_list
 @single_keyword
 def box(keyword):
@@ -262,7 +275,7 @@ def box(keyword):
     return keyword in ('border-box', 'padding-box', 'content-box')
 
 
-@property()
+@property(multiple_values=True)
 def border_spacing(tokens):
     """Validator for the `border-spacing` property."""
     lengths = [get_length(token, negative=False) for token in tokens]
@@ -273,10 +286,10 @@ def border_spacing(tokens):
             return tuple(lengths)
 
 
-@property('border-top-right-radius')
-@property('border-bottom-right-radius')
-@property('border-bottom-left-radius')
-@property('border-top-left-radius')
+@property('border-top-right-radius', multiple_values=True)
+@property('border-bottom-right-radius', multiple_values=True)
+@property('border-bottom-left-radius', multiple_values=True)
+@property('border-top-left-radius', multiple_values=True)
 def border_corner_radius(tokens):
     """Validator for the `border-*-radius` properties."""
     lengths = [
@@ -382,7 +395,7 @@ def bleed(token):
         return get_length(token)
 
 
-@property(unstable=True)
+@property(unstable=True, multiple_values=True)
 def marks(tokens):
     """``marks`` property validation."""
     if len(tokens) == 2:
@@ -616,7 +629,7 @@ def direction(keyword):
     return keyword in ('ltr', 'rtl')
 
 
-@property()
+@property(multiple_values=True)
 def display(tokens):
     """``display`` property validation."""
     for token in tokens:
@@ -669,7 +682,7 @@ def float_(keyword):  # XXX do not hide the "float" builtin
     return keyword in ('left', 'right', 'footnote', 'none')
 
 
-@property()
+@property(multiple_values=True)
 @comma_separated_list
 def font_family(tokens):
     """``font-family`` property validation."""
@@ -771,7 +784,7 @@ def font_variant_numeric(tokens):
         return tuple(values)
 
 
-@property()
+@property(multiple_values=True)
 def font_feature_settings(tokens):
     """``font-feature-settings`` property validation."""
     if len(tokens) == 1 and get_keyword(tokens[0]) == 'normal':
@@ -841,7 +854,7 @@ def font_variant_east_asian(tokens):
         return tuple(values)
 
 
-@property()
+@property(multiple_values=True)
 def font_variation_settings(tokens):
     """``font-variation-settings`` property validation."""
     if len(tokens) == 1 and get_keyword(tokens[0]) == 'normal':
@@ -1088,7 +1101,7 @@ def position(token):
         return keyword
 
 
-@property()
+@property(multiple_values=True)
 def quotes(tokens):
     """``quotes`` property validation."""
     if (tokens and len(tokens) % 2 == 0 and
@@ -1417,7 +1430,7 @@ def hyphenate_limit_zone(token):
     return get_length(token, negative=False, percentage=True)
 
 
-@property(unstable=True)
+@property(unstable=True, multiple_values=True)
 def hyphenate_limit_chars(tokens):
     """Validation for ``hyphenate-limit-chars``."""
     if len(tokens) == 1:
@@ -1473,7 +1486,7 @@ def lang(token):
         return ('string', token.value)
 
 
-@property(unstable=True, wants_base_url=True)
+@property(unstable=True, multiple_values=True, wants_base_url=True)
 def bookmark_label(tokens, base_url):
     """Validation for ``bookmark-label``."""
     parsed_tokens = tuple(
@@ -1515,7 +1528,7 @@ def footnote_policy(keyword):
     return keyword in ('auto', 'line', 'block')
 
 
-@property(unstable=True, wants_base_url=True)
+@property(unstable=True, multiple_values=True, wants_base_url=True)
 @comma_separated_list
 def string_set(tokens, base_url):
     """Validation for ``string-set``."""

--- a/weasyprint/css/validation/properties.py
+++ b/weasyprint/css/validation/properties.py
@@ -76,7 +76,7 @@ def property(property_name=None, proprietary=False, unstable=False,
 
 
 def validate_non_shorthand(name, tokens, base_url=None, required=False):
-    """Default validator for non-shorthand properties."""
+    """Validator for non-shorthand properties."""
     if name.startswith('--'):
         # TODO: validate content
         return ((name, tokens),)

--- a/weasyprint/draw.py
+++ b/weasyprint/draw.py
@@ -1053,9 +1053,7 @@ def draw_text(stream, textbox, offset_x, text_overflow, block_ellipsis):
         return
 
     text_decoration_values = textbox.style['text_decoration_line']
-    text_decoration_color = textbox.style['text_decoration_color']
-    if text_decoration_color == 'currentColor':
-        text_decoration_color = textbox.style['color']
+    text_decoration_color = get_color(textbox.style, 'text_decoration_color')
     if 'overline' in text_decoration_values:
         thickness = textbox.pango_layout.underline_thickness
         offset_y = (


### PR DESCRIPTION
Fix #1219.

Possible improvement before merging: support `var()` in other functions.

Let’s forget for now: ~support other functions such as `calc()` (see #357.)~