### PR TITLE
Fix table row height calculation to use cell's border-height

### DIFF
--- a/tests/layout/test_table.py
+++ b/tests/layout/test_table.py
@@ -1866,6 +1866,24 @@ def test_table_row_height_3():
 
 
 @assert_no_logs
+def test_table_row_height_4():
+    # A row cannot be shorter than the border-height of its tallest cell
+    page, = render_pages('''
+      <table style="border-spacing: 0;">
+        <tr style="height: 4px;">
+          <td style="border: 1px solid; padding: 5px;"></td>
+        </tr>
+      </table>
+    ''')
+    html, = page.children
+    body, = html.children
+    wrapper, = body.children
+    table, = wrapper.children
+    row_group, = table.children
+    assert row_group.height == 12
+
+
+@assert_no_logs
 def test_table_vertical_align(assert_pixels):
     assert_pixels('''
         rrrrrrrrrrrrrrrrrrrrrrrrrrrr

--- a/weasyprint/layout/table.py
+++ b/weasyprint/layout/table.py
@@ -244,7 +244,7 @@ def table_layout(context, table, bottom_space, skip_stack, containing_block,
                     row.height = max(row_bottom_y - row.position_y, 0)
                 else:
                     row.height = max(row.height, max(
-                        row_cell.height for row_cell in ending_cells))
+                        row_cell.border_height() for row_cell in ending_cells))
                     row_bottom_y = row.position_y + row.height
             else:
                 row_bottom_y = row.position_y


### PR DESCRIPTION
This is a fix for #1968.

For rows with a specified height, I changed the code that calculates the maximum of the children cell's heights. It now uses the border-box-height instead of just `height`, similar to how it's done in the `row.height == 'auto'` case.