### PR TITLE
Fix tspan not respecting text-anchor

### DIFF
--- a/tests/draw/svg/test_text.py
+++ b/tests/draw/svg/test_text.py
@@ -280,6 +280,7 @@ def test_text_tspan(assert_pixels):
       </svg>
     ''')
 
+
 @assert_no_logs
 def test_text_tspan_anchor_middle(assert_pixels):
     assert_pixels('''
@@ -296,8 +297,7 @@ def test_text_tspan_anchor_middle(assert_pixels):
           <tspan x="10" y="1.5" text-anchor="middle">ABC</tspan>
         </text>
       </svg>
-    ''',
-    )
+    ''')
 
 
 @assert_no_logs
@@ -316,8 +316,8 @@ def test_text_tspan_anchor_end(assert_pixels):
           <tspan x="18" y="1.5" text-anchor="end">ABC</tspan>
         </text>
       </svg>
-    ''',
-    )
+    ''')
+
 
 @assert_no_logs
 def test_text_rotate(assert_pixels):

--- a/tests/draw/svg/test_text.py
+++ b/tests/draw/svg/test_text.py
@@ -280,6 +280,44 @@ def test_text_tspan(assert_pixels):
       </svg>
     ''')
 
+@assert_no_logs
+def test_text_tspan_anchor_middle(assert_pixels):
+    assert_pixels('''
+        _______BBBBBB_______
+        _______BBBBBB_______
+    ''', '''
+      <style>
+        @font-face { src: url(weasyprint.otf); font-family: weasyprint }
+        @page { size: 20px 2px }
+        svg { display: block }
+      </style>
+      <svg width="20px" height="2px" xmlns="http://www.w3.org/2000/svg">
+        <text x="10" y="10" font-family="weasyprint" font-size="2" fill="blue">
+          <tspan x="10" y="1.5" text-anchor="middle">ABC</tspan>
+        </text>
+      </svg>
+    ''',
+    )
+
+
+@assert_no_logs
+def test_text_tspan_anchor_end(assert_pixels):
+    assert_pixels('''
+        ____________BBBBBB__
+        ____________BBBBBB__
+    ''', '''
+      <style>
+        @font-face { src: url(weasyprint.otf); font-family: weasyprint }
+        @page { size: 20px 2px }
+        svg { display: block }
+      </style>
+      <svg width="20px" height="2px" xmlns="http://www.w3.org/2000/svg">
+        <text x="10" y="10" font-family="weasyprint" font-size="2" fill="blue">
+          <tspan x="18" y="1.5" text-anchor="end">ABC</tspan>
+        </text>
+      </svg>
+    ''',
+    )
 
 @assert_no_logs
 def test_text_rotate(assert_pixels):

--- a/weasyprint/svg/__init__.py
+++ b/weasyprint/svg/__init__.py
@@ -462,7 +462,7 @@ class SVG:
                         node.text_bounding_box, ((x1, y1), (x2, y2)))
 
         # Handle text anchor
-        if (node.tag == 'text' or node.tag == 'tspan') and text_anchor in ('middle', 'end'):
+        if TAGS.get(node.tag) == text and text_anchor in ('middle', 'end'):
             group_id = self.stream.id
             self.stream = original_streams.pop()
             self.stream.push_state()

--- a/weasyprint/svg/__init__.py
+++ b/weasyprint/svg/__init__.py
@@ -438,7 +438,7 @@ class SVG:
 
         # Handle text anchor
         text_anchor = node.get('text-anchor')
-        if (node.tag == 'text' or node.tag == 'tspan') and text_anchor in ('middle', 'end'):
+        if TAGS.get(node.tag) == text and text_anchor in ('middle', 'end'):
             group = self.stream.add_group(0, 0, 0, 0)  # BBox set after drawing
             original_streams.append(self.stream)
             self.stream = group

--- a/weasyprint/svg/__init__.py
+++ b/weasyprint/svg/__init__.py
@@ -438,7 +438,7 @@ class SVG:
 
         # Handle text anchor
         text_anchor = node.get('text-anchor')
-        if node.tag == 'text' and text_anchor in ('middle', 'end'):
+        if (node.tag == 'text' or node.tag == 'tspan') and text_anchor in ('middle', 'end'):
             group = self.stream.add_group(0, 0, 0, 0)  # BBox set after drawing
             original_streams.append(self.stream)
             self.stream = group
@@ -462,7 +462,7 @@ class SVG:
                         node.text_bounding_box, ((x1, y1), (x2, y2)))
 
         # Handle text anchor
-        if node.tag == 'text' and text_anchor in ('middle', 'end'):
+        if (node.tag == 'text' or node.tag == 'tspan') and text_anchor in ('middle', 'end'):
             group_id = self.stream.id
             self.stream = original_streams.pop()
             self.stream.push_state()


### PR DESCRIPTION
text-anchor attribute on `tspan` is not respected. It previously worked in v60.1 however the logic for text-anchor was moved into the `svg/__init__.py` file and caused this edge case not be handled, and there were no specific test cases.

See example below where text-anchor="middle" doesn't do anything

Tests pass

Replit reproducing bug: https://replit.com/@mlisitsa/Python-Weasyprint
Example:
```html
<svg
  width="600"
  height="217"
  role="img"
  viewBox="0 0 600 217"
  style="pointer-events: all; width: 100%; height: 100%"
>
  <text x="10" y="30" class="small">
    <tspan x="0" dx="0" dy="0" text-anchor="middle" >Middle</tspan>
    <tspan x="0" dx="0" dy="15">Start</tspan>
  </text>
</svg>
```