### PR TITLE
Speed up some list memory allocation.

### DIFF
--- a/weasyprint/layout/preferred.py
+++ b/weasyprint/layout/preferred.py
@@ -391,7 +391,7 @@ def table_and_columns_preferred_widths(context, box, outer=True):
                 grid_width = max(cell.grid_x + cell.colspan, grid_width)
                 grid_height = max(row_number + cell.rowspan, grid_height)
             row_number += 1
-    grid = [[None] * grid_width for i in range(grid_height)]
+    grid = [[None] * grid_width] * grid_height
     row_number = 0
     for row_group in table.children:
         for row in row_group.children:

--- a/weasyprint/layout/table.py
+++ b/weasyprint/layout/table.py
@@ -83,7 +83,7 @@ def table_layout(context, table, bottom_space, skip_stack, containing_block,
         group.width = rows_width
         new_group_children = []
         # For each rows, cells for which this is the last row (with rowspan)
-        ending_cells_by_row = [[] for row in group.children]
+        ending_cells_by_row = [[]] * len(group.children)
 
         is_group_start = skip_stack is None
         if is_group_start:


### PR DESCRIPTION
Instead of using a list comprehension, we use the * operator. This is faster because Python can allocate the list in a single go instead of growing it. In my testing, this tripled the speed of the table and grid layout for a very large dataset.

The test file in question https://raw.githubusercontent.com/sleepy-monax/wk-bench/main/input/simple-100K.html