### PR TITLE
add logging.set_log_level function

### DIFF
--- a/weasyprint/__main__.py
+++ b/weasyprint/__main__.py
@@ -12,6 +12,7 @@ from . import DEFAULT_OPTIONS, HTML, LOGGER, __version__
 from .pdf import VARIANTS
 from .text.ffi import pango
 from .urls import default_url_fetcher
+from .logging import set_log_level
 
 
 class PrintInfo(argparse.Action):
@@ -169,9 +170,12 @@ def main(argv=None, stdout=None, stdin=None, HTML=HTML):
 
     # Default to logging to stderr.
     if args.debug:
-        LOGGER.setLevel(logging.DEBUG)
+        set_log_level(logging.DEBUG)
     elif args.verbose:
-        LOGGER.setLevel(logging.INFO)
+        set_log_level(logging.INFO)
+    elif args.quiet:
+        set_log_level(logging.ERROR)
+
     if not args.quiet:
         handler = logging.StreamHandler()
         handler.setFormatter(logging.Formatter('%(levelname)s: %(message)s'))

--- a/weasyprint/__main__.py
+++ b/weasyprint/__main__.py
@@ -9,10 +9,10 @@ from functools import partial
 import pydyf
 
 from . import DEFAULT_OPTIONS, HTML, LOGGER, __version__
+from .logger import set_log_level
 from .pdf import VARIANTS
 from .text.ffi import pango
 from .urls import default_url_fetcher
-from .logging import set_log_level
 
 
 class PrintInfo(argparse.Action):

--- a/weasyprint/logger.py
+++ b/weasyprint/logger.py
@@ -22,7 +22,8 @@ if not LOGGER.handlers:  # pragma: no cover
 
 PROGRESS_LOGGER = logging.getLogger('weasyprint.progress')
 
+
 def set_log_level(level):
     LOGGER.setLevel(level)
     PROGRESS_LOGGER.setLevel(level)
-    logging.getLogger("fontTools").setLevel(level)
+    logging.getLogger('fontTools').setLevel(level)

--- a/weasyprint/logger.py
+++ b/weasyprint/logger.py
@@ -21,3 +21,8 @@ if not LOGGER.handlers:  # pragma: no cover
     LOGGER.addHandler(logging.NullHandler())
 
 PROGRESS_LOGGER = logging.getLogger('weasyprint.progress')
+
+def set_log_level(level):
+    LOGGER.setLevel(level)
+    PROGRESS_LOGGER.setLevel(level)
+    logging.getLogger("fontTools").setLevel(level)


### PR DESCRIPTION
currently, log level can only be set by the CLI and does not touch fontTools logging (which can be very verbose). This PR adds functionality to set all three loggers log level at once.