### PR TITLE
Fix computed values on table element overwritten after first page in running tables

### DIFF
--- a/tests/draw/test_table.py
+++ b/tests/draw/test_table.py
@@ -1473,7 +1473,6 @@ def test_running_elements_table_border_collapse_span(assert_pixels):
     ''')
 
 
-@pytest.mark.xfail
 @assert_no_logs
 def test_running_elements_table_border_collapse_margin(assert_pixels):
     assert_pixels(2 * '''

--- a/weasyprint/formatting_structure/build.py
+++ b/weasyprint/formatting_structure/build.py
@@ -970,6 +970,7 @@ def wrap_table(box, children):
         grid_height += len(group.children)
 
     table = box.copy_with_children(row_groups)
+    table.style = table.style.copy()
     table.column_groups = tuple(column_groups)
     if table.style['border_collapse'] == 'collapse':
         table.collapsed_border_grid = collapse_table_borders(


### PR DESCRIPTION
This is a naive fix using "ghost" style properties until a proper fix can be implemented.

The comment before the computed values are overwritten is probably a hint for a proper fix but unable to grasp the logic of table wrapper box and table box yet:
https://github.com/Kozea/WeasyPrint/blob/3f6775acd635bf98e02c97e7e6e83e0df653eb71/weasyprint/formatting_structure/build.py#L987-L989

Note: This will fix #2013