### PR TITLE
suggest "dnf" instead of "yum" to install Fedora packages

### DIFF
--- a/docs/first_steps.rst
+++ b/docs/first_steps.rst
@@ -129,17 +129,17 @@ Fedora ≥ 34
 
 To install WeasyPrint using your distribution’s package::
 
-  yum install weasyprint
+  dnf install weasyprint
 
 To install WeasyPrint inside a virtualenv using wheels (if possible), you need
 the following packages::
 
-  yum install python-pip pango
+  dnf install python-pip pango
 
 To install WeasyPrint inside a virtualenv without using wheels, you need the
 following packages::
 
-  yum install python-pip pango gcc python3-devel gcc-c++ zlib-devel libjpeg-devel openjpeg2-devel libffi-devel
+  dnf install python3-pip pango gcc python3-devel gcc-c++ zlib-devel libjpeg-devel openjpeg2-devel libffi-devel
 
 
 Ubuntu ≥ 20.04


### PR DESCRIPTION
`yum` was superseeded by `dnf` a long time ago.