### PR TITLE
Fixed selects with empty values displaying None

### DIFF
--- a/weasyprint/pdf/anchors.py
+++ b/weasyprint/pdf/anchors.py
@@ -174,7 +174,7 @@ def add_inputs(inputs, matrix, pdf, page, resources, stream, font_map,
             selected_values = []
             for option in element:
                 value = pydyf.String(option.attrib.get('value', ''))
-                text = pydyf.String(option.text)
+                text = pydyf.String(option.text or "")
                 options.append(pydyf.Array([value, text]))
                 if 'selected' in option.attrib:
                     selected_values.append(value)


### PR DESCRIPTION
Previously for optional selects with an option without text WeasyPrint was rendering a `None` in the PDF combobox option, so I've started to explicitly send an empty string when the text is `None`.