### PR TITLE
Don’t update dependencies on macOS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,8 +25,6 @@ jobs:
       - name: Install DejaVu, Pango and Ghostscript (MacOS)
         if: matrix.os == 'macos-latest'
         run: |
-          rm /usr/local/bin/2to3*
-          brew update
           brew tap homebrew/cask-fonts
           brew install --cask font-dejavu
           brew install pango ghostscript


### PR DESCRIPTION
Latest versions of Homebrew packages break CI, we don’t need them.