### PR TITLE
fix: initialize next_box_height to avoid unboundlocalerrors

### DIFF
--- a/weasyprint/layout/column.py
+++ b/weasyprint/layout/column.py
@@ -176,6 +176,9 @@ def columns_layout(context, box, bottom_space, skip_stack, containing_block,
                 new_boxes.append(new_box)
                 column_skip_stack = resume_at
 
+                # Avoid edge cases resulting in a UnboundLocalError in line 223
+                next_box_height = 0
+
                 # Calculate consumed height, empty space and next box height
                 in_flow_children = [
                     child for child in new_box.children


### PR DESCRIPTION
As promised in #2106, this is my proposed fix for `UnboundLocalError`s inside of the `layout/column.py` module.

I am still not sure yet if initializing the value with `0` is the right move here, however, in our case, monkey-patching it this way seemed to work without any further problems. 

Let me know if this is fine.