### PR TITLE
Support CSS Grid layout

### DIFF
--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -757,6 +757,56 @@ supported. The ``flex`` and ``flex-flow`` shorthands are supported too.
 
 .. _CSS Flexible Box Layout Module Level 1: https://www.w3.org/TR/css-flexbox-1/
 
+CSS Grid Layout Module Level 2
+++++++++++++++++++++++++++++++
+
+The `CSS Grid Layout Module Level 2`_ "defines a two-dimensional grid-based layout
+system, optimized for user interface design".
+
+This module works for simple cases, but has some limitations. Here are
+non-exhaustive lists of supported/unsupported features.
+
+Supported:
+
+- ``display: grid``,
+- ``grid-auto-*``, ``grid-template-*`` and other ``grid-*`` properties,
+- ``grid`` and other ``grid-*`` shorthands,
+- flexible lengths (``fr`` unit),
+- line names,
+- grid areas,
+- auto rows and auto columns,
+- ``z-index``,
+- ``repeat(X, *)``,
+- ``minmax()``,
+- ``align-*`` and ``justify-*`` alignment properties,
+- ``gap`` and ``*-gap`` properties for gutters,
+- dense auto flow,
+- ``order``,
+- margins, borders, padding on grid containers and grid items,
+- fragmentation between rows.
+
+Unsupported or untested:
+
+- ``display: inline-grid``,
+- auto content size for grid containers,
+- ``grid-auto-flow: column``,
+- subgrids,
+- ``repeat(auto-fill, *)`` and ``repeat(auto-fit, *)``,
+- auto margins for grid items,
+- ``span`` with line names,
+- ``span`` for flexible tracks,
+- ``safe`` and ``unsafe`` alignments,
+- baseline alignment,
+- grid items with intrinsic size (images),
+- distribute space beyond limits,
+- grid items larger than grid containers,
+- ``min-width``, ``max-width``, ``min-height``, ``max-height`` on grid items,
+- complex ``min-content`` and ``max-content`` cases,
+- absolutely positioned and floating grid items,
+- fragmentation in rows.
+
+.. _CSS Grid Layout Module Level 2: https://www.w3.org/TR/css-grid-2/
+
 CSS Basic User Interface Module Level 3/4
 +++++++++++++++++++++++++++++++++++++++++
 

--- a/tests/css/test_expanders.py
+++ b/tests/css/test_expanders.py
@@ -625,6 +625,38 @@ def test_flex_flow_invalid(rule):
 
 @assert_no_logs
 @pytest.mark.parametrize('rule, result', (
+    ('auto', {'start': 'auto'}),
+    ('auto / auto', {'start': 'auto', 'end': 'auto'}),
+    ('4', {'start': (None, 4, None)}),
+    ('4 / -4', {'start': (None, 4, None), 'end': (None, -4, None)}),
+    ('c / d', {'start': (None, None, 'c'), 'end': (None, None, 'd')}),
+    ('ab / cd 4', {'start': (None, None, 'ab'), 'end': (None, 4, 'cd')}),
+    ('ab 2 span', {'start': ('span', 2, 'ab')}),
+))
+def test_grid_column_row(rule, result):
+    assert expand_to_dict(f'grid-column: {rule}') == dict(
+        (f'grid_column_{key}', value) for key, value in result.items())
+    assert expand_to_dict(f'grid-row: {rule}') == dict(
+        (f'grid_row_{key}', value) for key, value in result.items())
+
+
+@assert_no_logs
+@pytest.mark.parametrize('rule', (
+    'auto auto',
+    '4 / 2 / c',
+    'span',
+    '4 / span',
+    'c /',
+    '/4',
+    'col / 2.1',
+))
+def test_grid_column_row_invalid(rule):
+    assert_invalid(f'grid-column: {rule}')
+    assert_invalid(f'grid-row: {rule}')
+
+
+@assert_no_logs
+@pytest.mark.parametrize('rule, result', (
     ('page-break-after: left', {'break_after': 'left'}),
     ('page-break-before: always', {'break_before': 'page'}),
     ('page-break-after: inherit', {'break_after': 'inherit'}),

--- a/tests/css/test_expanders.py
+++ b/tests/css/test_expanders.py
@@ -625,13 +625,14 @@ def test_flex_flow_invalid(rule):
 
 @assert_no_logs
 @pytest.mark.parametrize('rule, result', (
-    ('auto', {'start': 'auto'}),
+    ('auto', {'start': 'auto', 'end': 'auto'}),
     ('auto / auto', {'start': 'auto', 'end': 'auto'}),
-    ('4', {'start': (None, 4, None)}),
+    ('4', {'start': (None, 4, None), 'end': 'auto'}),
+    ('c', {'start': (None, None, 'c'), 'end': (None, None, 'c')}),
     ('4 / -4', {'start': (None, 4, None), 'end': (None, -4, None)}),
     ('c / d', {'start': (None, None, 'c'), 'end': (None, None, 'd')}),
     ('ab / cd 4', {'start': (None, None, 'ab'), 'end': (None, 4, 'cd')}),
-    ('ab 2 span', {'start': ('span', 2, 'ab')}),
+    ('ab 2 span', {'start': ('span', 2, 'ab'), 'end': 'auto'}),
 ))
 def test_grid_column_row(rule, result):
     assert expand_to_dict(f'grid-column: {rule}') == dict(
@@ -653,6 +654,58 @@ def test_grid_column_row(rule, result):
 def test_grid_column_row_invalid(rule):
     assert_invalid(f'grid-column: {rule}')
     assert_invalid(f'grid-row: {rule}')
+
+
+@assert_no_logs
+@pytest.mark.parametrize('rule, result', (
+    ('auto', {
+        'row_start': 'auto', 'row_end': 'auto',
+        'column_start': 'auto', 'column_end': 'auto'}),
+    ('auto / auto', {
+        'row_start': 'auto', 'row_end': 'auto',
+        'column_start': 'auto', 'column_end': 'auto'}),
+    ('auto / auto / auto', {
+        'row_start': 'auto', 'row_end': 'auto',
+        'column_start': 'auto', 'column_end': 'auto'}),
+    ('auto / auto / auto / auto', {
+        'row_start': 'auto', 'row_end': 'auto',
+        'column_start': 'auto', 'column_end': 'auto'}),
+    ('1/c/2 d/span 2 ab', {
+        'row_start': (None, 1, None), 'row_end': (None, None, 'c'),
+        'column_start': (None, 2, 'd'), 'column_end': ('span', 2, 'ab')}),
+    ('1  /  c', {
+        'row_start': (None, 1, None), 'row_end': (None, None, 'c'),
+        'column_start': 'auto', 'column_end': (None, None, 'c')}),
+    ('a / c 2', {
+        'row_start': (None, None, 'a'), 'row_end': (None, 2, 'c'),
+        'column_start': (None, None, 'a'), 'column_end': 'auto'}),
+    ('a', {
+        'row_start': (None, None, 'a'), 'row_end': (None, None, 'a'),
+        'column_start': (None, None, 'a'), 'column_end': (None, None, 'a')}),
+    ('span 2', {
+        'row_start': ('span', 2, None), 'row_end': 'auto',
+        'column_start': 'auto', 'column_end': 'auto'}),
+))
+def test_grid_area(rule, result):
+    assert expand_to_dict(f'grid-area: {rule}') == dict(
+        (f'grid_{key}', value) for key, value in result.items())
+
+
+@assert_no_logs
+@pytest.mark.parametrize('rule', (
+    'auto auto',
+    'auto / auto auto',
+    '4 / 2 / c / d / e',
+    'span',
+    '4 / span',
+    'c /',
+    '/4',
+    'c//4',
+    '/',
+    '1 / 2 / 4 / 0.5',
+))
+def test_grid_area_invalid(rule):
+    assert_invalid(f'grid-area: {rule}')
 
 
 @assert_no_logs

--- a/tests/css/test_validation.py
+++ b/tests/css/test_validation.py
@@ -731,6 +731,7 @@ def test_grid_auto_columns_rows_invalid(rule):
     ('column dense', ('column', 'dense')),
     ('dense row', ('dense', 'row')),
     ('dense column', ('dense', 'column')),
+    ('dense', ('dense', 'row')),
 ))
 def test_grid_auto_flow(rule, value):
     assert get_value(f'grid-auto-flow: {rule}') == value
@@ -741,7 +742,6 @@ def test_grid_auto_flow(rule, value):
     'row row',
     'column column',
     'dense dense',
-    'dense',
     'coucou',
     'row column',
     'column row',

--- a/tests/css/test_validation.py
+++ b/tests/css/test_validation.py
@@ -801,6 +801,7 @@ def test_grid_template_columns_rows_invalid(rule):
 
 @assert_no_logs
 @pytest.mark.parametrize('rule, value', (
+    ('none', 'none'),
     ('"head head" "nav main" "foot ...."',
      (('head', 'head'), ('nav', 'main'), ('foot', None))),
     ('"title board" "stats board"',

--- a/tests/css/test_validation.py
+++ b/tests/css/test_validation.py
@@ -769,14 +769,14 @@ def test_grid_auto_flow_invalid(rule):
      ('subgrid', ('a',), ('b',), ('c',), ('d',), ('e',), ('f',))),
     ('[outer-edge] 20px [main-start] 1fr [center] 1fr max-content [main-end]',
      (('outer-edge',), (20, 'px'), ('main-start',), (1, 'fr'), ('center',),
-      (1, 'fr'), 'max-content', ('main-end',))),
+      (1, 'fr'), (), 'max-content', ('main-end',))),
     ('repeat(auto-fill, minmax(25ch, 1fr))',
-     (('repeat()', 'auto-fill', (('minmax()', (25, 'ch'), (1, 'fr')),)),)),
+     ((), ('repeat()', 'auto-fill', (('minmax()', (25, 'ch'), (1, 'fr')),)), ())),
     ('[a] auto [b] minmax(min-content, 1fr) [b c d] '
      'repeat(2, [e] 40px) repeat(5, auto)',
      (('a',), 'auto', ('b',), ('minmax()', 'min-content', (1, 'fr')),
       ('b', 'c', 'd'), ('repeat()', 2, (('e',), (40, 'px'))),
-      ('repeat()', 5, ('auto',)))),
+      (), ('repeat()', 5, ('auto',)), ())),
 ))
 def test_grid_template_columns_rows(rule, value):
     assert get_value(f'grid-template-columns: {rule}') == value

--- a/tests/css/test_validation.py
+++ b/tests/css/test_validation.py
@@ -822,3 +822,42 @@ def test_grid_template_areas(rule, value):
 ))
 def test_grid_template_areas_invalid(rule):
     assert_invalid(f'grid-template-areas: {rule}')
+
+
+@assert_no_logs
+@pytest.mark.parametrize('rule, value', (
+    ('auto', 'auto'),
+    ('4', (None, 4, None)),
+    ('C', (None, None, 'c')),
+    ('4 c', (None, 4, 'c')),
+    ('col -4', (None, -4, 'col')),
+    ('span c 4', ('span', 4, 'c')),
+    ('span 4 c', ('span', 4, 'c')),
+    ('4 span c', ('span', 4, 'c')),
+    ('super 4 span', ('span', 4, 'super')),
+))
+def test_grid_line(rule, value):
+    assert get_value(f'grid-row-start: {rule}') == value
+    assert get_value(f'grid-row-end: {rule}') == value
+    assert get_value(f'grid-column-start: {rule}') == value
+    assert get_value(f'grid-column-end: {rule}') == value
+
+
+@assert_no_logs
+@pytest.mark.parametrize('rule', (
+    'span',
+    '0',
+    '1.1',
+    'span 0',
+    'span -1',
+    'span 2.1',
+    'span auto',
+    'auto auto',
+    '-4 cOL span',
+    'span 1.1 col',
+))
+def test_grid_line_invalid(rule):
+    assert_invalid(f'grid-row-start: {rule}')
+    assert_invalid(f'grid-row-end: {rule}')
+    assert_invalid(f'grid-column-start: {rule}')
+    assert_invalid(f'grid-column-end: {rule}')

--- a/tests/css/test_validation.py
+++ b/tests/css/test_validation.py
@@ -796,3 +796,28 @@ def test_grid_template_columns_rows(rule, value):
 def test_grid_template_columns_rows_invalid(rule):
     assert_invalid(f'grid-template-columns: {rule}')
     assert_invalid(f'grid-template-rows: {rule}')
+
+
+@assert_no_logs
+@pytest.mark.parametrize('rule, value', (
+    ('"head head" "nav main" "foot ...."',
+     (('head', 'head'), ('nav', 'main'), ('foot', None))),
+    ('"title board" "stats board"',
+     (('title', 'board'), ('stats', 'board'))),
+    ('". a" "b a" ".a"',
+     ((None, 'a'), ('b', 'a'), (None, 'a'))),
+))
+def test_grid_template_areas(rule, value):
+    assert get_value(f'grid-template-areas: {rule}') == value
+
+
+@assert_no_logs
+@pytest.mark.parametrize('rule', (
+    '"head head coucou" "nav main" "foot ...."',
+    '". a" "b c" ". a"',
+    '". a" "b a" "a a"',
+    '"a a a a" "a b b a" "a a a a"',
+    '" "',
+))
+def test_grid_template_areas_invalid(rule):
+    assert_invalid(f'grid-template-areas: {rule}')

--- a/tests/css/test_validation.py
+++ b/tests/css/test_validation.py
@@ -862,3 +862,274 @@ def test_grid_line_invalid(rule):
     assert_invalid(f'grid-row-end: {rule}')
     assert_invalid(f'grid-column-start: {rule}')
     assert_invalid(f'grid-column-end: {rule}')
+
+
+@assert_no_logs
+@pytest.mark.parametrize('rule, value', (
+    ('normal', ('normal',)),
+    ('baseline', ('first', 'baseline')),
+    ('first baseline', ('first', 'baseline')),
+    ('last baseline', ('last', 'baseline')),
+    ('baseline last', ('baseline', 'last')),
+    ('space-between', ('space-between',)),
+    ('space-around', ('space-around',)),
+    ('space-evenly', ('space-evenly',)),
+    ('stretch', ('stretch',)),
+    ('center', ('center',)),
+    ('start', ('start',)),
+    ('end', ('end',)),
+    ('flex-start', ('flex-start',)),
+    ('flex-end', ('flex-end',)),
+    ('safe center', ('safe', 'center')),
+    ('unsafe start', ('unsafe', 'start')),
+    ('safe end', ('safe', 'end')),
+    ('safe flex-start', ('safe', 'flex-start')),
+    ('unsafe flex-start', ('unsafe', 'flex-start')),
+))
+def test_align_content(rule, value):
+    assert get_value(f'align-content: {rule}') == value
+
+
+@assert_no_logs
+@pytest.mark.parametrize('rule', (
+    'auto',
+    'none',
+    'auto auto',
+    'first last',
+    'baseline baseline',
+    'start safe',
+    'start end',
+    'safe unsafe',
+    'left',
+    'right',
+))
+def test_align_content_invalid(rule):
+    assert_invalid(f'align-content: {rule}')
+
+
+@assert_no_logs
+@pytest.mark.parametrize('rule, value', (
+    ('normal', ('normal',)),
+    ('stretch', ('stretch',)),
+    ('baseline', ('first', 'baseline')),
+    ('first baseline', ('first', 'baseline')),
+    ('last baseline', ('last', 'baseline')),
+    ('baseline last', ('baseline', 'last')),
+    ('center', ('center',)),
+    ('self-start', ('self-start',)),
+    ('self-end', ('self-end',)),
+    ('start', ('start',)),
+    ('end', ('end',)),
+    ('flex-start', ('flex-start',)),
+    ('flex-end', ('flex-end',)),
+    ('safe center', ('safe', 'center')),
+    ('unsafe start', ('unsafe', 'start')),
+    ('safe end', ('safe', 'end')),
+    ('unsafe self-start', ('unsafe', 'self-start')),
+    ('safe self-end', ('safe', 'self-end')),
+    ('safe flex-start', ('safe', 'flex-start')),
+    ('unsafe flex-start', ('unsafe', 'flex-start')),
+))
+def test_align_items(rule, value):
+    assert get_value(f'align-items: {rule}') == value
+
+
+@assert_no_logs
+@pytest.mark.parametrize('rule', (
+    'auto',
+    'none',
+    'auto auto',
+    'first last',
+    'baseline baseline',
+    'start safe',
+    'start end',
+    'safe unsafe',
+    'left',
+    'right',
+    'space-between',
+))
+def test_align_items_invalid(rule):
+    assert_invalid(f'align-items: {rule}')
+
+
+@assert_no_logs
+@pytest.mark.parametrize('rule, value', (
+    ('auto', ('auto',)),
+    ('normal', ('normal',)),
+    ('stretch', ('stretch',)),
+    ('baseline', ('first', 'baseline')),
+    ('first baseline', ('first', 'baseline')),
+    ('last baseline', ('last', 'baseline')),
+    ('baseline last', ('baseline', 'last')),
+    ('center', ('center',)),
+    ('self-start', ('self-start',)),
+    ('self-end', ('self-end',)),
+    ('start', ('start',)),
+    ('end', ('end',)),
+    ('flex-start', ('flex-start',)),
+    ('flex-end', ('flex-end',)),
+    ('safe center', ('safe', 'center')),
+    ('unsafe start', ('unsafe', 'start')),
+    ('safe end', ('safe', 'end')),
+    ('unsafe self-start', ('unsafe', 'self-start')),
+    ('safe self-end', ('safe', 'self-end')),
+    ('safe flex-start', ('safe', 'flex-start')),
+    ('unsafe flex-start', ('unsafe', 'flex-start')),
+))
+def test_align_self(rule, value):
+    assert get_value(f'align-self: {rule}') == value
+
+
+@assert_no_logs
+@pytest.mark.parametrize('rule', (
+    'none',
+    'auto auto',
+    'first last',
+    'baseline baseline',
+    'start safe',
+    'start end',
+    'safe unsafe',
+    'left',
+    'right',
+    'space-between',
+))
+def test_align_self_invalid(rule):
+    assert_invalid(f'align-self: {rule}')
+
+
+@assert_no_logs
+@pytest.mark.parametrize('rule, value', (
+    ('normal', ('normal',)),
+    ('space-between', ('space-between',)),
+    ('space-around', ('space-around',)),
+    ('space-evenly', ('space-evenly',)),
+    ('stretch', ('stretch',)),
+    ('center', ('center',)),
+    ('left', ('left',)),
+    ('right', ('right',)),
+    ('start', ('start',)),
+    ('end', ('end',)),
+    ('flex-start', ('flex-start',)),
+    ('flex-end', ('flex-end',)),
+    ('safe center', ('safe', 'center')),
+    ('unsafe start', ('unsafe', 'start')),
+    ('safe end', ('safe', 'end')),
+    ('unsafe left', ('unsafe', 'left')),
+    ('safe right', ('safe', 'right')),
+    ('safe flex-start', ('safe', 'flex-start')),
+    ('unsafe flex-start', ('unsafe', 'flex-start')),
+))
+def test_justify_content(rule, value):
+    assert get_value(f'justify-content: {rule}') == value
+
+
+@assert_no_logs
+@pytest.mark.parametrize('rule', (
+    'auto',
+    'none',
+    'baseline',
+    'auto auto',
+    'first last',
+    'baseline baseline',
+    'start safe',
+    'start end',
+    'safe unsafe',
+))
+def test_justify_content_invalid(rule):
+    assert_invalid(f'justify-content: {rule}')
+
+
+@assert_no_logs
+@pytest.mark.parametrize('rule, value', (
+    ('normal', ('normal',)),
+    ('stretch', ('stretch',)),
+    ('baseline', ('first', 'baseline')),
+    ('first baseline', ('first', 'baseline')),
+    ('last baseline', ('last', 'baseline')),
+    ('baseline last', ('baseline', 'last')),
+    ('center', ('center',)),
+    ('self-start', ('self-start',)),
+    ('self-end', ('self-end',)),
+    ('start', ('start',)),
+    ('end', ('end',)),
+    ('left', ('left',)),
+    ('right', ('right',)),
+    ('flex-start', ('flex-start',)),
+    ('flex-end', ('flex-end',)),
+    ('safe center', ('safe', 'center')),
+    ('unsafe start', ('unsafe', 'start')),
+    ('safe end', ('safe', 'end')),
+    ('unsafe self-start', ('unsafe', 'self-start')),
+    ('safe self-end', ('safe', 'self-end')),
+    ('safe flex-start', ('safe', 'flex-start')),
+    ('unsafe flex-start', ('unsafe', 'flex-start')),
+    ('legacy', ('legacy',)),
+    ('legacy left', ('legacy', 'left')),
+    ('left legacy', ('left', 'legacy')),
+    ('legacy center', ('legacy', 'center')),
+))
+def test_justify_items(rule, value):
+    assert get_value(f'justify-items: {rule}') == value
+
+
+@assert_no_logs
+@pytest.mark.parametrize('rule', (
+    'auto',
+    'none',
+    'auto auto',
+    'first last',
+    'baseline baseline',
+    'start safe',
+    'start end',
+    'safe unsafe',
+    'space-between',
+))
+def test_justify_items_invalid(rule):
+    assert_invalid(f'justify-items: {rule}')
+
+
+@assert_no_logs
+@pytest.mark.parametrize('rule, value', (
+    ('auto', ('auto',)),
+    ('normal', ('normal',)),
+    ('stretch', ('stretch',)),
+    ('baseline', ('first', 'baseline')),
+    ('first baseline', ('first', 'baseline')),
+    ('last baseline', ('last', 'baseline')),
+    ('baseline last', ('baseline', 'last')),
+    ('center', ('center',)),
+    ('self-start', ('self-start',)),
+    ('self-end', ('self-end',)),
+    ('start', ('start',)),
+    ('end', ('end',)),
+    ('left', ('left',)),
+    ('right', ('right',)),
+    ('flex-start', ('flex-start',)),
+    ('flex-end', ('flex-end',)),
+    ('safe center', ('safe', 'center')),
+    ('unsafe start', ('unsafe', 'start')),
+    ('safe end', ('safe', 'end')),
+    ('unsafe left', ('unsafe', 'left')),
+    ('safe right', ('safe', 'right')),
+    ('unsafe self-start', ('unsafe', 'self-start')),
+    ('safe self-end', ('safe', 'self-end')),
+    ('safe flex-start', ('safe', 'flex-start')),
+    ('unsafe flex-start', ('unsafe', 'flex-start')),
+))
+def test_justify_self(rule, value):
+    assert get_value(f'justify-self: {rule}') == value
+
+
+@assert_no_logs
+@pytest.mark.parametrize('rule', (
+    'none',
+    'auto auto',
+    'first last',
+    'baseline baseline',
+    'start safe',
+    'start end',
+    'safe unsafe',
+    'space-between',
+))
+def test_justify_self_invalid(rule):
+    assert_invalid(f'justify-self: {rule}')

--- a/tests/css/test_validation.py
+++ b/tests/css/test_validation.py
@@ -758,25 +758,26 @@ def test_grid_auto_flow_invalid(rule):
 @assert_no_logs
 @pytest.mark.parametrize('rule, value', (
     ('none', 'none'),
-    ('subgrid', ('subgrid',)),
+    ('subgrid', ('subgrid', ())),
     ('subgrid [a] repeat(auto-fill, [b]) [c]',
-     ('subgrid', ('a',), ('repeat()', 'auto-fill', (('b',),)), ('c',))),
+     ('subgrid', (('a',), ('repeat()', 'auto-fill', (('b',),)), ('c',)))),
     ('subgrid [a] [a] [a] [a] repeat(auto-fill, [b]) [c] [c]',
-     ('subgrid', ('a',), ('a',), ('a',), ('a',),
-      ('repeat()', 'auto-fill', (('b',),)), ('c',), ('c',))),
-    ('subgrid [] [a]', ('subgrid', (), ('a',))),
+     ('subgrid', (('a',), ('a',), ('a',), ('a',),
+      ('repeat()', 'auto-fill', (('b',),)), ('c',), ('c',)))),
+    ('subgrid [] [a]', ('subgrid', ((), ('a',)))),
     ('subgrid [a] [b] [c] [d] [e] [f]',
-     ('subgrid', ('a',), ('b',), ('c',), ('d',), ('e',), ('f',))),
+     ('subgrid', (('a',), ('b',), ('c',), ('d',), ('e',), ('f',)))),
     ('[outer-edge] 20px [main-start] 1fr [center] 1fr max-content [main-end]',
      (('outer-edge',), (20, 'px'), ('main-start',), (1, 'fr'), ('center',),
       (1, 'fr'), (), 'max-content', ('main-end',))),
     ('repeat(auto-fill, minmax(25ch, 1fr))',
-     ((), ('repeat()', 'auto-fill', (('minmax()', (25, 'ch'), (1, 'fr')),)), ())),
+     ((), ('repeat()', 'auto-fill', (
+         (), ('minmax()', (25, 'ch'), (1, 'fr')), ())), ())),
     ('[a] auto [b] minmax(min-content, 1fr) [b c d] '
      'repeat(2, [e] 40px) repeat(5, auto)',
      (('a',), 'auto', ('b',), ('minmax()', 'min-content', (1, 'fr')),
-      ('b', 'c', 'd'), ('repeat()', 2, (('e',), (40, 'px'))),
-      (), ('repeat()', 5, ('auto',)), ())),
+      ('b', 'c', 'd'), ('repeat()', 2, (('e',), (40, 'px'), ())),
+      (), ('repeat()', 5, ((), 'auto', ())), ())),
 ))
 def test_grid_template_columns_rows(rule, value):
     assert get_value(f'grid-template-columns: {rule}') == value

--- a/tests/layout/test_grid.py
+++ b/tests/layout/test_grid.py
@@ -537,3 +537,137 @@ def test_grid_template_fr_undefined_free_space():
     assert div_b.width == div_d.width == 5
     assert article.width == 10
     assert article.height == 16
+
+
+@assert_no_logs
+def test_grid_column_start():
+    page, = render_pages('''
+      <style>
+        @font-face { src: url(weasyprint.otf); font-family: weasyprint }
+        dl {
+          display: grid;
+          font-family: weasyprint;
+          font-size: 2px;
+          grid-template-columns: max-content auto;
+          line-height: 1;
+          width: 10px;
+        }
+        dt {
+          display: block;
+          grid-column-start: 1;
+        }
+        dd {
+          display: block;
+          grid-column-start: 2;
+        }
+      </style>
+      <dl>
+        <dt>A</dt>
+        <dd>A1</dd>
+        <dd>A2</dd>
+        <dt>B</dt>
+        <dd>B1</dd>
+        <dd>B2</dd>
+      </dl>
+    ''')
+    html, = page.children
+    body, = html.children
+    dl, = body.children
+    dt_a, dd_a1, dd_a2, dt_b, dd_b1, dd_b2 = dl.children
+    assert dt_a.position_y == dd_a1.position_y == 0
+    assert dd_a2.position_y == 2
+    assert dt_b.position_y == dd_b1.position_y == 4
+    assert dd_b2.position_y == 6
+    assert dt_a.position_x == dt_b.position_x == 0
+    assert dd_a1.position_x == dd_a2.position_x == 2
+    assert dd_b1.position_x == dd_b2.position_x == 2
+
+
+@assert_no_logs
+def test_grid_column_start_blockified():
+    page, = render_pages('''
+      <style>
+        @font-face { src: url(weasyprint.otf); font-family: weasyprint }
+        dl {
+          display: grid;
+          font-family: weasyprint;
+          font-size: 2px;
+          grid-template-columns: max-content auto;
+          line-height: 1;
+          width: 10px;
+        }
+        dt {
+          display: inline;
+          grid-column-start: 1;
+        }
+        dd {
+          display: inline;
+          grid-column-start: 2;
+        }
+      </style>
+      <dl>
+        <dt>A</dt>
+        <dd>A1</dd>
+        <dd>A2</dd>
+        <dt>B</dt>
+        <dd>B1</dd>
+        <dd>B2</dd>
+      </dl>
+    ''')
+    html, = page.children
+    body, = html.children
+    dl, = body.children
+    dt_a, dd_a1, dd_a2, dt_b, dd_b1, dd_b2 = dl.children
+    assert dt_a.position_y == dd_a1.position_y == 0
+    assert dd_a2.position_y == 2
+    assert dt_b.position_y == dd_b1.position_y == 4
+    assert dd_b2.position_y == 6
+    assert dt_a.position_x == dt_b.position_x == 0
+    assert dd_a1.position_x == dd_a2.position_x == 2
+    assert dd_b1.position_x == dd_b2.position_x == 2
+
+
+@assert_no_logs
+def test_grid_undefined_free_space():
+    page, = render_pages('''
+      <style>
+        @font-face { src: url(weasyprint.otf); font-family: weasyprint }
+        body {
+          font-family: weasyprint;
+          font-size: 2px;
+          line-height: 1;
+        }
+        .columns {
+          display: grid;
+          grid-template-columns: 1fr 1fr;
+          width: 8px;
+        }
+        .rows {
+          display: grid;
+          grid-template-rows: 1fr 1fr;
+        }
+      </style>
+      <div class="columns">
+        <div class="rows">
+          <div>aa</div>
+          <div>b</div>
+        </div>
+        <div class="rows">
+          <div>c<br>c</div>
+          <div>d</div>
+        </div>
+      </div>
+    ''')
+    html, = page.children
+    body, = html.children
+    div_c, = body.children
+    div_c1, div_c2 = div_c.children
+    div_r11, div_r12 = div_c1.children
+    div_r21, div_r22 = div_c2.children
+    assert div_r11.position_x == div_r12.position_x == 0
+    assert div_r21.position_x == div_r22.position_x == 4
+    assert div_r11.position_y == div_r21.position_y == 0
+    assert div_r12.position_y == div_r22.position_y == 4
+    assert div_r11.height == div_r12.height == div_r21.height == div_r22.height == 4
+    assert div_r11.width == div_r12.width == div_r21.width == div_r22.width == 4
+    assert div_c.width == 8

--- a/tests/layout/test_grid.py
+++ b/tests/layout/test_grid.py
@@ -505,3 +505,36 @@ def test_grid_shorthand_auto_flow_columns_none_dense():
     assert div_a.width == div_b.width == div_c.width == 10
     assert {div.height for div in article.children} == {2}
     assert article.width == 10
+
+
+@assert_no_logs
+def test_grid_template_fr_undefined_free_space():
+    page, = render_pages('''
+      <style>
+        @font-face { src: url(weasyprint.otf); font-family: weasyprint }
+        article {
+          display: grid;
+          font-family: weasyprint;
+          font-size: 2px;
+          grid-template-rows: 1fr 1fr;
+          grid-template-columns: 1fr 1fr;
+          line-height: 1;
+          width: 10px;
+        }
+      </style>
+      <article>
+        <div>a</div> <div>b<br>b<br>b<br>b</div>
+        <div>c</div> <div>d</div>
+      </article>
+    ''')
+    html, = page.children
+    body, = html.children
+    article, = body.children
+    div_a, div_b, div_c, div_d = article.children
+    assert div_a.position_x == div_c.position_x == 0
+    assert div_b.position_x == div_d.position_x == 5
+    assert div_a.height == div_b.height == div_c.height == div_d.height == 8
+    assert div_a.width == div_c.width == 5
+    assert div_b.width == div_d.width == 5
+    assert article.width == 10
+    assert article.height == 16

--- a/tests/layout/test_grid.py
+++ b/tests/layout/test_grid.py
@@ -50,7 +50,8 @@ def test_grid_rows():
     assert div_a.position_x == div_b.position_x == div_c.position_x == 0
     assert div_a.position_y < div_b.position_y < div_c.position_y
     assert div_a.height == div_b.height == div_c.height
-    assert article.width == div_a.width == div_b.width == div_c.width == html.width
+    assert article.width == html.width
+    assert div_a.width == div_b.width == div_c.width == html.width
 
 
 @assert_no_logs
@@ -275,7 +276,7 @@ def test_grid_template_areas_overlap():
     div_a1, div_a2, div_a3 = article.children
     assert div_a1.position_x == div_a2.position_x == div_a3.position_x == 0
     assert div_a1.position_y == div_a2.position_y == div_a3.position_y == 0
-    assert div_a1.width == div_a2.width == div_a3.width == 6  # 2 + (10 - 2) / 2
+    assert div_a1.width == div_a2.width == div_a3.width == 6  # 2 + (10-2) / 2
     assert div_a1.height == div_a2.height == div_a3.height == 2
     assert article.width == 10
 
@@ -308,7 +309,7 @@ def test_grid_template_areas_extra_span():
     article, = body.children
     div_a, div_b, div_c, div_d, div_e, div_f = article.children
     assert div_a.position_x == div_c.position_x == div_e.position_x == 0
-    assert div_d.position_x == 4  # 2 + (10 - 2 × 3) / 2
+    assert div_d.position_x == 4  # 2 + (10 - 2×3) / 2
     assert div_b.position_x == div_f.position_x == 6
     assert div_a.position_y == div_b.position_y == 0
     assert div_c.position_y == div_d.position_y == 2

--- a/tests/layout/test_grid.py
+++ b/tests/layout/test_grid.py
@@ -1,0 +1,440 @@
+"""Tests for grid layout."""
+
+from ..testing_utils import assert_no_logs, render_pages
+
+
+@assert_no_logs
+def test_grid_empty():
+    page, = render_pages('''
+      <article style="display: grid">
+      </article>
+    ''')
+    html, = page.children
+    body, = html.children
+    article, = body.children
+    assert article.position_x == 0
+    assert article.position_y == 0
+    assert article.width == html.width
+    assert article.height == 0
+
+
+@assert_no_logs
+def test_grid_single_item():
+    page, = render_pages('''
+      <article style="display: grid">
+        <div>a</div>
+      </article>
+    ''')
+    html, = page.children
+    body, = html.children
+    article, = body.children
+    div, = article.children
+    assert article.position_x == div.position_x == 0
+    assert article.position_y == div.position_y == 0
+    assert article.width == div.width == html.width
+
+
+@assert_no_logs
+def test_grid_rows():
+    page, = render_pages('''
+      <article style="display: grid">
+        <div>a</div>
+        <div>b</div>
+        <div>c</div>
+      </article>
+    ''')
+    html, = page.children
+    body, = html.children
+    article, = body.children
+    div_a, div_b, div_c = article.children
+    assert div_a.position_x == div_b.position_x == div_c.position_x == 0
+    assert div_a.position_y < div_b.position_y < div_c.position_y
+    assert div_a.height == div_b.height == div_c.height
+    assert article.width == div_a.width == div_b.width == div_c.width == html.width
+
+
+@assert_no_logs
+def test_grid_template_fr():
+    page, = render_pages('''
+      <style>
+        @font-face { src: url(weasyprint.otf); font-family: weasyprint }
+        article {
+          display: grid;
+          font-family: weasyprint;
+          font-size: 2px;
+          grid-template-rows: auto 1fr;
+          grid-template-columns: auto 1fr;
+          line-height: 1;
+          width: 10px;
+        }
+      </style>
+      <article>
+        <div>a</div> <div>b</div>
+        <div>c</div> <div>d</div>
+      </article>
+    ''')
+    html, = page.children
+    body, = html.children
+    article, = body.children
+    div_a, div_b, div_c, div_d = article.children
+    assert div_a.position_x == div_c.position_x == 0
+    assert div_b.position_x == div_d.position_x == 2
+    assert div_a.height == div_b.height == div_c.height == div_d.height == 2
+    assert div_a.width == div_c.width == 2
+    assert div_b.width == div_d.width == 8
+    assert article.width == 10
+
+
+@assert_no_logs
+def test_grid_template_areas():
+    page, = render_pages('''
+      <style>
+        @font-face { src: url(weasyprint.otf); font-family: weasyprint }
+        article {
+          display: grid;
+          font-family: weasyprint;
+          font-size: 2px;
+          grid-template-areas: 'a b' 'c d';
+          line-height: 1;
+          width: 10px;
+        }
+      </style>
+      <article>
+        <div>a</div> <div>b</div>
+        <div>c</div> <div>d</div>
+      </article>
+    ''')
+    html, = page.children
+    body, = html.children
+    article, = body.children
+    div_a, div_b, div_c, div_d = article.children
+    assert div_a.position_x == div_c.position_x == 0
+    assert div_b.position_x == div_d.position_x == 5
+    assert div_a.position_y == div_b.position_y == 0
+    assert div_c.position_y == div_d.position_y == 2
+    assert div_a.height == div_b.height == div_c.height == div_d.height == 2
+    assert div_a.width == div_b.width == div_c.width == div_d.width == 5
+    assert article.width == 10
+
+
+@assert_no_logs
+def test_grid_template_areas_grid_area():
+    page, = render_pages('''
+      <style>
+        @font-face { src: url(weasyprint.otf); font-family: weasyprint }
+        article {
+          display: grid;
+          font-family: weasyprint;
+          font-size: 2px;
+          grid-template-areas: 'b a' 'd c';
+          line-height: 1;
+          width: 10px;
+        }
+      </style>
+      <article>
+        <div style="grid-area: a">a</div> <div style="grid-area: b">b</div>
+        <div style="grid-area: c">c</div> <div style="grid-area: d">d</div>
+      </article>
+    ''')
+    html, = page.children
+    body, = html.children
+    article, = body.children
+    div_a, div_b, div_c, div_d = article.children
+    assert div_b.position_x == div_d.position_x == 0
+    assert div_a.position_x == div_c.position_x == 5
+    assert div_a.position_y == div_b.position_y == 0
+    assert div_c.position_y == div_d.position_y == 2
+    assert div_a.height == div_b.height == div_c.height == div_d.height == 2
+    assert div_a.width == div_b.width == div_c.width == div_d.width == 5
+    assert article.width == 10
+
+
+@assert_no_logs
+def test_grid_template_areas_empty_row():
+    page, = render_pages('''
+      <style>
+        @font-face { src: url(weasyprint.otf); font-family: weasyprint }
+        article {
+          display: grid;
+          font-family: weasyprint;
+          font-size: 2px;
+          grid-template-areas: 'b a' 'd a' 'd c';
+          line-height: 1;
+          width: 10px;
+        }
+      </style>
+      <article>
+        <div style="grid-area: a">a</div> <div style="grid-area: b">b</div>
+        <div style="grid-area: c">c</div> <div style="grid-area: d">d</div>
+      </article>
+    ''')
+    html, = page.children
+    body, = html.children
+    article, = body.children
+    div_a, div_b, div_c, div_d = article.children
+    assert div_b.position_x == div_d.position_x == 0
+    assert div_a.position_x == div_c.position_x == 5
+    assert div_a.position_y == div_b.position_y == 0
+    assert div_c.position_y == div_d.position_y == 2
+    assert div_a.height == div_b.height == div_c.height == div_d.height == 2
+    assert div_a.width == div_b.width == div_c.width == div_d.width == 5
+    assert article.width == 10
+
+
+@assert_no_logs
+def test_grid_template_areas_multiple_rows():
+    page, = render_pages('''
+      <style>
+        @font-face { src: url(weasyprint.otf); font-family: weasyprint }
+        article {
+          display: grid;
+          font-family: weasyprint;
+          font-size: 2px;
+          grid-template-areas: 'b a' 'd a' '. c';
+          line-height: 1;
+          width: 10px;
+        }
+      </style>
+      <article>
+        <div style="grid-area: a">a</div> <div style="grid-area: b">b</div>
+        <div style="grid-area: c">c</div> <div style="grid-area: d">d</div>
+      </article>
+    ''')
+    html, = page.children
+    body, = html.children
+    article, = body.children
+    div_a, div_b, div_c, div_d = article.children
+    assert div_b.position_x == div_d.position_x == 0
+    assert div_a.position_x == div_c.position_x == 5
+    assert div_a.position_y == div_b.position_y == 0
+    assert div_c.position_y == 4
+    assert div_d.position_y == 2
+    assert div_a.height == 4
+    assert div_b.height == div_c.height == div_d.height == 2
+    assert div_a.width == div_b.width == div_c.width == div_d.width == 5
+    assert article.width == 10
+
+
+@assert_no_logs
+def test_grid_template_areas_multiple_columns():
+    page, = render_pages('''
+      <style>
+        @font-face { src: url(weasyprint.otf); font-family: weasyprint }
+        article {
+          display: grid;
+          font-family: weasyprint;
+          font-size: 2px;
+          grid-template-areas: 'b b' 'c a';
+          line-height: 1;
+          width: 10px;
+        }
+      </style>
+      <article>
+        <div style="grid-area: a">a</div>
+        <div style="grid-area: b">b</div>
+        <div style="grid-area: c">c</div>
+      </article>
+    ''')
+    html, = page.children
+    body, = html.children
+    article, = body.children
+    div_a, div_b, div_c = article.children
+    assert div_b.position_x == div_c.position_x == 0
+    assert div_a.position_x == 5
+    assert div_a.position_y == div_c.position_y == 2
+    assert div_b.position_y == 0
+    assert div_a.height == div_b.height == div_c.height == 2
+    assert div_a.width == div_c.width == 5
+    assert div_b.width == 10
+    assert article.width == 10
+
+
+@assert_no_logs
+def test_grid_template_areas_overlap():
+    page, = render_pages('''
+      <style>
+        @font-face { src: url(weasyprint.otf); font-family: weasyprint }
+        article {
+          display: grid;
+          font-family: weasyprint;
+          font-size: 2px;
+          grid-template-areas: 'a b' 'c d';
+          line-height: 1;
+          width: 10px;
+        }
+      </style>
+      <article>
+        <div style="grid-area: a">a</div>
+        <div style="grid-area: a">a</div>
+        <div style="grid-area: a">a</div>
+      </article>
+    ''')
+    html, = page.children
+    body, = html.children
+    article, = body.children
+    div_a1, div_a2, div_a3 = article.children
+    assert div_a1.position_x == div_a2.position_x == div_a3.position_x == 0
+    assert div_a1.position_y == div_a2.position_y == div_a3.position_y == 0
+    assert div_a1.width == div_a2.width == div_a3.width == 6  # 2 + (10 - 2) / 2
+    assert div_a1.height == div_a2.height == div_a3.height == 2
+    assert article.width == 10
+
+
+@assert_no_logs
+def test_grid_template_areas_extra_span():
+    page, = render_pages('''
+      <style>
+        @font-face { src: url(weasyprint.otf); font-family: weasyprint }
+        article {
+          display: grid;
+          font-family: weasyprint;
+          font-size: 2px;
+          grid-template-areas: 'a . b' 'c d d';
+          line-height: 1;
+          width: 10px;
+        }
+      </style>
+      <article>
+        <div style="grid-area: a">a</div>
+        <div style="grid-area: b">b</div>
+        <div style="grid-area: c">c</div>
+        <div style="grid-area: d">d</div>
+        <div style="grid-row: span 2; grid-column: span 2">e</div>
+        <div>f</div>
+      </article>
+    ''')
+    html, = page.children
+    body, = html.children
+    article, = body.children
+    div_a, div_b, div_c, div_d, div_e, div_f = article.children
+    assert div_a.position_x == div_c.position_x == div_e.position_x == 0
+    assert div_d.position_x == 4  # 2 + (10 - 2 × 3) / 2
+    assert div_b.position_x == div_f.position_x == 6
+    assert div_a.position_y == div_b.position_y == 0
+    assert div_c.position_y == div_d.position_y == 2
+    assert div_e.position_y == div_f.position_y == 4
+    assert div_a.width == div_b.width == div_c.width == div_f.width == 4
+    assert div_d.width == div_e.width == 6
+    assert {div.height for div in article.children} == {2}
+    assert article.width == 10
+
+
+@assert_no_logs
+def test_grid_template_areas_extra_span_dense():
+    page, = render_pages('''
+      <style>
+        @font-face { src: url(weasyprint.otf); font-family: weasyprint }
+        article {
+          display: grid;
+          font-family: weasyprint;
+          font-size: 2px;
+          grid-auto-flow: dense;
+          grid-template-areas: 'a . b' 'c d d';
+          line-height: 1;
+          width: 9px;
+        }
+      </style>
+      <article>
+        <div style="grid-area: a">a</div>
+        <div style="grid-area: b">b</div>
+        <div style="grid-area: c">c</div>
+        <div style="grid-area: d">d</div>
+        <div style="grid-row: span 2; grid-column: span 2">e</div>
+        <div>f</div>
+      </article>
+    ''')
+    html, = page.children
+    body, = html.children
+    article, = body.children
+    div_a, div_b, div_c, div_d, div_e, div_f = article.children
+    assert div_a.position_x == div_c.position_x == div_e.position_x == 0
+    assert div_d.position_x == div_f.position_x == 3
+    assert div_b.position_x == 6
+    assert div_a.position_y == div_b.position_y == div_f.position_y == 0
+    assert div_c.position_y == div_d.position_y == 2
+    assert div_e.position_y == 4
+    assert div_a.width == div_b.width == div_c.width == div_f.width == 3
+    assert div_d.width == div_e.width == 6
+    assert {div.height for div in article.children} == {2}
+    assert article.width == 9
+
+
+@assert_no_logs
+def test_grid_template_repeat_fr():
+    page, = render_pages('''
+      <style>
+        @font-face { src: url(weasyprint.otf); font-family: weasyprint }
+        article {
+          display: grid;
+          font-family: weasyprint;
+          font-size: 2px;
+          grid-template-columns: repeat(2, 1fr 2fr);
+          line-height: 1;
+          width: 12px;
+        }
+      </style>
+      <article>
+        <div>a</div>
+        <div>b</div>
+        <div>c</div>
+        <div>d</div>
+        <div>e</div>
+        <div>f</div>
+        <div>g</div>
+        <div>h</div>
+      </article>
+    ''')
+    html, = page.children
+    body, = html.children
+    article, = body.children
+    div_a, div_b, div_c, div_d, div_e, div_f, div_g, div_h = article.children
+    assert div_a.position_x == div_e.position_x == 0
+    assert div_b.position_x == div_f.position_x == 2
+    assert div_c.position_x == div_g.position_x == 6
+    assert div_d.position_x == div_h.position_x == 8
+    assert div_a.position_y == div_b.position_y == 0
+    assert div_c.position_y == div_d.position_y == 0
+    assert div_e.position_y == div_f.position_y == 2
+    assert div_g.position_y == div_h.position_y == 2
+    assert div_a.width == div_c.width == div_e.width == div_g.width == 2
+    assert div_b.width == div_d.width == div_f.width == div_h.width == 4
+    assert {div.height for div in article.children} == {2}
+    assert article.width == 12
+
+
+@assert_no_logs
+def test_grid_template_shorthand_fr():
+    page, = render_pages('''
+      <style>
+        @font-face { src: url(weasyprint.otf); font-family: weasyprint }
+        article {
+          display: grid;
+          font-family: weasyprint;
+          font-size: 2px;
+          grid-template: auto 1fr / auto 1fr auto;
+          line-height: 1;
+          width: 10px;
+        }
+      </style>
+      <article>
+        <div>a</div>
+        <div>b</div>
+        <div>c</div>
+        <div>d</div>
+        <div>e</div>
+        <div>f</div>
+      </article>
+    ''')
+    html, = page.children
+    body, = html.children
+    article, = body.children
+    div_a, div_b, div_c, div_d, div_e, div_f = article.children
+    assert div_a.position_x == div_d.position_x == 0
+    assert div_b.position_x == div_e.position_x == 2
+    assert div_c.position_x == div_f.position_x == 8
+    assert div_a.position_y == div_b.position_y == div_c.position_y == 0
+    assert div_d.position_y == div_e.position_y == div_f.position_y == 2
+    assert div_a.width == div_c.width == div_d.width == div_f.width == 2
+    assert div_b.width == div_e.width == 6
+    assert {div.height for div in article.children} == {2}
+    assert article.width == 10

--- a/tests/layout/test_grid.py
+++ b/tests/layout/test_grid.py
@@ -474,7 +474,6 @@ def test_grid_shorthand_auto_flow_rows_fr_size():
     assert article.width == 10
 
 
-@assert_no_logs
 def test_grid_shorthand_auto_flow_columns_none_dense():
     page, = render_pages('''
       <style>

--- a/tests/layout/test_grid.py
+++ b/tests/layout/test_grid.py
@@ -439,3 +439,69 @@ def test_grid_template_shorthand_fr():
     assert div_b.width == div_e.width == 6
     assert {div.height for div in article.children} == {2}
     assert article.width == 10
+
+
+@assert_no_logs
+def test_grid_shorthand_auto_flow_rows_fr_size():
+    page, = render_pages('''
+      <style>
+        @font-face { src: url(weasyprint.otf); font-family: weasyprint }
+        article {
+          display: grid;
+          font-family: weasyprint;
+          font-size: 2px;
+          grid: auto-flow 1fr / 6px;
+          line-height: 1;
+          width: 10px;
+        }
+      </style>
+      <article>
+        <div>a</div>
+        <div>b</div>
+        <div>c</div>
+      </article>
+    ''')
+    html, = page.children
+    body, = html.children
+    article, = body.children
+    div_a, div_b, div_c = article.children
+    assert div_a.position_x == div_b.position_x == div_c.position_x == 0
+    assert div_a.position_y == 0
+    assert div_b.position_y == 2
+    assert div_c.position_y == 4
+    assert div_a.width == div_b.width == div_c.width == 6
+    assert {div.height for div in article.children} == {2}
+    assert article.width == 10
+
+
+@assert_no_logs
+def test_grid_shorthand_auto_flow_columns_none_dense():
+    page, = render_pages('''
+      <style>
+        @font-face { src: url(weasyprint.otf); font-family: weasyprint }
+        article {
+          display: grid;
+          font-family: weasyprint;
+          font-size: 2px;
+          grid: none / auto-flow 1fr dense;
+          line-height: 1;
+          width: 10px;
+        }
+      </style>
+      <article>
+        <div>a</div>
+        <div>b</div>
+        <div>c</div>
+      </article>
+    ''')
+    html, = page.children
+    body, = html.children
+    article, = body.children
+    div_a, div_b, div_c = article.children
+    assert div_a.position_x == div_b.position_x == div_c.position_x == 0
+    assert div_a.position_y == 0
+    assert div_b.position_y == 2
+    assert div_c.position_y == 4
+    assert div_a.width == div_b.width == div_c.width == 10
+    assert {div.height for div in article.children} == {2}
+    assert article.width == 10

--- a/tests/layout/test_grid.py
+++ b/tests/layout/test_grid.py
@@ -671,3 +671,132 @@ def test_grid_undefined_free_space():
     assert div_r11.height == div_r12.height == div_r21.height == div_r22.height == 4
     assert div_r11.width == div_r12.width == div_r21.width == div_r22.width == 4
     assert div_c.width == 8
+
+
+@assert_no_logs
+def test_grid_padding():
+    page, = render_pages('''
+      <style>
+        @font-face { src: url(weasyprint.otf); font-family: weasyprint }
+        article {
+          display: grid;
+          font-family: weasyprint;
+          font-size: 2px;
+          grid-template-rows: auto 1fr;
+          grid-template-columns: auto 1fr;
+          line-height: 1;
+          width: 14px;
+        }
+      </style>
+      <article>
+        <div style="padding: 1px">a</div> <div>b</div>
+        <div>c</div> <div style="padding: 2px">d</div>
+      </article>
+    ''')
+    html, = page.children
+    body, = html.children
+    article, = body.children
+    div_a, div_b, div_c, div_d = article.children
+    assert div_a.position_x == div_c.position_x == div_c.content_box_x() == 0
+    assert div_a.content_box_x() == 1
+    assert div_b.position_x == div_b.content_box_x() == div_d.position_x == 4
+    assert div_d.content_box_x() == 6
+    assert div_a.width == 2
+    assert div_b.width == 10
+    assert div_c.width == 4
+    assert div_d.width == 6
+    assert article.width == 14
+    assert div_a.position_y == div_b.position_y == div_b.content_box_y() == 0
+    assert div_a.content_box_y() == 1
+    assert div_c.position_y == div_c.content_box_y() == div_d.position_y == 4
+    assert div_d.content_box_y() == 6
+    assert div_a.height == div_d.height == 2
+    assert div_b.height == 4
+    assert div_c.height == 6
+    assert article.height == 10
+
+
+@assert_no_logs
+def test_grid_border():
+    page, = render_pages('''
+      <style>
+        @font-face { src: url(weasyprint.otf); font-family: weasyprint }
+        article {
+          display: grid;
+          font-family: weasyprint;
+          font-size: 2px;
+          grid-template-rows: auto 1fr;
+          grid-template-columns: auto 1fr;
+          line-height: 1;
+          width: 14px;
+        }
+      </style>
+      <article>
+        <div style="border: 1px solid">a</div> <div>b</div>
+        <div>c</div> <div style="border: 2px solid">d</div>
+      </article>
+    ''')
+    html, = page.children
+    body, = html.children
+    article, = body.children
+    div_a, div_b, div_c, div_d = article.children
+    assert div_a.position_x == div_c.position_x == div_c.padding_box_x() == 0
+    assert div_a.padding_box_x() == 1
+    assert div_b.position_x == div_b.padding_box_x() == div_d.position_x == 4
+    assert div_d.padding_box_x() == 6
+    assert div_a.width == 2
+    assert div_b.width == 10
+    assert div_c.width == 4
+    assert div_d.width == 6
+    assert article.width == 14
+    assert div_a.position_y == div_b.position_y == div_b.padding_box_y() == 0
+    assert div_a.padding_box_y() == 1
+    assert div_c.position_y == div_c.padding_box_y() == div_d.position_y == 4
+    assert div_d.padding_box_y() == 6
+    assert div_a.height == div_d.height == 2
+    assert div_b.height == 4
+    assert div_c.height == 6
+    assert article.height == 10
+
+
+@assert_no_logs
+def test_grid_margin():
+    page, = render_pages('''
+      <style>
+        @font-face { src: url(weasyprint.otf); font-family: weasyprint }
+        article {
+          display: grid;
+          font-family: weasyprint;
+          font-size: 2px;
+          grid-template-rows: auto 1fr;
+          grid-template-columns: auto 1fr;
+          line-height: 1;
+          width: 14px;
+        }
+      </style>
+      <article>
+        <div style="margin: 1px">a</div> <div>b</div>
+        <div>c</div> <div style="margin: 2px">d</div>
+      </article>
+    ''')
+    html, = page.children
+    body, = html.children
+    article, = body.children
+    div_a, div_b, div_c, div_d = article.children
+    assert div_a.position_x == div_c.position_x == div_c.border_box_x() == 0
+    assert div_a.border_box_x() == 1
+    assert div_b.position_x == div_b.border_box_x() == div_d.position_x == 4
+    assert div_d.border_box_x() == 6
+    assert div_a.width == 2
+    assert div_b.width == 10
+    assert div_c.width == 4
+    assert div_d.width == 6
+    assert article.width == 14
+    assert div_a.position_y == div_b.position_y == div_b.border_box_y() == 0
+    assert div_a.border_box_y() == 1
+    assert div_c.position_y == div_c.border_box_y() == div_d.position_y == 4
+    assert div_d.border_box_y() == 6
+    assert div_a.height == div_d.height == 2
+    assert div_b.height == 4
+    assert div_c.height == 6
+    assert article.height == 10

--- a/weasyprint/css/computed_values.py
+++ b/weasyprint/css/computed_values.py
@@ -593,7 +593,7 @@ def _compute_track_breadth(style, name, value):
     """Compute track breadth."""
     if value in ('auto', 'min-content', 'max-content'):
         return value
-    elif value.type == 'dimension':
+    elif isinstance(value, Dimension):
         if value.unit == 'fr':
             return value
         else:

--- a/weasyprint/css/computed_values.py
+++ b/weasyprint/css/computed_values.py
@@ -647,11 +647,11 @@ def grid_auto(style, name, values):
             return_values.append(track_breadth)
         elif value[0] == 'minmax()':
             return_values.append((
-                'minmax()', grid_auto(style, name, [value[1]]),
-                grid_auto(style, name, [value[2]])))
+                'minmax()', grid_auto(style, name, [value[1]])[0],
+                grid_auto(style, name, [value[2]])[0]))
         elif value[0] == 'fit-content()':
             return_values.append((
-                'fit-content()', grid_auto(style, name, [value[1]])))
+                'fit-content()', grid_auto(style, name, [value[1]])[0]))
     return tuple(return_values)
 
 

--- a/weasyprint/css/computed_values.py
+++ b/weasyprint/css/computed_values.py
@@ -440,8 +440,9 @@ def border_radius(style, name, values):
 
 
 @register_computer('column-gap')
-def column_gap(style, name, value):
-    """Compute the ``column-gap`` property."""
+@register_computer('row-gap')
+def gap(style, name, value):
+    """Compute the ``*-gap`` properties."""
     if value == 'normal':
         return value
     return length(style, name, value, pixels_only=True)

--- a/weasyprint/css/properties.py
+++ b/weasyprint/css/properties.py
@@ -206,7 +206,7 @@ INITIAL_VALUES = {
     'align_self': ('auto',),
     'justify_content': ('normal',),
     'justify_items': ('normal',),
-    'justify_self': ('normal',),
+    'justify_self': ('auto',),
     'order': 0,
     'column_gap': 'normal',
     'row_gap': 'normal',

--- a/weasyprint/css/properties.py
+++ b/weasyprint/css/properties.py
@@ -201,10 +201,12 @@ INITIAL_VALUES = {
     'grid_column_end': 'auto',
 
     # CSS Box Alignment Module Level 3 (WD): https://www.w3.org/TR/css-align-3/
-    'align_content': 'normal',
-    'align_items': 'normal',
-    'align_self': 'auto',
-    'justify_content': 'normal',
+    'align_content': ('normal',),
+    'align_items': ('normal',),
+    'align_self': ('auto',),
+    'justify_content': ('normal',),
+    'justify_items': ('normal',),
+    'justify_self': ('normal',),
     'order': 0,
     'column_gap': 'normal',
     'row_gap': 'normal',

--- a/weasyprint/css/properties.py
+++ b/weasyprint/css/properties.py
@@ -195,6 +195,10 @@ INITIAL_VALUES = {
     'grid_template_areas': 'none',
     'grid_template_columns': 'none',
     'grid_template_rows': 'none',
+    'grid_row_start': 'auto',
+    'grid_column_start': 'auto',
+    'grid_row_end': 'auto',
+    'grid_column_end': 'auto',
 
     # CSS Box Alignment Module Level 3 (WD): https://www.w3.org/TR/css-align-3/
     'align_content': 'normal',

--- a/weasyprint/css/validation/expanders.py
+++ b/weasyprint/css/validation/expanders.py
@@ -918,6 +918,30 @@ def expand_gap(tokens, name):
     yield 'row-gap', tokens[1:2]
 
 
+@expander('place-content')
+@generic_expander('align-content', 'justify-content')
+def expand_place_content(tokens, name):
+    """Expand the ``place-content`` property."""
+    # TODO
+    raise InvalidValues
+
+
+@expander('place-items')
+@generic_expander('align-items', 'justify-items')
+def expand_place_items(tokens, name):
+    """Expand the ``place-items`` property."""
+    # TODO
+    raise InvalidValues
+
+
+@expander('place-self')
+@generic_expander('align-self', 'justify-self')
+def expand_place_self(tokens, name):
+    """Expand the ``place-self`` property."""
+    # TODO
+    raise InvalidValues
+
+
 @expander('line-clamp')
 @generic_expander('max-lines', 'continue', 'block-ellipsis')
 def expand_line_clamp(tokens, name):

--- a/weasyprint/css/validation/expanders.py
+++ b/weasyprint/css/validation/expanders.py
@@ -17,7 +17,7 @@ from .properties import ( # isort:skip
     border_image_width, border_image_outset, border_image_repeat, border_style,
     border_width, box, column_count, column_width, flex_basis, flex_direction,
     flex_grow_shrink, flex_wrap, font_family, font_size, font_stretch,
-    font_style, font_weight, grid_line, grid_template, line_height,
+    font_style, font_weight, gap, grid_line, grid_template, line_height,
     list_style_image, list_style_position, list_style_type, other_colors,
     overflow_wrap, validate_non_shorthand)
 
@@ -900,6 +900,19 @@ def expand_grid_area(tokens, name):
     sides = ('row-start', 'row-end', 'column-start', 'column-end')
     for tokens, side in zip(tokens_list, sides):
         yield f'grid-{side}', tokens
+
+
+@expander('gap')
+@generic_expander('column-gap', 'row-gap')
+def expand_gap(tokens, name):
+    """Expand the ``gap`` property."""
+    if len(tokens) != 2:
+        raise InvalidValues
+    column_gap, row_gap = gap(tokens[0:1]), gap(tokens[1:2])
+    if None in (column_gap, row_gap):
+        raise InvalidValues
+    yield 'column-gap', tokens[0:1]
+    yield 'row-gap', tokens[1:2]
 
 
 @expander('line-clamp')

--- a/weasyprint/css/validation/expanders.py
+++ b/weasyprint/css/validation/expanders.py
@@ -16,9 +16,10 @@ from .properties import ( # isort:skip
     background_size, block_ellipsis, border_image_source, border_image_slice,
     border_image_width, border_image_outset, border_image_repeat, border_style,
     border_width, box, column_count, column_width, flex_basis, flex_direction,
-    flex_grow_shrink, flex_wrap, font_family, font_size, font_stretch, font_style,
-    font_weight, line_height, list_style_image, list_style_position, list_style_type,
-    other_colors, overflow_wrap, validate_non_shorthand)
+    flex_grow_shrink, flex_wrap, font_family, font_size, font_stretch,
+    font_style, font_weight, grid_line, line_height, list_style_image,
+    list_style_position, list_style_type, other_colors, overflow_wrap,
+    validate_non_shorthand)
 
 EXPANDERS = {}
 
@@ -752,6 +753,49 @@ def expand_flex_flow(tokens, name):
                 raise InvalidValues
     else:
         raise InvalidValues
+
+
+@expander('grid-template')
+@generic_expander('-columns', '-rows', '-areas')
+def expand_grid_template(tokens, name):
+    """Expand the ``grid-template`` property."""
+    # TODO: write expander
+
+
+@expander('grid')
+@generic_expander('-template-columns', '-template-rows', '-template-areas',
+                  '-auto-columns', '-auto-rows', '-auto-flow')
+def expand_grid(tokens, name):
+    """Expand the ``grid`` property."""
+    # TODO: write expander
+
+
+@expander('grid-column')
+@expander('grid-row')
+@generic_expander('-start', '-end')
+def expand_grid_column_row(tokens, name):
+    """Expand the ``grid-[column|row]`` properties."""
+    grid_lines = [[]]
+    for token in tokens:
+        if token.type == 'literal' and token.value == '/':
+            if len(grid_lines) != 1:
+                raise InvalidValues
+            grid_lines.append([])
+            continue
+        grid_lines[-1].append(token)
+    if len(grid_lines) in (1, 2):
+        for token, side in zip(grid_lines, ('start', 'end')):
+            if not grid_line(token):
+                raise InvalidValues
+            yield f'-{side}', token
+
+
+@expander('grid-area')
+@generic_expander('grid-row-start', 'grid-row-end',
+                  'grid-column-start', 'grid-column-end')
+def expand_grid_area(tokens, name):
+    """Expand the ``grid-area`` property."""
+    # TODO: write expander
 
 
 @expander('line-clamp')

--- a/weasyprint/css/validation/expanders.py
+++ b/weasyprint/css/validation/expanders.py
@@ -914,8 +914,8 @@ def expand_gap(tokens, name):
     column_gap, row_gap = gap(tokens[0:1]), gap(tokens[1:2])
     if None in (column_gap, row_gap):
         raise InvalidValues
-    yield 'column-gap', tokens[0:1]
-    yield 'row-gap', tokens[1:2]
+    yield 'row-gap', tokens[0:1]
+    yield 'column-gap', tokens[1:2]
 
 
 @expander('place-content')

--- a/weasyprint/css/validation/expanders.py
+++ b/weasyprint/css/validation/expanders.py
@@ -799,6 +799,7 @@ def expand_grid_template(tokens, name):
 def expand_grid(tokens, name):
     """Expand the ``grid`` property."""
     # TODO: write expander
+    raise InvalidValues
 
 
 def _expand_grid_column_row_area(tokens, max_number):

--- a/weasyprint/css/validation/expanders.py
+++ b/weasyprint/css/validation/expanders.py
@@ -755,10 +755,7 @@ def expand_flex_flow(tokens, name):
         raise InvalidValues
 
 
-@expander('grid-template')
-@generic_expander('-columns', '-rows', '-areas')
-def expand_grid_template(tokens, name):
-    """Expand the ``grid-template`` property."""
+def _expand_grid_template(tokens, name):
     line, column = tokens[0].source_line, tokens[0].source_column
     none = IdentToken(line, column, 'none')
     if len(tokens) == 1 and get_keyword(tokens[0]) == 'none':
@@ -792,6 +789,13 @@ def expand_grid_template(tokens, name):
     raise InvalidValues
 
 
+@expander('grid-template')
+@generic_expander('-columns', '-rows', '-areas')
+def expand_grid_template(tokens, name):
+    """Expand the ``grid-template`` property."""
+    yield from _expand_grid_template(tokens, name)
+
+
 @expander('grid')
 @generic_expander('-template-columns', '-template-rows', '-template-areas',
                   '-auto-columns', '-auto-rows', '-auto-flow')
@@ -803,8 +807,7 @@ def expand_grid(tokens, name):
     row = IdentToken(line, column, 'row')
     column = IdentToken(line, column, 'column')
     try:
-        template = tuple(
-            expand_grid_template(tokens, 'grid-template', base_url=None))
+        template = tuple(_expand_grid_template(tokens, 'grid-template'))
     except InvalidValues:
         pass
     else:

--- a/weasyprint/css/validation/expanders.py
+++ b/weasyprint/css/validation/expanders.py
@@ -905,17 +905,44 @@ def expand_grid_area(tokens, name):
         yield f'grid-{side}', tokens
 
 
+@expander('grid-gap')
 @expander('gap')
 @generic_expander('column-gap', 'row-gap')
 def expand_gap(tokens, name):
     """Expand the ``gap`` property."""
-    if len(tokens) != 2:
+    if len(tokens) == 1:
+        if gap(tokens) is None:
+            raise InvalidValues
+        yield 'row-gap', tokens
+        yield 'column-gap', tokens
+    elif len(tokens) == 2:
+        column_gap, row_gap = gap(tokens[0:1]), gap(tokens[1:2])
+        if None in (column_gap, row_gap):
+            raise InvalidValues
+        yield 'row-gap', tokens[0:1]
+        yield 'column-gap', tokens[1:2]
+    else:
         raise InvalidValues
-    column_gap, row_gap = gap(tokens[0:1]), gap(tokens[1:2])
-    if None in (column_gap, row_gap):
+
+
+@expander('grid-column-gap')
+@generic_expander('column-gap')
+def expand_legacy_column_gap(tokens, name):
+    """Expand legacy ``grid-column-gap`` property."""
+    keyword = gap(tokens)
+    if keyword is None:
         raise InvalidValues
-    yield 'row-gap', tokens[0:1]
-    yield 'column-gap', tokens[1:2]
+    yield 'column-gap', tokens
+
+
+@expander('grid-row-gap')
+@generic_expander('row-gap')
+def expand_legacy_row_gap(tokens, name):
+    """Expand legacy ``grid-row-gap`` property."""
+    keyword = gap(tokens)
+    if keyword is None:
+        raise InvalidValues
+    yield 'row-gap', tokens
 
 
 @expander('place-content')

--- a/weasyprint/css/validation/properties.py
+++ b/weasyprint/css/validation/properties.py
@@ -1528,7 +1528,7 @@ def grid_template(tokens):
 @property()
 def grid_template_areas(tokens):
     """``grid-template-areas`` property validation."""
-    if len(tokens) == 1 and tokens[0] == 'none':
+    if len(tokens) == 1 and get_keyword(tokens[0]) == 'none':
         return 'none'
     grid_areas = []
     for token in tokens:

--- a/weasyprint/css/validation/properties.py
+++ b/weasyprint/css/validation/properties.py
@@ -1444,16 +1444,21 @@ def grid_template(tokens):
             if line_names is not None:
                 if last_is_line_name:
                     return
-                return_tokens.append(line_names)
                 last_is_line_name = True
+                return_tokens.append(line_names)
                 continue
-            last_is_line_name = False
             fixed_size = _fixed_size(token)
             if fixed_size:
+                if not last_is_line_name:
+                    return_tokens.append(())
+                last_is_line_name = False
                 return_tokens.append(fixed_size)
                 continue
             track_size = _track_size(token)
             if track_size:
+                if not last_is_line_name:
+                    return_tokens.append(())
+                last_is_line_name = False
                 return_tokens.append(track_size)
                 includes_track = True
                 continue
@@ -1495,11 +1500,17 @@ def grid_template(tokens):
                             names_and_sizes.append(track_size)
                             continue
                         return
+                    if not last_is_line_name:
+                        return_tokens.append(())
+                    last_is_line_name = False
                     return_tokens.append(
                         ('repeat()', number, tuple(names_and_sizes)))
+                    continue
             return
         if includes_auto_repeat and includes_track:
             return
+        if not last_is_line_name:
+            return_tokens.append(())
     return tuple(return_tokens)
 
 

--- a/weasyprint/css/validation/properties.py
+++ b/weasyprint/css/validation/properties.py
@@ -1592,7 +1592,7 @@ def grid_line(tokens):
             elif keyword != 'span':
                 return (None, None, keyword)
         elif token.type == 'number' and token.is_integer and token.value:
-            return (None, token.value, None)
+            return (None, token.int_value, None)
         return
     number = ident = span = None
     for token in tokens:
@@ -1608,7 +1608,7 @@ def grid_line(tokens):
                 continue
         elif token.type == 'number' and token.is_integer and token.value:
             if number is None:
-                number = token.value
+                number = token.int_value
                 continue
         return
     if span:

--- a/weasyprint/css/validation/properties.py
+++ b/weasyprint/css/validation/properties.py
@@ -1410,10 +1410,11 @@ def grid_template(tokens):
         return 'none'
     if get_keyword(tokens[0]) == 'subgrid':
         return_tokens.append('subgrid')
+        subgrid_tokens = []
         for token in tokens[1:]:
             line_names = _line_names(token)
             if line_names is not None:
-                return_tokens.append(line_names)
+                subgrid_tokens.append(line_names)
                 continue
             function = parse_function(token)
             if function:
@@ -1431,10 +1432,11 @@ def grid_template(tokens):
                         line_names = _line_names(arg)
                         if line_names is not None:
                             line_names_list.append(line_names)
-                    return_tokens.append(
+                    subgrid_tokens.append(
                         ('repeat()', number, tuple(line_names_list)))
                     continue
             return
+        return_tokens.append(tuple(subgrid_tokens))
     else:
         includes_auto_repeat = False
         includes_track = False
@@ -1487,22 +1489,29 @@ def grid_template(tokens):
                             names_and_sizes.append(line_names)
                             repeat_last_is_line_name = True
                             continue
-                        repeat_last_is_line_name = False
                         # fixed-repead
                         fixed_size = _fixed_size(arg)
                         if fixed_size:
+                            if not repeat_last_is_line_name:
+                                names_and_sizes.append(())
+                            repeat_last_is_line_name = False
                             names_and_sizes.append(fixed_size)
                             continue
                         # track-repeat
                         track_size = _track_size(arg)
                         if track_size:
                             includes_track = True
+                            if not repeat_last_is_line_name:
+                                names_and_sizes.append(())
+                            repeat_last_is_line_name = False
                             names_and_sizes.append(track_size)
                             continue
                         return
                     if not last_is_line_name:
                         return_tokens.append(())
                     last_is_line_name = False
+                    if not repeat_last_is_line_name:
+                        names_and_sizes.append(())
                     return_tokens.append(
                         ('repeat()', number, tuple(names_and_sizes)))
                     continue

--- a/weasyprint/css/validation/properties.py
+++ b/weasyprint/css/validation/properties.py
@@ -1578,6 +1578,48 @@ def grid_template_areas(tokens):
         return tuple(grid_areas)
 
 
+@property('grid-row-start')
+@property('grid-row-end')
+@property('grid-column-start')
+@property('grid-column-end')
+def grid_line(tokens):
+    """``grid-[row|column]-[start—end]`` properties validation."""
+    if len(tokens) == 1:
+        token = tokens[0]
+        if keyword := get_keyword(token):
+            if keyword == 'auto':
+                return keyword
+            elif keyword != 'span':
+                return (None, None, keyword)
+        elif token.type == 'number' and token.is_integer and token.value:
+            return (None, token.value, None)
+        return
+    number = ident = span = None
+    for token in tokens:
+        if keyword := get_keyword(token):
+            if keyword == 'auto':
+                return
+            if keyword == 'span':
+                if span is None:
+                    span = 'span'
+                    continue
+            elif keyword and ident is None:
+                ident = keyword
+                continue
+        elif token.type == 'number' and token.is_integer and token.value:
+            if number is None:
+                number = token.value
+                continue
+        return
+    if span:
+        if number and number < 0:
+            return
+        elif ident or number:
+            return (span, number, ident)
+    elif number:
+        return (span, number, ident)
+
+
 @property()
 @single_keyword
 def flex_wrap(keyword):

--- a/weasyprint/css/validation/properties.py
+++ b/weasyprint/css/validation/properties.py
@@ -1395,6 +1395,8 @@ def grid_auto_flow(tokens):
         keyword = get_keyword(tokens[0])
         if keyword in ('row', 'column'):
             return (keyword,)
+        elif keyword == 'dense':
+            return (keyword, 'row')
     elif len(tokens) == 2:
         keywords = [get_keyword(token) for token in tokens]
         if 'dense' in keywords and ('row' in keywords or 'column' in keywords):

--- a/weasyprint/css/validation/properties.py
+++ b/weasyprint/css/validation/properties.py
@@ -1630,38 +1630,142 @@ def flex_wrap(keyword):
 
 
 @property()
-@single_keyword
-def justify_content(keyword):
+def justify_content(tokens):
     """``justify-content`` property validation."""
-    return keyword in (
-        'flex-start', 'flex-end', 'center', 'space-between', 'space-around',
-        'space-evenly', 'stretch', 'normal')
+    if len(tokens) == 1:
+        keyword = get_keyword(tokens[0])
+        if keyword in (
+                'center', 'space-between', 'space-around', 'space-evenly',
+                'stretch', 'normal', 'flex-start', 'flex-end',
+                'start', 'end', 'left', 'right'):
+            return (keyword,)
+    elif len(tokens) == 2:
+        keywords = tuple(get_keyword(token) for token in tokens)
+        if keywords[0] in ('safe', 'unsafe'):
+            if keywords[1] in (
+                    'center', 'start', 'end', 'flex-start', 'flex-end', 'left',
+                    'right'):
+                return keywords
 
 
 @property()
-@single_keyword
-def align_items(keyword):
+def justify_items(tokens):
+    """``justify-items`` property validation."""
+    if len(tokens) == 1:
+        keyword = get_keyword(tokens[0])
+        if keyword in (
+                'normal', 'stretch', 'center', 'start', 'end', 'self-start',
+                'self-end', 'flex-start', 'flex-end', 'left', 'right',
+                'legacy'):
+            return (keyword,)
+        elif keyword == 'baseline':
+            return ('first', keyword)
+    elif len(tokens) == 2:
+        keywords = tuple(get_keyword(token) for token in tokens)
+        if keywords[0] in ('safe', 'unsafe'):
+            if keywords[1] in (
+                    'center', 'start', 'end', 'self-start', 'self-end',
+                    'flex-start', 'flex-end', 'left', 'right'):
+                return keywords
+        elif 'baseline' in keywords:
+            if 'first' in keywords or 'last' in keywords:
+                return keywords
+        elif 'legacy' in keywords:
+            if set(keywords) & {'left', 'right', 'center'}:
+                return keywords
+
+
+@property()
+def justify_self(tokens):
+    """``justify-self`` property validation."""
+    if len(tokens) == 1:
+        keyword = get_keyword(tokens[0])
+        if keyword in (
+                'auto', 'normal', 'stretch', 'center', 'start', 'end',
+                'self-start', 'self-end', 'flex-start', 'flex-end', 'left',
+                'right'):
+            return (keyword,)
+        elif keyword == 'baseline':
+            return ('first', keyword)
+    elif len(tokens) == 2:
+        keywords = tuple(get_keyword(token) for token in tokens)
+        if keywords[0] in ('safe', 'unsafe'):
+            if keywords[1] in (
+                    'center', 'start', 'end', 'self-start', 'self-end',
+                    'flex-start', 'flex-end', 'left', 'right'):
+                return keywords
+        elif 'baseline' in keywords:
+            if 'first' in keywords or 'last' in keywords:
+                return keywords
+
+
+@property()
+def align_items(tokens):
     """``align-items`` property validation."""
-    return keyword in (
-        'flex-start', 'flex-end', 'center', 'baseline', 'stretch', 'normal')
+    if len(tokens) == 1:
+        keyword = get_keyword(tokens[0])
+        if keyword in (
+                'normal', 'stretch', 'center', 'start', 'end', 'self-start',
+                'self-end', 'flex-start', 'flex-end'):
+            return (keyword,)
+        elif keyword == 'baseline':
+            return ('first', keyword)
+    elif len(tokens) == 2:
+        keywords = tuple(get_keyword(token) for token in tokens)
+        if keywords[0] in ('safe', 'unsafe'):
+            if keywords[1] in (
+                    'center', 'start', 'end', 'self-start', 'self-end',
+                    'flex-start', 'flex-end'):
+                return keywords
+        elif 'baseline' in keywords:
+            if 'first' in keywords or 'last' in keywords:
+                return keywords
 
 
 @property()
-@single_keyword
-def align_self(keyword):
+def align_self(tokens):
     """``align-self`` property validation."""
-    return keyword in (
-        'auto', 'flex-start', 'flex-end', 'center',
-        'baseline', 'stretch', 'normal')
+    if len(tokens) == 1:
+        keyword = get_keyword(tokens[0])
+        if keyword in (
+                'auto', 'normal', 'stretch', 'center', 'start', 'end',
+                'self-start', 'self-end', 'flex-start', 'flex-end'):
+            return (keyword,)
+        elif keyword == 'baseline':
+            return ('first', keyword)
+    elif len(tokens) == 2:
+        keywords = tuple(get_keyword(token) for token in tokens)
+        if keywords[0] in ('safe', 'unsafe'):
+            if keywords[1] in (
+                    'center', 'start', 'end', 'self-start', 'self-end',
+                    'flex-start', 'flex-end'):
+                return keywords
+        elif 'baseline' in keywords:
+            if 'first' in keywords or 'last' in keywords:
+                return keywords
 
 
 @property()
-@single_keyword
-def align_content(keyword):
+def align_content(tokens):
     """``align-content`` property validation."""
-    return keyword in (
-        'flex-start', 'flex-end', 'center', 'space-between', 'space-around',
-        'space-evenly', 'stretch', 'normal')
+    if len(tokens) == 1:
+        keyword = get_keyword(tokens[0])
+        if keyword in (
+                'center', 'space-between', 'space-around', 'space-evenly',
+                'stretch', 'normal', 'flex-start', 'flex-end',
+                'start', 'end'):
+            return (keyword,)
+        elif keyword == 'baseline':
+            return ('first', keyword)
+    elif len(tokens) == 2:
+        keywords = tuple(get_keyword(token) for token in tokens)
+        if keywords[0] in ('safe', 'unsafe'):
+            if keywords[1] in (
+                    'center', 'start', 'end', 'flex-start', 'flex-end'):
+                return keywords
+        elif 'baseline' in keywords:
+            if 'first' in keywords or 'last' in keywords:
+                return keywords
 
 
 @property()

--- a/weasyprint/draw.py
+++ b/weasyprint/draw.py
@@ -1211,8 +1211,8 @@ def draw_inline_level(stream, page, box, offset_x=0, text_overflow='clip',
                       block_ellipsis='none'):
     if isinstance(box, StackingContext):
         stacking_context = box
-        assert isinstance(
-            stacking_context.box, (boxes.InlineBlockBox, boxes.InlineFlexBox))
+        assert isinstance(stacking_context.box, (
+            boxes.InlineBlockBox, boxes.InlineFlexBox, boxes.InlineGridBox))
         draw_stacking_context(stream, stacking_context)
     else:
         draw_background(stream, box.background)

--- a/weasyprint/formatting_structure/boxes.py
+++ b/weasyprint/formatting_structure/boxes.py
@@ -68,6 +68,7 @@ class Box:
     # Default, may be overriden on instances.
     is_table_wrapper = False
     is_flex_item = False
+    is_grid_item = False
     is_for_root_element = False
     is_column = False
     is_leader = False
@@ -773,5 +774,25 @@ class InlineFlexBox(FlexContainerBox, InlineLevelBox):
     """A box that is both inline-level and a flex container.
 
     It behaves as inline on the outside and as a flex container on the inside.
+
+    """
+
+
+class GridContainerBox(ParentBox):
+    """A box that contains only grid-items."""
+
+
+class GridBox(GridContainerBox, BlockLevelBox):
+    """A box that is both block-level and a grid container.
+
+    It behaves as block on the outside and as a grid container on the inside.
+
+    """
+
+
+class InlineGridBox(GridContainerBox, InlineLevelBox):
+    """A box that is both inline-level and a grid container.
+
+    It behaves as inline on the outside and as a grid container on the inside.
 
     """

--- a/weasyprint/formatting_structure/build.py
+++ b/weasyprint/formatting_structure/build.py
@@ -28,6 +28,9 @@ BOX_TYPE_FROM_DISPLAY = {
     ('block', 'flex'): boxes.FlexBox,
     ('inline', 'flex'): boxes.InlineFlexBox,
 
+    ('block', 'grid'): boxes.GridBox,
+    ('inline', 'grid'): boxes.InlineGridBox,
+
     ('table-row',): boxes.TableRowBox,
     ('table-row-group',): boxes.TableRowGroupBox,
     ('table-header-group',): boxes.TableRowGroupBox,
@@ -51,6 +54,7 @@ def create_anonymous_boxes(box):
     """Create anonymous boxes in box descendants according to layout rules."""
     box = anonymous_table_boxes(box)
     box = flex_boxes(box)
+    box = grid_boxes(box)
     box = inline_in_block(box)
     box = block_in_inline(box)
     return box
@@ -1034,6 +1038,45 @@ def flex_children(box, children):
             else:
                 flex_children.append(child)
         return flex_children
+    else:
+        return children
+
+
+def grid_boxes(box):
+    """Remove and add boxes according to the grid model.
+
+    Take and return a ``Box`` object.
+
+    See https://drafts.csswg.org/css-grid-2/#grid-item
+
+    """
+    if not isinstance(box, boxes.ParentBox) or box.is_running():
+        return box
+
+    # Do recursion.
+    children = [grid_boxes(child) for child in box.children]
+    box.children = grid_children(box, children)
+    return box
+
+
+def grid_children(box, children):
+    if isinstance(box, boxes.GridContainerBox):
+        grid_children = []
+        for child in children:
+            if not child.is_absolutely_positioned():
+                child.is_grid_item = True
+            if isinstance(child, boxes.TextBox) and not child.text.strip(' '):
+                # TODO: ignore texts only containing "characters that can be
+                # affected by the white-space property"
+                # https://drafts.csswg.org/css-grid-2/#grid-item
+                continue
+            if isinstance(child, boxes.InlineLevelBox):
+                anonymous = boxes.BlockBox.anonymous_from(box, [child])
+                anonymous.is_grid_item = True
+                grid_children.append(anonymous)
+            else:
+                grid_children.append(child)
+        return grid_children
     else:
         return children
 

--- a/weasyprint/formatting_structure/build.py
+++ b/weasyprint/formatting_structure/build.py
@@ -1072,6 +1072,7 @@ def grid_children(box, children):
                 continue
             if isinstance(child, boxes.InlineLevelBox):
                 anonymous = boxes.BlockBox.anonymous_from(child, [child])
+                anonymous.style = child.style
                 child.is_grid_item = False
                 anonymous.is_grid_item = True
                 grid_children.append(anonymous)

--- a/weasyprint/formatting_structure/build.py
+++ b/weasyprint/formatting_structure/build.py
@@ -1071,7 +1071,7 @@ def grid_children(box, children):
                 # https://drafts.csswg.org/css-grid-2/#grid-item
                 continue
             if isinstance(child, boxes.InlineLevelBox):
-                anonymous = boxes.BlockBox.anonymous_from(box, [child])
+                anonymous = boxes.BlockBox.anonymous_from(child, [child])
                 child.is_grid_item = False
                 anonymous.is_grid_item = True
                 grid_children.append(anonymous)

--- a/weasyprint/formatting_structure/build.py
+++ b/weasyprint/formatting_structure/build.py
@@ -1072,6 +1072,7 @@ def grid_children(box, children):
                 continue
             if isinstance(child, boxes.InlineLevelBox):
                 anonymous = boxes.BlockBox.anonymous_from(box, [child])
+                child.is_grid_item = False
                 anonymous.is_grid_item = True
                 grid_children.append(anonymous)
             else:

--- a/weasyprint/layout/block.py
+++ b/weasyprint/layout/block.py
@@ -7,6 +7,7 @@ from .absolute import AbsolutePlaceholder, absolute_layout
 from .column import columns_layout
 from .flex import flex_layout
 from .float import avoid_collisions, float_layout, get_clearance
+from .grid import grid_layout
 from .inline import iter_line_boxes
 from .min_max import handle_min_max_width
 from .percent import resolve_percentages, resolve_position_percentages
@@ -79,6 +80,10 @@ def block_level_layout_switch(context, box, bottom_space, skip_stack,
         result = block_replaced_box_layout(context, box, containing_block)
     elif isinstance(box, boxes.FlexBox):
         result = flex_layout(
+            context, box, bottom_space, skip_stack, containing_block,
+            page_is_empty, absolute_boxes, fixed_boxes)
+    elif isinstance(box, boxes.GridBox):
+        result = grid_layout(
             context, box, bottom_space, skip_stack, containing_block,
             page_is_empty, absolute_boxes, fixed_boxes)
     else:  # pragma: no cover
@@ -644,7 +649,8 @@ def block_container_layout(context, box, bottom_space, skip_stack,
 
     collapsing_with_children = not (
         box.border_top_width or box.padding_top or box.is_flex_item or
-        establishes_formatting_context(box) or box.is_for_root_element)
+        box.is_grid_item or establishes_formatting_context(box) or
+        box.is_for_root_element)
     if collapsing_with_children:
         # Not counting margins in adjoining_margins, if any
         # (there are not padding or borders, see above)

--- a/weasyprint/layout/flex.py
+++ b/weasyprint/layout/flex.py
@@ -489,7 +489,7 @@ def flex_layout(context, box, bottom_space, skip_stack, containing_block,
             for i, child in line:
                 align_self = child.style['align_self']
                 if (box.style['flex_direction'].startswith('row') and
-                        align_self == 'baseline' and
+                        'baseline' in align_self and
                         child.margin_top != 'auto' and
                         child.margin_bottom != 'auto'):
                     collected_items.append(child)
@@ -537,9 +537,9 @@ def flex_layout(context, box, bottom_space, skip_stack, containing_block,
 
     # Step 9
     align_content = box.style['align_content']
-    if align_content == 'normal':
-        align_content = 'stretch'
-    if align_content == 'stretch':
+    if 'normal' in align_content:
+        align_content = ('stretch',)
+    if 'stretch' in align_content:
         definite_cross_size = None
         if cross == 'height' and box.style['height'] != 'auto':
             definite_cross_size = box.style['height'].value
@@ -560,16 +560,16 @@ def flex_layout(context, box, bottom_space, skip_stack, containing_block,
 
     # Step 11
     align_items = box.style['align_items']
-    if align_items == 'normal':
-        align_items = 'stretch'
+    if 'normal' in align_items:
+        align_items = ('stretch',)
     for line in flex_lines:
         for i, child in line:
             align_self = child.style['align_self']
-            if align_self == 'normal':
-                align_self = 'stretch'
-            elif align_self == 'auto':
+            if 'normal' in align_self:
+                align_self = ('stretch',)
+            elif 'auto' in align_self:
                 align_self = align_items
-            if align_self == 'stretch' and child.style[cross] == 'auto':
+            if 'stretch' in align_self and child.style[cross] == 'auto':
                 cross_margins = (
                     (child.margin_top, child.margin_bottom)
                     if cross == 'height'
@@ -598,13 +598,13 @@ def flex_layout(context, box, bottom_space, skip_stack, containing_block,
         box.content_box_x() if axis == 'width'
         else box.content_box_y())
     justify_content = box.style['justify_content']
-    if justify_content == 'normal':
-        justify_content = 'flex-start'
+    if 'normal' in justify_content:
+        justify_content = ('flex-start',)
     if box.style['flex_direction'].endswith('-reverse'):
-        if justify_content == 'flex-start':
-            justify_content = 'flex-end'
+        if 'flex-start' in justify_content:
+            justify_content = ('flex-end',)
         elif justify_content == 'flex-end':
-            justify_content = 'flex-start'
+            justify_content = ('flex-start',)
 
     for line in flex_lines:
         position_axis = original_position_axis
@@ -655,19 +655,19 @@ def flex_layout(context, box, bottom_space, skip_stack, containing_block,
         if box.style['direction'] == 'rtl' and axis == 'width':
             free_space *= -1
 
-        if justify_content == 'flex-end':
+        if {'end', 'flex-end', 'right'} & set(justify_content):
             position_axis += free_space
-        elif justify_content == 'center':
+        elif 'center' in justify_content:
             position_axis += free_space / 2
-        elif justify_content == 'space-around':
+        elif 'space-around' in justify_content:
             position_axis += free_space / len(line) / 2
-        elif justify_content == 'space-evenly':
+        elif 'space-evenly' in justify_content:
             position_axis += free_space / (len(line) + 1)
 
         for i, child in line:
             if axis == 'width':
                 child.position_x = position_axis
-                if justify_content == 'stretch':
+                if 'stretch' in justify_content:
                     child.width += free_space / len(line)
             else:
                 child.position_y = position_axis
@@ -677,12 +677,12 @@ def flex_layout(context, box, bottom_space, skip_stack, containing_block,
             if box.style['direction'] == 'rtl' and axis == 'width':
                 margin_axis *= -1
             position_axis += margin_axis
-            if justify_content == 'space-around':
+            if 'space-around' in justify_content:
                 position_axis += free_space / len(line)
-            elif justify_content == 'space-between':
+            elif 'space-between' in justify_content:
                 if len(line) > 1:
                     position_axis += free_space / (len(line) - 1)
-            elif justify_content == 'space-evenly':
+            elif 'space-evenly' in justify_content:
                 position_axis += free_space / (len(line) + 1)
 
     # Step 13
@@ -694,9 +694,9 @@ def flex_layout(context, box, bottom_space, skip_stack, containing_block,
         # TODO: don't duplicate this loop
         for i, child in line:
             align_self = child.style['align_self']
-            if align_self == 'auto':
+            if 'auto' in align_self:
                 align_self = align_items
-            if align_self == 'baseline' and axis == 'width':
+            if 'baseline' in align_self and axis == 'width':
                 # TODO: handle vertical text
                 child.baseline = child._baseline - position_cross
                 line.lower_baseline = max(line.lower_baseline, child.baseline)
@@ -745,34 +745,34 @@ def flex_layout(context, box, bottom_space, skip_stack, containing_block,
             else:
                 # Step 14
                 align_self = child.style['align_self']
-                if align_self == 'normal':
-                    align_self = 'stretch'
-                elif align_self == 'auto':
+                if 'normal' in align_self:
+                    align_self = ('stretch',)
+                elif 'auto' in align_self:
                     align_self = align_items
                 position = 'position_y' if cross == 'height' else 'position_x'
                 setattr(child, position, position_cross)
-                if align_self == 'flex-end':
+                if {'end', 'self-end', 'flex-end'} & set(align_self):
                     if cross == 'height':
                         child.position_y += (
                             line.cross_size - child.margin_height())
                     else:
                         child.position_x += (
                             line.cross_size - child.margin_width())
-                elif align_self == 'center':
+                elif 'center' in align_self:
                     if cross == 'height':
                         child.position_y += (
                             line.cross_size - child.margin_height()) / 2
                     else:
                         child.position_x += (
                             line.cross_size - child.margin_width()) / 2
-                elif align_self == 'baseline':
+                elif 'baseline' in align_self:
                     if cross == 'height':
                         child.position_y += (
                             line.lower_baseline - child.baseline)
                     else:
                         # Handle vertical text
                         pass
-                elif align_self == 'stretch':
+                elif 'stretch' in align_self:
                     if child.style[cross] == 'auto':
                         if cross == 'height':
                             margins = child.margin_top + child.margin_bottom
@@ -813,29 +813,29 @@ def flex_layout(context, box, bottom_space, skip_stack, containing_block,
                         current_value = getattr(child, direction)
                         current_value += cross_translate
                         setattr(child, direction, current_value)
-                        if align_content == 'flex-end':
+                        if {'flex-end', 'end'} & set(align_content):
                             setattr(
                                 child, direction,
                                 current_value + extra_cross_size)
-                        elif align_content == 'center':
+                        elif 'center' in align_content:
                             setattr(
                                 child, direction,
                                 current_value + extra_cross_size / 2)
-                        elif align_content == 'space-around':
+                        elif 'space-around' in align_content:
                             setattr(
                                 child, direction,
                                 current_value + extra_cross_size /
                                 len(flex_lines) / 2)
-                        elif align_content == 'space-evenly':
+                        elif 'space-evenly' in align_content:
                             setattr(
                                 child, direction,
                                 current_value + extra_cross_size /
                                 (len(flex_lines) + 1))
-                if align_content == 'space-between':
+                if 'space-between' in align_content:
                     cross_translate += extra_cross_size / (len(flex_lines) - 1)
-                elif align_content == 'space-around':
+                elif 'space-around' in align_content:
                     cross_translate += extra_cross_size / len(flex_lines)
-                elif align_content == 'space-evenly':
+                elif 'space-evenly' in align_content:
                     cross_translate += extra_cross_size / (len(flex_lines) + 1)
 
     # TODO: don't use block_box_layout, see TODOs in Step 14 and

--- a/weasyprint/layout/float.py
+++ b/weasyprint/layout/float.py
@@ -21,6 +21,7 @@ def float_layout(context, box, containing_block, absolute_boxes, fixed_boxes,
     """Set the width and position of floating ``box``."""
     from .block import block_container_layout
     from .flex import flex_layout
+    from .grid import grid_layout
 
     cb_width, cb_height = (containing_block.width, containing_block.height)
     resolve_percentages(box, (cb_width, cb_height))
@@ -64,6 +65,12 @@ def float_layout(context, box, containing_block, absolute_boxes, fixed_boxes,
         context.finish_block_formatting_context(box)
     elif isinstance(box, boxes.FlexContainerBox):
         box, resume_at, _, _, _ = flex_layout(
+            context, box, bottom_space=bottom_space,
+            skip_stack=skip_stack, containing_block=containing_block,
+            page_is_empty=True, absolute_boxes=absolute_boxes,
+            fixed_boxes=fixed_boxes)
+    elif isinstance(box, boxes.GridContainerBox):
+        box, resume_at, _, _, _ = grid_layout(
             context, box, bottom_space=bottom_space,
             skip_stack=skip_stack, containing_block=containing_block,
             page_is_empty=True, absolute_boxes=absolute_boxes,

--- a/weasyprint/layout/grid.py
+++ b/weasyprint/layout/grid.py
@@ -949,7 +949,12 @@ def grid_layout(context, box, bottom_space, skip_stack, containing_block,
         # TODO: Take care of page fragmentation.
         new_children.append(new_child)
 
+    # TODO: Set real baseline value.
+    if isinstance(box, boxes.InlineGridBox):
+        box.baseline = 0
+
     # TODO: Include gutters, margins, borders, paddings.
     box.height = sum(size for size, _ in rows_sizes)
     box.children = new_children
+
     return box, None, {'break': 'any', 'page': None}, [], False

--- a/weasyprint/layout/grid.py
+++ b/weasyprint/layout/grid.py
@@ -136,7 +136,8 @@ def _get_column_placement(row_placement, column_start, column_end,
             if x in occupied_columns:
                 continue
             if column_start == 'auto':
-                placement = _get_placement(x + 1, column_end, columns)
+                placement = _get_placement(
+                    (None, x + 1, None), column_end, columns)
             else:
                 assert column_start[0] == 'span'
                 # If the placement contains two spans, remove the one
@@ -144,14 +145,16 @@ def _get_column_placement(row_placement, column_start, column_end,
                 # https://drafts.csswg.org/css-grid/#grid-placement-errors
                 assert column_start == 'auto' or column_start[1] == 'span'
                 span = _get_span(column_start)
-                placement = _get_placement(column_start, x + 1 + span, columns)
+                placement = _get_placement(
+                    column_start, (None, x + 1 + span, None), columns)
             columns = range(placement[0], placement[0] + placement[1])
             if not set(columns) & occupied_columns:
                 return placement
     else:
         y = max(occupied_columns) + 1
         if column_start == 'auto':
-            return _get_placement(y + 1, column_end, columns)
+            return _get_placement(
+                (None, y + 1, None), column_end, columns)
         else:
             assert column_start[0] == 'span'
             # If the placement contains two spans, remove the one contributed
@@ -159,7 +162,8 @@ def _get_column_placement(row_placement, column_start, column_end,
             # https://drafts.csswg.org/css-grid/#grid-placement-errors
             assert column_start == 'auto' or column_start[1] == 'span'
             for end_y in count(y + 1):
-                placement = _get_placement(column_start, end_y + 1, columns)
+                placement = _get_placement(
+                    column_start, (None, end_y + 1, None), columns)
                 if placement[0] >= y:
                     return placement
 

--- a/weasyprint/layout/grid.py
+++ b/weasyprint/layout/grid.py
@@ -989,7 +989,7 @@ def grid_layout(context, box, bottom_space, skip_stack, containing_block,
     if box.height == 'auto':
         box.height = (
             sum(size for size, _ in rows_sizes) +
-            (len(rows_sizes) - 1)* row_gap)
+            (len(rows_sizes) - 1) * row_gap)
         free_height = 0
     else:
         free_height = (

--- a/weasyprint/layout/grid.py
+++ b/weasyprint/layout/grid.py
@@ -1148,6 +1148,7 @@ def grid_layout(context, box, bottom_space, skip_stack, containing_block,
                 new_child.translate(diff / 2, 0)
             elif justify_self & {'right', 'end', 'flex-end', 'self-end'}:
                 new_child.translate(diff, 0)
+        new_child.width -= new_child.margin_width() - new_child.width
 
         # TODO: Apply auto margins.
         height -= new_child.margin_height() - new_child.height
@@ -1159,6 +1160,7 @@ def grid_layout(context, box, bottom_space, skip_stack, containing_block,
                 new_child.translate(0, diff / 2)
             elif align_self & {'end', 'flex-end', 'self-end'}:
                 new_child.translate(0, diff)
+        new_child.height -= new_child.margin_height() - new_child.height
 
         # TODO: Take care of page fragmentation.
         new_children.append(new_child)

--- a/weasyprint/layout/grid.py
+++ b/weasyprint/layout/grid.py
@@ -288,7 +288,7 @@ def _distribute_extra_space(affected_sizes, affected_tracks_types,
                 limit = tracks_sizes[track_number][1]
                 if affected_size + item_incurred_increase >= limit:
                     extra = (
-                        item_incurred_increase + affected_size_index - limit)
+                        item_incurred_increase + affected_size - limit)
                     item_incurred_increase -= extra
                 space -= item_incurred_increase
                 item_incurred_increases[track_number] = item_incurred_increase
@@ -306,8 +306,7 @@ def _distribute_extra_space(affected_sizes, affected_tracks_types,
                     limit = tracks_sizes[track_number][1]
                     if affected_size + item_incurred_increase >= limit:
                         extra = (
-                            item_incurred_increase +
-                            affected_size_index - limit)
+                            item_incurred_increase + affected_size - limit)
                         item_incurred_increase -= extra
                     space -= item_incurred_increase
                     item_incurred_increases[track_number] = (

--- a/weasyprint/layout/grid.py
+++ b/weasyprint/layout/grid.py
@@ -1,0 +1,50 @@
+"""Layout for grid containers and grid-items."""
+
+from itertools import cycle
+
+
+def grid_layout(context, box, bottom_space, skip_stack, containing_block,
+                page_is_empty, absolute_boxes, fixed_boxes):
+    # Define explicit grid
+    grid_areas = box.style['grid_template_areas']
+    rows = box.style['grid_template_rows']
+    columns = box.style['grid_template_columns']
+
+    if grid_areas == 'none':
+        grid_areas = ()
+    grid_areas = [list(row) for row in grid_areas]
+    
+    if rows == 'none':
+        rows = ((),)
+    rows = list(rows)
+
+    if columns == 'none':
+        columns = ((),)
+    columns = list(columns)
+
+    # Adjust rows number
+    grid_areas_columns = len(grid_areas[0]) if grid_areas else 0
+    rows_diff = int((len(rows) - 1) / 2) - len(grid_areas)
+    if rows_diff > 0:
+        for _ in range(rows_diff):
+            grid_areas.append([None] * grid_areas_columns)
+    elif rows_diff < 0:
+        rows_sizes = cycle(box.style['grid_auto_rows'])
+        for _ in range(-rows_diff):
+            rows.append(next(rows_sizes))
+            rows.append(())
+
+    # Adjust columns number
+    columns_diff = int((len(columns) - 1) / 2) - grid_areas_columns
+    if columns_diff > 0:
+        for row in grid_areas:
+            for _ in range(columns_diff):
+                row.append(None)
+    elif columns_diff < 0:
+        columns_sizes = cycle(box.style['grid_auto_columns'])
+        for _ in range(-columns_diff):
+            columns.append(next(columns_sizes))
+            columns.append(())
+
+    # 1. Position anything that’s not auto-positioned.
+    pass

--- a/weasyprint/layout/grid.py
+++ b/weasyprint/layout/grid.py
@@ -3,6 +3,88 @@
 from itertools import cycle
 
 
+def placement(start, end, lines):
+    if (start == end == 'auto' or
+        start == 'auto' and end[0] == 'span' or
+        end == 'auto' and start[0] == 'span' or
+        start[0] == 'span' and end[0] == 'span'):
+        return
+    if start != 'auto':
+        span, number, ident = start
+        if ident and span is None and number is None:
+            for coordinate, line in enumerate(lines):
+                if f'{ident}-start' in line:
+                    break
+            else:
+                number = 1
+        if number and span is None:
+            if ident is None:
+                coordinate = number - 1
+            else:
+                step = 1 if number > 0 else -1
+                for coordinate, line in enumerate(lines[::step]):
+                    if ident in line:
+                        number -= step
+                    if number == 0:
+                        break
+                else:
+                    coordinate += abs(number)
+                if step == -1:
+                    coordinate = len(lines) - 1 - coordinate
+        if span is not None:
+            size = number or 1
+            coordinate = None
+            span_ident = ident
+    else:
+        size = 1
+        span_ident = None
+        coordinate = None
+    if end != 'auto':
+        span, number, ident = end
+        if ident and span is None and number is None:
+            for coordinate_end, line in enumerate(lines):
+                if f'{ident}-end' in line:
+                    break
+            else:
+                number = 1
+        if number and span is None:
+            if ident is None:
+                coordinate_end = number - 1
+            else:
+                step = 1 if number > 0 else -1
+                for coordinate_end, line in enumerate(lines[::step]):
+                    if ident in line:
+                        number -= step
+                    if number == 0:
+                        break
+                else:
+                    coordinate_end += abs(number)
+                if step == -1:
+                    coordinate_end = len(lines) - 1 - coordinate_end
+        if span is not None:
+            size = number or 1
+            span_ident = ident
+        else:
+            size = coordinate_end - coordinate
+        if coordinate is None:
+            if coordinate_span is None:
+                coordinate = coordinate_end - size
+            else:
+                number = coordinate_end
+                if coordinate_end > 0:
+                    for coordinate, line in enumerate(lines[coordinate_end-1::-1]):
+                        if span_ident in line:
+                            number -= 1
+                        if number == 0:
+                            coordinate = coordinate_end - 1 - coordinate
+                            break
+                    else:
+                        coordinate = -number
+                else:
+                    coordinate = -number
+    return (coordinate, size)
+
+
 def grid_layout(context, box, bottom_space, skip_stack, containing_block,
                 page_is_empty, absolute_boxes, fixed_boxes):
     # Define explicit grid
@@ -16,11 +98,11 @@ def grid_layout(context, box, bottom_space, skip_stack, containing_block,
 
     if rows == 'none':
         rows = ((),)
-    rows = list(rows)
+    rows = [row if i % 2 else list(row) for i, row in enumerate(rows)]
 
     if columns == 'none':
         columns = ((),)
-    columns = list(columns)
+    columns = [column if i % 2 else list(column) for i, column in enumerate(columns)]
 
     # Adjust rows number
     grid_areas_columns = len(grid_areas[0]) if grid_areas else 0
@@ -32,7 +114,7 @@ def grid_layout(context, box, bottom_space, skip_stack, containing_block,
         rows_sizes = cycle(box.style['grid_auto_rows'])
         for _ in range(-rows_diff):
             rows.append(next(rows_sizes))
-            rows.append(())
+            rows.append([])
 
     # Adjust columns number
     columns_diff = int((len(columns) - 1) / 2) - grid_areas_columns
@@ -44,7 +126,43 @@ def grid_layout(context, box, bottom_space, skip_stack, containing_block,
         columns_sizes = cycle(box.style['grid_auto_columns'])
         for _ in range(-columns_diff):
             columns.append(next(columns_sizes))
-            columns.append(())
+            columns.append([])
 
-    # 1. Position anything that’s not auto-positioned.
-    pass
+    # Add implicit line names
+    for y, row in enumerate(grid_areas):
+        for x, area_name in enumerate(row):
+            if area_name is None:
+                continue
+            start_name = f'{area_name}-start'
+            if start_name not in [name for row in rows[::2] for name in row]:
+                rows[2*y].append(start_name)
+            if start_name not in [name for column in columns[::2] for name in column]:
+                columns[2*x].append(start_name)
+    for y, row in enumerate(grid_areas[::-1]):
+        for x, area_name in enumerate(row[::-1]):
+            if area_name is None:
+                continue
+            end_name = f'{area_name}-end'
+            if end_name not in [name for row in rows[::2] for name in row]:
+                rows[-2*y-1].append(end_name)
+            if end_name not in [name for column in columns[::2] for name in column]:
+                columns[-2*x-1].append(end_name)
+
+    # 1. Grid placement algorithm
+    # 1. Position anything that’s not auto-positioned
+    children_position = {}
+    for child in box.children:
+        column_start = child.style['grid_column_start']
+        column_end = child.style['grid_column_end']
+        row_start = child.style['grid_row_start']
+        row_end = child.style['grid_row_end']
+        column = (column_start, column_end)
+        row = (row_start, row_end)
+
+        column_placement = placement(column_start, column_end, columns[::2])
+        row_placement = placement(row_start, row_end, rows[::2])
+
+        if column_placement and row_placement:
+            x, width = column_placement
+            y, height = row_placement
+            children_position[child] = (x, y, width, height)

--- a/weasyprint/layout/grid.py
+++ b/weasyprint/layout/grid.py
@@ -466,7 +466,7 @@ def _resolve_tracks_sizes(sizing_functions, box_size, children_positions,
             sizing_functions, tracks_sizes, span, direction, context,
             containing_block)
     # 1.2.4 Increase sizes to accommodate items spanning flexible tracks.
-    # TODO
+    # TODO: Support spans for flexible tracks.
     # 1.2.5 Fix infinite growth limits.
     for sizes in tracks_sizes:
         if sizes[1] is inf:
@@ -547,6 +547,7 @@ def grid_layout(context, box, bottom_space, skip_stack, containing_block,
 
     # Define explicit grid
     grid_areas = box.style['grid_template_areas']
+    # TODO: Support 'column' value in grid-auto-flow.
     flow = box.style['grid_auto_flow']
     auto_rows = cycle(box.style['grid_auto_rows'])
     auto_columns = cycle(box.style['grid_auto_columns'])
@@ -902,7 +903,7 @@ def grid_layout(context, box, bottom_space, skip_stack, containing_block,
         from .inline import inline_block_width
         inline_block_width(box, context, containing_block)
     if box.width == 'auto':
-        # TODO: calculate max-width
+        # TODO: Calculate max-width.
         box.width = containing_block.width
 
     # 3. Run the grid sizing algorithm.

--- a/weasyprint/layout/grid.py
+++ b/weasyprint/layout/grid.py
@@ -647,10 +647,10 @@ def grid_layout(context, box, bottom_space, skip_stack, containing_block,
             column_end = child.style['grid_column_end']
             column_placement = _get_placement(
                 column_start, column_end, columns[::2])
+            remaining_grid_items.append(child)
             if column_placement:
                 x, width = column_placement
             else:
-                remaining_grid_items.append(child)
                 continue
         implicit_x1 = min(x, implicit_x1)
         implicit_x2 = max(x + width, implicit_x2)

--- a/weasyprint/layout/grid.py
+++ b/weasyprint/layout/grid.py
@@ -5,6 +5,7 @@ from math import inf
 
 from ..css.properties import Dimension
 from ..formatting_structure import boxes
+from ..logger import LOGGER
 from .percent import percentage, resolve_percentages
 from .preferred import max_content_width, min_content_width
 from .table import find_in_flow_baseline
@@ -186,6 +187,7 @@ def _get_template_tracks(tracks):
         tracks = ((),)
     if 'subgrid' in tracks:
         # TODO: Support subgrids.
+        LOGGER.warning('Subgrids are unsupported')
         return [[]]
     tracks_list = []
     for i, track in enumerate(tracks):
@@ -195,6 +197,8 @@ def _get_template_tracks(tracks):
                 repeat_number, repeat_track_list = track[1:]
                 if not isinstance(repeat_number, int):
                     # TODO: Respect auto-fit and auto-fill.
+                    LOGGER.warning(
+                        '"auto-fit" and "auto-fill" are unsupported in repeat()')
                     repeat_number = 1
                 for _ in range(repeat_number):
                     for j, repeat_track in enumerate(repeat_track_list):
@@ -571,7 +575,6 @@ def grid_layout(context, box, bottom_space, skip_stack, containing_block,
 
     # Define explicit grid
     grid_areas = box.style['grid_template_areas']
-    # TODO: Support 'column' value in grid-auto-flow.
     flow = box.style['grid_auto_flow']
     auto_rows = cycle(box.style['grid_auto_rows'])
     auto_columns = cycle(box.style['grid_auto_columns'])
@@ -583,6 +586,10 @@ def grid_layout(context, box, bottom_space, skip_stack, containing_block,
     row_gap = box.style['row_gap']
     if row_gap == 'normal':
         row_gap = 0
+
+    # TODO: Support 'column' value in grid-auto-flow.
+    if 'column' in flow:
+        LOGGER.warning('"column" is not supported in grid-auto-flow')
 
     if grid_areas == 'none':
         grid_areas = ((None,),)
@@ -1035,7 +1042,9 @@ def grid_layout(context, box, bottom_space, skip_stack, containing_block,
             rows_positions.append(y)
             y += size + free_height / (rows_number + 1) + row_gap
     else:
-        # TODO: Support baseline value.
+        if align_content & {'baseline'}:
+            # TODO: Support baseline value.
+            LOGGER.warning('Baseline alignment is not supported for grid layout')
         for size, _ in rows_sizes:
             rows_positions.append(y)
             y += size + row_gap
@@ -1159,6 +1168,7 @@ def grid_layout(context, box, bottom_space, skip_stack, containing_block,
     box = box.copy_with_children(new_children)
     if isinstance(box, boxes.InlineGridBox):
         # TODO: Synthetize a real baseline value.
+        LOGGER.warning('Inline grids are not supported')
         box.baseline = baseline or 0
 
     context.finish_block_formatting_context(box)

--- a/weasyprint/layout/grid.py
+++ b/weasyprint/layout/grid.py
@@ -333,20 +333,19 @@ def _resolve_tracks_sizes(sizing_functions, box_size, children_positions,
                           containing_block):
     assert direction in 'xy'
     tracks_sizes = []
-    if box_size == 'auto':
-        # TODO: Check that auto box size is 0 for percentages.
-        box_size = 0
+    # TODO: Check that auto box size is 0 for percentages.
+    percent_box_size = 0 if box_size == 'auto' else box_size
     # 1.1 Initialize track sizes.
     for min_function, max_function in sizing_functions:
         base_size = None
         if _is_length(min_function):
-            base_size = percentage(min_function, box_size)
+            base_size = percentage(min_function, percent_box_size)
         elif (min_function in ('min-content', 'max-content', 'auto') or
               min_function[0] == 'fit-content()'):
             base_size = 0
         growth_limit = None
         if _is_length(max_function):
-            growth_limit = percentage(max_function, box_size)
+            growth_limit = percentage(max_function, percent_box_size)
         elif (max_function in ('min-content', 'max-content', 'auto') or
               max_function[0] == 'fit-content()' or _is_fr(max_function)):
             growth_limit = inf

--- a/weasyprint/layout/grid.py
+++ b/weasyprint/layout/grid.py
@@ -830,16 +830,17 @@ def grid_layout(context, box, bottom_space, skip_stack, containing_block,
                 # 2. Increment the cursor’s row position.
                 row_start = child.style['grid_row_start']
                 row_end = child.style['grid_row_end']
-                for y in count(cursor_y):
+                for cursor_y in count(cursor_y):
                     if row_start == 'auto':
                         y, height = _get_placement(
-                            (None, y + 1, None), row_end, rows[::2])
+                            (None, cursor_y + 1, None), row_end, rows[::2])
                     else:
                         assert row_start[0] == 'span'
                         assert row_start == 'auto' or row_start[0] == 'span'
                         span = _get_span(row_start)
                         y, height = _get_placement(
-                            row_start, (None, y + 1 + span, None), rows[::2])
+                            row_start, (None, cursor_y + 1 + span, None),
+                            rows[::2])
                     if y < cursor_y:
                         continue
                     for row in range(y, y + height):

--- a/weasyprint/layout/grid.py
+++ b/weasyprint/layout/grid.py
@@ -521,12 +521,12 @@ def _resolve_tracks_sizes(sizing_functions, box_size, children_positions,
                     free_space -= flex_fraction * max_function.value
                     sizes[0] = flex_fraction * max_function.value
     # 1.5 Expand stretched auto tracks.
+    justify_content = containing_block.style['justify_content']
+    align_content = containing_block.style['align_content']
     x_stretch = (
-        direction == 'x' and
-        containing_block.style['justify_content'] in ('normal', 'stretch'))
+        direction == 'x' and set(justify_content) & {'normal', 'stretch'})
     y_stretch = (
-        direction == 'y' and
-        containing_block.style['align_content'] in ('normal', 'stretch'))
+        direction == 'y' and set(align_content) & {'normal', 'stretch'})
     if (x_stretch or y_stretch) and free_space > 0:
         auto_tracks_sizes = [
             sizes for sizes, (min_function, _)

--- a/weasyprint/layout/grid.py
+++ b/weasyprint/layout/grid.py
@@ -314,7 +314,7 @@ def _distribute_extra_space(affected_sizes, affected_tracks_types,
                         item_incurred_increase)
             # 2.4 Distribute space beyond limits.
             if space:
-                # TODO
+                # TODO: Distribute space beyond limits.
                 pass
             # 2.5. Set the track’s planned increase.
             for k, extra in enumerate(item_incurred_increases):

--- a/weasyprint/layout/grid.py
+++ b/weasyprint/layout/grid.py
@@ -1084,6 +1084,20 @@ def grid_layout(context, box, bottom_space, skip_stack, containing_block,
         height = (
             sum(size for size, _ in rows_sizes[y:y+height]) +
             (height - 1) * row_gap)
+
+        justify_self = set(child.style['justify_self'])
+        if justify_self & {'auto'}:
+            justify_self = justify_items
+        if justify_self & {'normal', 'stretch'}:
+            if child.style['width'] == 'auto':
+                child.style['width'] = Dimension(width, 'px')
+        align_self = set(child.style['align_self'])
+        if align_self & {'auto'}:
+            align_self = align_items
+        if align_self & {'normal', 'stretch'}:
+            if child.style['height'] == 'auto':
+                child.style['height'] = Dimension(height, 'px')
+
         # TODO: Find a better solution for the layout.
         parent = boxes.BlockContainerBox.anonymous_from(box, ())
         resolve_percentages(parent, containing_block)
@@ -1102,10 +1116,7 @@ def grid_layout(context, box, bottom_space, skip_stack, containing_block,
             continue
 
         # TODO: Apply auto margins.
-        justify_self = set(new_child.style['justify_self'])
         width -= new_child.margin_width() - new_child.width
-        if justify_self & {'auto'}:
-            justify_self = justify_items
         if justify_self & {'normal', 'stretch'}:
             new_child.width = max(width, new_child.width)
         else:
@@ -1117,10 +1128,7 @@ def grid_layout(context, box, bottom_space, skip_stack, containing_block,
                 new_child.translate(diff, 0)
 
         # TODO: Apply auto margins.
-        align_self = set(new_child.style['align_self'])
         height -= new_child.margin_height() - new_child.height
-        if align_self & {'auto'}:
-            align_self = align_items
         if align_self & {'normal', 'stretch'}:
             new_child.height = max(height, new_child.height)
         else:

--- a/weasyprint/layout/grid.py
+++ b/weasyprint/layout/grid.py
@@ -62,15 +62,23 @@ def placement(start, end, lines):
                 if step == -1:
                     coordinate_end = len(lines) - 1 - coordinate_end
         if span is not None:
-            size = number or 1
+            size = span_number = number or 1
             span_ident = ident
-        else:
+            if span_ident is not None:
+                for size, line in enumerate(lines[coordinate+1:], start=1):
+                    if span_ident in line:
+                        span_number -= 1
+                    if span_number == 0:
+                        break
+                else:
+                    size += span_number
+        elif coordinate is not None:
             size = coordinate_end - coordinate
         if coordinate is None:
-            if coordinate_span is None:
+            if span_ident is None:
                 coordinate = coordinate_end - size
             else:
-                number = coordinate_end
+                number = number or 1
                 if coordinate_end > 0:
                     for coordinate, line in enumerate(lines[coordinate_end-1::-1]):
                         if span_ident in line:
@@ -82,6 +90,14 @@ def placement(start, end, lines):
                         coordinate = -number
                 else:
                     coordinate = -number
+            size = coordinate_end - coordinate
+    else:
+        size = 1
+    if size < 0:
+        size = -size
+        coordinate -= size
+    if size == 0:
+        size = 1
     return (coordinate, size)
 
 
@@ -166,3 +182,4 @@ def grid_layout(context, box, bottom_space, skip_stack, containing_block,
             x, width = column_placement
             y, height = row_placement
             children_position[child] = (x, y, width, height)
+    # TODO: handle unpositioned items (auto/span or span/auto)

--- a/weasyprint/layout/grid.py
+++ b/weasyprint/layout/grid.py
@@ -1,9 +1,25 @@
 """Layout for grid containers and grid-items."""
 
-from itertools import cycle
+from itertools import count, cycle
 
 
-def placement(start, end, lines):
+def _intersect(position_1, size_1, position_2, size_2):
+    return (
+        position_1 < position_2 + size_2 and
+        position_2 < position_1 + size_1)
+
+
+def _intersect_with_children(x, y, width, height, positions):
+    for full_x, full_y, full_width, full_height in positions:
+        x_intersect = _intersect(x, width, full_x, full_width)
+        y_intersect = _intersect(y, height, full_y, full_height)
+        if x_intersect and y_intersect:
+            return True
+    return False
+
+
+def _get_placement(start, end, lines):
+    # Input coordinates are 1-indexed, returned coordinates are 0-indexed.
     if (start == end == 'auto' or
         start == 'auto' and end[0] == 'span' or
         end == 'auto' and start[0] == 'span' or
@@ -17,7 +33,7 @@ def placement(start, end, lines):
                     break
             else:
                 number = 1
-        if number and span is None:
+        if number is not None and span is None:
             if ident is None:
                 coordinate = number - 1
             else:
@@ -47,7 +63,7 @@ def placement(start, end, lines):
                     break
             else:
                 number = 1
-        if number and span is None:
+        if number is not None and span is None:
             if ident is None:
                 coordinate_end = number - 1
             else:
@@ -101,15 +117,69 @@ def placement(start, end, lines):
     return (coordinate, size)
 
 
+def _get_span(place):
+    # TODO: handle lines
+    span = 1
+    if place[0] == 'span':
+        span = place[1] or 1
+    return span
+
+
+def _get_column_placement(row_placement, column_start, column_end,
+                          columns, children_positions, dense):
+    occupied_columns = set()
+    for x, y, width, height in children_positions.values():
+        # Test whether cells overlap.
+        if _intersect(y, height, *row_placement):
+            for x in range(x, x + width):
+                occupied_columns.add(x)
+    if dense:
+        for x in count():
+            if x in occupied_columns:
+                continue
+            if column_start == 'auto':
+                placement = _get_placement(x + 1, column_end, columns)
+            else:
+                assert column_start[0] == 'span'
+                # If the placement contains two spans, remove the one contributed
+                # by the end grid-placement property.
+                # https://drafts.csswg.org/css-grid/#grid-placement-errors
+                assert column_start == 'auto' or column_start[1] == 'span'
+                span = _get_span(column_start)
+                placement = _get_placement(column_start, x + 1 + span, columns)
+            columns = range(placement[0], placement[0] + placement[1])
+            if not set(columns) & occupied_columns:
+                return placement
+    else:
+        y = max(occupied_columns) + 1
+        if column_start == 'auto':
+            return _get_placement(y + 1, column_end, columns)
+        else:
+            assert column_start[0] == 'span'
+            # If the placement contains two spans, remove the one contributed
+            # by the end grid-placement property.
+            # https://drafts.csswg.org/css-grid/#grid-placement-errors
+            assert column_start == 'auto' or column_start[1] == 'span'
+            for end_y in count(y + 1):
+                placement = _get_placement(column_start, end_y + 1, columns)
+                if placement[0] >= y:
+                    return placement
+
+
 def grid_layout(context, box, bottom_space, skip_stack, containing_block,
                 page_is_empty, absolute_boxes, fixed_boxes):
     # Define explicit grid
     grid_areas = box.style['grid_template_areas']
     rows = box.style['grid_template_rows']
     columns = box.style['grid_template_columns']
+    flow = box.style['grid_auto_flow']
+    auto_rows = cycle(box.style['grid_auto_rows'])
+    auto_columns = cycle(box.style['grid_auto_columns'])
+    auto_rows_back = cycle(box.style['grid_auto_rows'][::-1])
+    auto_columns_back = cycle(box.style['grid_auto_columns'][::-1])
 
     if grid_areas == 'none':
-        grid_areas = ()
+        grid_areas = ((None,),)
     grid_areas = [list(row) for row in grid_areas]
 
     if rows == 'none':
@@ -127,9 +197,8 @@ def grid_layout(context, box, bottom_space, skip_stack, containing_block,
         for _ in range(rows_diff):
             grid_areas.append([None] * grid_areas_columns)
     elif rows_diff < 0:
-        rows_sizes = cycle(box.style['grid_auto_rows'])
         for _ in range(-rows_diff):
-            rows.append(next(rows_sizes))
+            rows.append(next(auto_rows))
             rows.append([])
 
     # Adjust columns number
@@ -139,9 +208,8 @@ def grid_layout(context, box, bottom_space, skip_stack, containing_block,
             for _ in range(columns_diff):
                 row.append(None)
     elif columns_diff < 0:
-        columns_sizes = cycle(box.style['grid_auto_columns'])
         for _ in range(-columns_diff):
-            columns.append(next(columns_sizes))
+            columns.append(next(auto_columns))
             columns.append([])
 
     # Add implicit line names
@@ -164,22 +232,256 @@ def grid_layout(context, box, bottom_space, skip_stack, containing_block,
             if end_name not in [name for column in columns[::2] for name in column]:
                 columns[-2*x-1].append(end_name)
 
-    # 1. Grid placement algorithm
-    # 1. Position anything that’s not auto-positioned
-    children_position = {}
+    # 1. Run the grid placement algorithm.
+
+    # 1.1 Position anything that’s not auto-positioned.
+    children_positions = {}
     for child in box.children:
         column_start = child.style['grid_column_start']
         column_end = child.style['grid_column_end']
         row_start = child.style['grid_row_start']
         row_end = child.style['grid_row_end']
-        column = (column_start, column_end)
-        row = (row_start, row_end)
 
-        column_placement = placement(column_start, column_end, columns[::2])
-        row_placement = placement(row_start, row_end, rows[::2])
+        column_placement = _get_placement(column_start, column_end, columns[::2])
+        row_placement = _get_placement(row_start, row_end, rows[::2])
 
         if column_placement and row_placement:
             x, width = column_placement
             y, height = row_placement
-            children_position[child] = (x, y, width, height)
-    # TODO: handle unpositioned items (auto/span or span/auto)
+            children_positions[child] = (x, y, width, height)
+
+    # 1.2 Process the items locked to a given row.
+    children = sorted(box.children, key=lambda item: item.style['order'])
+    for child in children:
+        if child in children_positions:
+            continue
+        row_start = child.style['grid_row_start']
+        row_end = child.style['grid_row_end']
+        row_placement = _get_placement(row_start, row_end, rows[::2])
+        if not row_placement:
+            continue
+        y, height = row_placement
+        column_start = child.style['grid_column_start']
+        column_end = child.style['grid_column_end']
+        x, width = _get_column_placement(
+            row_placement, column_start, column_end, columns,
+            children_positions, 'dense' in flow)
+        children_positions[child] = (x, y, width, height)
+
+    # 1.3 Determine the columns in the implicit grid.
+    # 1.3.1 Start with the columns from the explicit grid.
+    implicit_x1 = 0
+    implicit_x2 = len(grid_areas[0]) if grid_areas else 0
+    # 1.3.2 Add columns to the beginning and end of the implicit grid.
+    remaining_grid_items = []
+    for child in children:
+        if child in children_positions:
+            x, _, width, _ = children_positions[child]
+        else:
+            column_start = child.style['grid_column_start']
+            column_end = child.style['grid_column_end']
+            column_placement = _get_placement(
+                column_start, column_end, columns[::2])
+            if column_placement:
+                x, width = column_placement
+            else:
+                remaining_grid_items.append(child)
+                continue
+        implicit_x1 = min(x, implicit_x1)
+        implicit_x2 = max(x + width, implicit_x2)
+    # 1.3.3 Add columns to accommodate max column span.
+    for child in remaining_grid_items:
+        column_start = child.style['grid_column_start']
+        column_end = child.style['grid_column_end']
+        if column_start == column_end == 'auto':
+            span = 1
+        elif column_start != 'auto':
+            is_span, span, _ = column_start
+            assert is_span
+        else:
+            is_span, span, _ = column_end
+            assert is_span
+        implicit_x2 = max(implicit_x1 + (span or 1), implicit_x2)
+
+    # 1.4 Position the remaining grid items.
+    implicit_y1 = 0
+    implicit_y2 = len(grid_areas)
+    for position in children_positions.values():
+        _, y, _, height = position
+        implicit_y1 = min(y, implicit_y1)
+        implicit_y2 = max(y + height, implicit_y2)
+    for _ in range(0 - implicit_x1):
+        columns.insert(0, next(auto_columns_back))
+        columns.insert(0, [])
+    for _ in range(len(grid_areas[0]) if grid_areas else 0, implicit_x2):
+        columns.append(next(auto_columns))
+        columns.append([])
+    for _ in range(0 - implicit_y1):
+        rows.insert(0, next(auto_rows_back))
+        rows.insert(0, [])
+    for _ in range(len(grid_areas), implicit_y2):
+        rows.append(next(auto_rows))
+        rows.append([])
+    cursor_x, cursor_y = implicit_x1, implicit_y1
+    if 'dense' in flow:
+        for child in remaining_grid_items:
+            column_start = child.style['grid_column_start']
+            column_end = child.style['grid_column_end']
+            column_placement = _get_placement(
+                column_start, column_end, columns[::2])
+            if column_placement:
+                # 1. Set the row position of the cursor.
+                cursor_y = implicit_y1
+                x, width = column_placement
+                cursor_x = x
+                # 2. Increment the cursor’s row position.
+                row_start = child.style['grid_row_start']
+                row_end = child.style['grid_row_end']
+                for y in count(cursor_y):
+                    if row_start == 'auto':
+                        y, height = _get_placement((None, y + 1, None), row_end, rows[::2])
+                    else:
+                        assert row_start[0] == 'span'
+                        assert row_start == 'auto' or row_start[1] == 'span'
+                        span = _get_span(row_start)
+                        y, height = _get_placement(row_start, (None, y + 1 + span, None), rows[::2])
+                    if y < cursor_y:
+                        continue
+                    for row in range(y, y + height):
+                        if _intersect_with_children(x, y, width, height, children_positions.values()):
+                            # Child intersects with a positioned child on current row.
+                            break
+                    else:
+                        # Child doesn’t intersect with any positioned child on any row.
+                        break
+                y_diff = y + height - implicit_y2
+                if y_diff > 0:
+                    for _ in range(y_diff):
+                        rows.append(next(auto_rows))
+                        rows.append([])
+                    implicit_y2 = y + height
+                # 3. Set the item’s row-start line.
+                children_positions[child] = (x, y, width, height)
+            else:
+                # 1. Set the cursor’s row and column positions.
+                cursor_x, cursor_y = implicit_x1, implicit_y1
+                while True:
+                    # 2. Increment the column position of the cursor.
+                    y = cursor_y
+                    row_start = child.style['grid_row_start']
+                    row_end = child.style['grid_row_end']
+                    column_start = child.style['grid_column_start']
+                    column_end = child.style['grid_column_end']
+                    for x in range(cursor_x, implicit_x2):
+                        if row_start == 'auto':
+                            y, height = _get_placement((None, y + 1, None), row_end, rows[::2])
+                        else:
+                            span = _get_span(row_start)
+                            y, height = _get_placement(row_start, (None, y + 1 + span, None), rows[::2])
+                        if column_start == 'auto':
+                            x, width = _get_placement((None, x + 1, None), column_end, columns[::2])
+                        else:
+                            span = _get_span(column_start)
+                            x, width = _get_placement(column_start, (None, x + 1 + span, None), columns[::2])
+                        if _intersect_with_children(x, y, width, height, children_positions.values()):
+                            # Child intersects with a positioned child.
+                            continue
+                        else:
+                            # Free place found.
+                            # 3. Set the item’s row-start and column-start lines.
+                            children_positions[child] = (x, y, width, height)
+                            break
+                    else:
+                        # No room found.
+                        # 2. Return to the previous step.
+                        cursor_y += 1
+                        y_diff = cursor_y - implicit_y2
+                        if y_diff > 0:
+                            for _ in range(y_diff):
+                                rows.append(next(auto_rows))
+                                rows.append([])
+                            implicit_y2 = cursor_y
+                        cursor_x = implicit_x1
+                        continue
+                    break
+    else:
+        for child in remaining_grid_items:
+            column_start = child.style['grid_column_start']
+            column_end = child.style['grid_column_end']
+            column_placement = _get_placement(
+                column_start, column_end, columns[::2])
+            if column_placement:
+                # 1. Set the column position of the cursor.
+                x, width = column_placement
+                if x < cursor_x:
+                    cursor_y += 1
+                cursor_x = x
+                # 2. Increment the cursor’s row position.
+                row_start = child.style['grid_row_start']
+                row_end = child.style['grid_row_end']
+                for y in count(cursor_y):
+                    if row_start == 'auto':
+                        y, height = _get_placement((None, y + 1, None), row_end, rows[::2])
+                    else:
+                        assert row_start[0] == 'span'
+                        assert row_start == 'auto' or row_start[1] == 'span'
+                        span = _get_span(row_start)
+                        y, height = _get_placement(row_start, (None, y + 1 + span, None), rows[::2])
+                    if y < cursor_y:
+                        continue
+                    for row in range(y, y + height):
+                        if _intersect_with_children(x, y, width, height, children_positions.values()):
+                            # Child intersects with a positioned child on current row.
+                            break
+                    else:
+                        # Child doesn’t intersect with any positioned child on any row.
+                        break
+                implicit_y2 = max(y + height, implicit_y2)
+                y_diff = y + height - implicit_y2
+                if y_diff > 0:
+                    for _ in range(y_diff):
+                        rows.append(next(auto_rows))
+                        rows.append([])
+                    implicit_y2 = y + height
+                # 3. Set the item’s row-start line.
+                children_positions[child] = (x, y, width, height)
+            else:
+                while True:
+                    # 1. Increment the column position of the cursor.
+                    y = cursor_y
+                    row_start = child.style['grid_row_start']
+                    row_end = child.style['grid_row_end']
+                    column_start = child.style['grid_column_start']
+                    column_end = child.style['grid_column_end']
+                    for x in range(cursor_x, implicit_x2):
+                        if row_start == 'auto':
+                            y, height = _get_placement((None, y + 1, None), row_end, rows[::2])
+                        else:
+                            span = _get_span(row_start)
+                            y, height = _get_placement(row_start, (None, y + 1 + span, None), rows[::2])
+                        if column_start == 'auto':
+                            x, width = _get_placement((None, x + 1, None), column_end, columns[::2])
+                        else:
+                            span = _get_span(column_start)
+                            x, width = _get_placement(column_start, (None, x + 1 + span, None), columns[::2])
+                        if _intersect_with_children(x, y, width, height, children_positions.values()):
+                            # Child intersects with a positioned child.
+                            continue
+                        else:
+                            # Free place found.
+                            # 2. Set the item’s row-start and column-start lines.
+                            children_positions[child] = (x, y, width, height)
+                            break
+                    else:
+                        # No room found.
+                        # 2. Return to the previous step.
+                        cursor_y += 1
+                        y_diff = cursor_y - implicit_y2
+                        if y_diff > 0:
+                            for _ in range(y_diff):
+                                rows.append(next(auto_rows))
+                                rows.append([])
+                            implicit_y2 = cursor_y
+                        cursor_x = implicit_x1
+                        continue
+                    break

--- a/weasyprint/layout/grid.py
+++ b/weasyprint/layout/grid.py
@@ -143,7 +143,7 @@ def _get_column_placement(row_placement, column_start, column_end,
                 # If the placement contains two spans, remove the one
                 # contributed by the end grid-placement property.
                 # https://drafts.csswg.org/css-grid/#grid-placement-errors
-                assert column_start == 'auto' or column_start[1] == 'span'
+                assert column_start == 'auto' or column_start[0] == 'span'
                 span = _get_span(column_start)
                 placement = _get_placement(
                     column_start, (None, x + 1 + span, None), columns)
@@ -160,7 +160,7 @@ def _get_column_placement(row_placement, column_start, column_end,
             # If the placement contains two spans, remove the one contributed
             # by the end grid-placement property.
             # https://drafts.csswg.org/css-grid/#grid-placement-errors
-            assert column_start == 'auto' or column_start[1] == 'span'
+            assert column_start == 'auto' or column_start[0] == 'span'
             for end_y in count(y + 1):
                 placement = _get_placement(
                     column_start, (None, end_y + 1, None), columns)
@@ -705,7 +705,7 @@ def grid_layout(context, box, bottom_space, skip_stack, containing_block,
                             (None, y + 1, None), row_end, rows[::2])
                     else:
                         assert row_start[0] == 'span'
-                        assert row_start == 'auto' or row_start[1] == 'span'
+                        assert row_start == 'auto' or row_start[0] == 'span'
                         span = _get_span(row_start)
                         y, height = _get_placement(
                             row_start, (None, y + 1 + span, None), rows[::2])
@@ -807,7 +807,7 @@ def grid_layout(context, box, bottom_space, skip_stack, containing_block,
                             (None, y + 1, None), row_end, rows[::2])
                     else:
                         assert row_start[0] == 'span'
-                        assert row_start == 'auto' or row_start[1] == 'span'
+                        assert row_start == 'auto' or row_start[0] == 'span'
                         span = _get_span(row_start)
                         y, height = _get_placement(
                             row_start, (None, y + 1 + span, None), rows[::2])

--- a/weasyprint/layout/grid.py
+++ b/weasyprint/layout/grid.py
@@ -13,7 +13,7 @@ def grid_layout(context, box, bottom_space, skip_stack, containing_block,
     if grid_areas == 'none':
         grid_areas = ()
     grid_areas = [list(row) for row in grid_areas]
-    
+
     if rows == 'none':
         rows = ((),)
     rows = list(rows)

--- a/weasyprint/layout/grid.py
+++ b/weasyprint/layout/grid.py
@@ -7,6 +7,7 @@ from ..css.properties import Dimension
 from ..formatting_structure import boxes
 from .percent import percentage, resolve_percentages
 from .preferred import max_content_width, min_content_width
+from .table import find_in_flow_baseline
 
 
 def _is_length(sizing):
@@ -117,7 +118,7 @@ def _get_placement(start, end, lines):
 
 
 def _get_span(place):
-    # TODO: handle lines
+    # TODO: Handle lines.
     span = 1
     if place[0] == 'span':
         span = place[1] or 1
@@ -930,6 +931,7 @@ def grid_layout(context, box, bottom_space, skip_stack, containing_block,
 
     # 4. Lay out the grid items into their respective containing blocks.
     new_children = []
+    baseline = None
     for child in children:
         from .block import block_level_layout
         x, y, width, height = children_positions[child]
@@ -956,11 +958,13 @@ def grid_layout(context, box, bottom_space, skip_stack, containing_block,
         new_child.height = max(height, new_child.height)
         # TODO: Take care of page fragmentation.
         new_children.append(new_child)
+        if baseline is None and y == implicit_y1:
+            baseline = find_in_flow_baseline(new_child)
 
-    # TODO: Set real baseline value.
     box = box.copy_with_children(box.children)
     if isinstance(box, boxes.InlineGridBox):
-        box.baseline = 0
+        # TODO: Synthetize a real baseline value.
+        box.baseline = baseline or 0
 
     # TODO: Include gutters, margins, borders, paddings.
     box.height = sum(size for size, _ in rows_sizes)

--- a/weasyprint/layout/grid.py
+++ b/weasyprint/layout/grid.py
@@ -1042,6 +1042,7 @@ def grid_layout(context, box, bottom_space, skip_stack, containing_block,
             context, child, bottom_space, skip_stack, parent,
             page_is_empty, absolute_boxes, fixed_boxes)
         justify_self = set(new_child.style['justify_self'])
+        width -= new_child.margin_width() - new_child.width
         if justify_self & {'auto'}:
             justify_self = justify_items
         if justify_self & {'normal', 'stretch'}:
@@ -1054,6 +1055,7 @@ def grid_layout(context, box, bottom_space, skip_stack, containing_block,
             elif justify_self & {'right', 'end', 'flex-end', 'self-end'}:
                 new_child.translate(diff, 0)
         align_self = set(new_child.style['align_self'])
+        height -= new_child.margin_height() - new_child.height
         if align_self & {'auto'}:
             align_self = align_items
         if align_self & {'normal', 'stretch'}:

--- a/weasyprint/layout/grid.py
+++ b/weasyprint/layout/grid.py
@@ -151,7 +151,7 @@ def _get_column_placement(row_placement, column_start, column_end,
             if not set(columns) & occupied_columns:
                 return placement
     else:
-        y = max(occupied_columns) + 1
+        y = max(occupied_columns or [0]) + 1
         if column_start == 'auto':
             return _get_placement(
                 (None, y + 1, None), column_end, columns)

--- a/weasyprint/layout/grid.py
+++ b/weasyprint/layout/grid.py
@@ -5,7 +5,7 @@ from math import inf
 
 from ..css.properties import Dimension
 from ..formatting_structure import boxes
-from .percent import percentage
+from .percent import percentage, resolve_percentages
 from .preferred import max_content_width, min_content_width
 
 
@@ -930,8 +930,15 @@ def grid_layout(context, box, bottom_space, skip_stack, containing_block,
             size for size, _ in rows_sizes[:y])
         width = sum(size for size, _ in columns_sizes[x:x+width])
         height = sum(size for size, _ in rows_sizes[y:y+height])
+        # TODO: Find a better solution for the layout.
+        parent = boxes.BlockContainerBox.anonymous_from(containing_block, ())
+        resolve_percentages(parent, containing_block)
+        parent.position_x = child.position_x
+        parent.position_y = child.position_y
+        parent.width = width
+        parent.height = height
         new_child, resume_at, next_page, _, _, _ = block_level_layout(
-            context, child, bottom_space, skip_stack, (width, height),
+            context, child, bottom_space, skip_stack, parent,
             page_is_empty, absolute_boxes, fixed_boxes)
         new_child.width = max(width, new_child.width)
         new_child.height = max(height, new_child.height)

--- a/weasyprint/layout/grid.py
+++ b/weasyprint/layout/grid.py
@@ -188,19 +188,19 @@ def _get_template_tracks(tracks):
     tracks_list = []
     for i, track in enumerate(tracks):
         if i % 2:
-            # Track size
+            # Track size.
             if track[0] == 'repeat()':
                 repeat_number, repeat_track_list = track[1:]
                 if not isinstance(repeat_number, int):
-                    # TODO: Respect auto-fit and auto-fill
+                    # TODO: Respect auto-fit and auto-fill.
                     repeat_number = 1
                 for _ in range(repeat_number):
                     for j, repeat_track in enumerate(repeat_track_list):
                         if j % 2:
-                            # Track size in repeat
+                            # Track size in repeat.
                             tracks_list.append(repeat_track)
                         else:
-                            # Line names in repeat
+                            # Line names in repeat.
                             if len(tracks_list) % 2:
                                 tracks_list[-1].extend(repeat_track)
                             else:
@@ -208,7 +208,7 @@ def _get_template_tracks(tracks):
             else:
                 tracks_list.append(track)
         else:
-            # Line names
+            # Line names.
             if len(tracks_list) % 2:
                 tracks_list[-1].extend(track)
             else:

--- a/weasyprint/layout/grid.py
+++ b/weasyprint/layout/grid.py
@@ -1096,15 +1096,9 @@ def grid_layout(context, box, bottom_space, skip_stack, containing_block,
             page_is_empty, absolute_boxes, fixed_boxes)[:3]
         if new_child:
             page_is_empty = False
+            # TODO: Support fragmentation in grid items.
         else:
-            if child_resume_at:
-                pass
-                # if not resume_at:
-                #     resume_at = {}
-                # if y in resume_at:
-                #     resume_at[y][index] = child_resume_at
-                # else:
-                #     resume_at[y] = {index: child_resume_at}
+            # TODO: Support fragmentation in grid rows.
             continue
 
         # TODO: Apply auto margins.

--- a/weasyprint/layout/grid.py
+++ b/weasyprint/layout/grid.py
@@ -658,14 +658,11 @@ def grid_layout(context, box, bottom_space, skip_stack, containing_block,
     for child in remaining_grid_items:
         column_start = child.style['grid_column_start']
         column_end = child.style['grid_column_end']
-        if column_start == column_end == 'auto':
-            span = 1
-        elif column_start != 'auto':
-            is_span, span, _ = column_start
-            assert is_span
-        else:
-            is_span, span, _ = column_end
-            assert is_span
+        span = 1
+        if column_start != 'auto' and column_start[0] == 'span':
+            span = column_start[1]
+        elif column_end != 'auto' and column_end[0] == 'span':
+            span = column_end[1]
         implicit_x2 = max(implicit_x1 + (span or 1), implicit_x2)
 
     # 1.4 Position the remaining grid items.

--- a/weasyprint/layout/grid.py
+++ b/weasyprint/layout/grid.py
@@ -500,8 +500,10 @@ def _resolve_tracks_sizes(sizing_functions, box_size, children_positions,
             flex_factor_sum = 0
             iterable = enumerate(zip(tracks_sizes, sizing_functions))
             for i, (sizes, (_, max_function)) in iterable:
-                if i not in inflexible_tracks and _is_fr(max_function):
-                    flex_factor_sum += max_function.value
+                if _is_fr(max_function):
+                    leftover_space += sizes[0]
+                    if i not in inflexible_tracks:
+                        flex_factor_sum += max_function.value
             flex_factor_sum = max(1, flex_factor_sum)
             hypothetical_fr_size = leftover_space / flex_factor_sum
             stop = True
@@ -517,7 +519,7 @@ def _resolve_tracks_sizes(sizing_functions, box_size, children_positions,
             if _is_fr(max_function):
                 if flex_fraction * max_function.value > sizes[0]:
                     free_space -= flex_fraction * max_function.value
-                    sizes[0] += flex_fraction * max_function.value
+                    sizes[0] = flex_fraction * max_function.value
     # 1.5 Expand stretched auto tracks.
     x_stretch = (
         direction == 'x' and

--- a/weasyprint/layout/grid.py
+++ b/weasyprint/layout/grid.py
@@ -182,6 +182,9 @@ def _get_sizing_functions(size):
 def _get_template_tracks(tracks):
     if tracks == 'none':
         tracks = ((),)
+    if 'subgrid' in tracks:
+        # TODO: Support subgrids.
+        return [[]]
     tracks_list = []
     for i, track in enumerate(tracks):
         if i % 2:

--- a/weasyprint/layout/page.py
+++ b/weasyprint/layout/page.py
@@ -604,7 +604,8 @@ def make_page(context, root_box, page_type, resume_at, page_number,
 
     # TODO: handle cases where the root element is something else.
     # See https://www.w3.org/TR/CSS21/visuren.html#dis-pos-flo
-    assert isinstance(root_box, (boxes.BlockBox, boxes.FlexContainerBox))
+    assert isinstance(root_box, (
+        boxes.BlockBox, boxes.FlexContainerBox, boxes.GridContainerBox))
     context.create_block_formatting_context()
     context.current_page = page_number
     context.current_page_footnotes = []

--- a/weasyprint/layout/preferred.py
+++ b/weasyprint/layout/preferred.py
@@ -54,6 +54,9 @@ def min_content_width(context, box, outer=True):
         return replaced_min_content_width(box, outer)
     elif isinstance(box, boxes.FlexContainerBox):
         return flex_min_content_width(context, box, outer)
+    elif isinstance(box, boxes.GridContainerBox):
+        # TODO: Get real grid size.
+        return block_min_content_width(context, box, outer)
     else:
         raise TypeError(
             f'min-content width for {type(box).__name__} not handled yet')
@@ -81,6 +84,9 @@ def max_content_width(context, box, outer=True):
         return replaced_max_content_width(box, outer)
     elif isinstance(box, boxes.FlexContainerBox):
         return flex_max_content_width(context, box, outer)
+    elif isinstance(box, boxes.GridContainerBox):
+        # TODO: Get real grid size.
+        return block_max_content_width(context, box, outer)
     else:
         raise TypeError(
             f'max-content width for {type(box).__name__} not handled yet')

--- a/weasyprint/stacking.py
+++ b/weasyprint/stacking.py
@@ -74,6 +74,7 @@ def _dispatch(box, page, child_contexts, blocks, floats, blocks_and_cells):
     # Remove boxes defining a new stacking context from the children list.
     defines_stacking_context = (
         (style['position'] != 'static' and style['z_index'] != 'auto') or
+        (box.is_grid_item and style['z_index'] != 'auto') or
         style['opacity'] < 1 or
         style['transform'] or  # 'transform: none' gives a "falsy" empty list
         style['overflow'] != 'visible')
@@ -90,7 +91,8 @@ def _dispatch(box, page, child_contexts, blocks, floats, blocks_and_cells):
         child_contexts.insert(index, stacking_context)
     elif box.is_floated():
         floats.append(StackingContext.from_box(box, page, child_contexts))
-    elif isinstance(box, (boxes.InlineBlockBox, boxes.InlineFlexBox)):
+    elif isinstance(box, (
+            boxes.InlineBlockBox, boxes.InlineFlexBox, boxes.InlineGridBox)):
         # Have this fake stacking context be part of the "normal" box tree,
         # because we need its position in the middle of a tree of inline boxes.
         return StackingContext.from_box(box, page, child_contexts)


### PR DESCRIPTION
Fix #543.

This pull request adds initial support of CSS Grid layout.

🙏🏽 **Please test this branch.** 🙏🏽

You can install it with `pip install git+https://github.com/Kozea/WeasyPrint@grid`. Please report your feedback in a comment on this pull request, even to say that everything works for you! Don’t open other issues.

This work is the "first step" of a full CSS Grid layout. Many features are already supported, but some are not supported yet. A "second step" will be necessary to get a more complete support.

The code added for Grid is pretty clean, it follows the algorithm provided by the specification. The situation is much better than for Flex, and we can expect to keep most of this code unmodified in the future. Missing and buggy features are mainly caused by missing code, not by a broken code structure.

The current version is regularly tested using the W3C testing suite for Grid, there’s no crash for the 1500+ tests and references (even if some tests fail, of course).

The current algorithm is, as usually in WeasyPrint, a bit naive. We’ve put the accent on code clarity to improve readability and maintainability. We duplicated some lines on purpose, mainly to improve debugging sessions. We’ll probably keep this "simple" code for the next version and improve it (for performance and concision) in the future, when we have more experience and more tests.

Here are non-exhaustive lists of supported/unsupported features.

Supported:
- `display: grid`,
- `grid-auto-*`, `grid-template-*` and other `grid-*` properties,
- `grid` and other `grid-*` shorthands,
- flexible lengths (`fr` unit),
- line names,
- grid areas,
- auto rows and auto columns,
- z-index,
- `repeat(X, *)`,
- `minmax()`,
- `align-*` and `justify-*` alignment properties,
- `gap` and `*-gap` properties for gutters,
- `dense` auto flow,
- `z-index`,
- `order`,
- margins, borders, padding on grid containers and grid items,
- fragmentation between rows.

Unsupported or buggy:
- `display: inline-grid`,
- auto content size for grid containers,
- `grid-auto-flow: column`,
- subgrids,
- `repeat(auto-fill, *)` and `repeat(auto-fit, *)`,
- `auto` margins for grid items,
- `span` with line names,
- `span` for flexible tracks,
- `safe` and `unsafe` alignments,
- baseline alignment,
- grid items with intrinsic size (images),
- distribute space beyond limits,
- grid items larger than grid containers,
- `min-width`, `max-width`, `min-height`, `max-height` on grid items,
- complex `min-content` and `max-content` cases,
- absolutely positioned and floating grid items,
- fragmentation in rows.

Before merging this pull request, we’ll:
- [x] add more tests,
- [x] display warnings on unsupported features,
- [x] add documentation,
- [x] fix the main problems that will be reported.