### PR TITLE
Add a setup.cfg file for flake8 to ignore the venv/ directory.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+exclude =
+    venv/


### PR DESCRIPTION
The instructions on https://doc.courtbouillon.org/weasyprint/stable/contribute.html create a virtual environment under a `venv/` directory.

The `venv/bin/python -m flake8` command, on the same page, by default checks for style issues everywhere under the current directory, including under the `venv/` directory. This is unnecessarily slow and noisy.

By creating a `setup.cfg` file, we can exclude `venv/` by default.

(`tox.ini` or `.flake8` files would work as well, I picked `setup.cfg` arbitrarily.)