### PR TITLE
Allow column-direction flex containers to use percentage-based heights.

### DIFF
--- a/tests/layout/test_flex.py
+++ b/tests/layout/test_flex.py
@@ -545,3 +545,21 @@ def test_flex_absolute():
       <div style="display: flex; position: absolute">
         <div>a</div>
       </div>''')
+
+
+@assert_no_logs
+def test_flex_percent_height():
+    page, = render_pages('''
+      <style>
+        .a { height: 10px; width: 10px; }
+        .b { height: 10%; width: 100%; display: flex; flex-direction: column; }
+      </style>
+      <div class="a"">
+        <div class="b"></div>
+      </div>''')
+    html, = page.children
+    body, = html.children
+    a, = body.children
+    b, = a.children
+    assert a.height == 10
+    assert b.height == 1

--- a/weasyprint/layout/flex.py
+++ b/weasyprint/layout/flex.py
@@ -241,7 +241,10 @@ def flex_layout(context, box, bottom_space, skip_stack, containing_block,
         block.block_level_width(box, containing_block)
     else:
         if box.style['height'] != 'auto':
-            box.height = box.style['height'].value
+            if box.style['height'].unit == '%':
+                box.height = box.style['height'].value / 100. * containing_block.height
+            else:
+                box.height = box.style['height'].value
         else:
             box.height = 0
             for i, child in enumerate(children):


### PR DESCRIPTION
Currently, if a `flex-direction: column` flex div is assigned a percentage-based height, that height is interpreted as pixels, not as a percentage of the containing block. This pull request allows percentage-based heights to work properly in this case.