### PR TITLE
Include radio buttons when processing forms

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -511,9 +511,9 @@ def test_partial_pdf_custom_metadata():
     ('<input value="">', ['/Tx', '/V ()']),
     ('<input type="checkbox">', ['/Btn']),
     ('<input type="radio">',
-     ['/Btn', '/V /Off', '/AS /Off', f'/Ff {1 << (16 - 1)}']),
+     ['/Btn', '/V /Off', '/AS /Off', '/Ff 49152']),
     ('<input checked type="radio" name="foo" value="value">',
-     ['/Btn', '/T (foo)', '/V /dmFsdWU=', '/AS /dmFsdWU=']),
+     ['/Btn', '/T (1)', '/V /dmFsdWU=', '/AS /dmFsdWU=']),
     ('<form><input type="radio" name="foo" value="v0"></form>'
      '<form><input checked type="radio" name="foo" value="v1"></form>',
      ['/Btn', '/AS /djE=', '/V /djE=', '/AS /Off', '/V /Off']),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -512,13 +512,11 @@ def test_partial_pdf_custom_metadata():
     ('<input type="checkbox">', ['/Btn']),
     ('<input type="radio">',
      ['/Btn', '/V /Off', '/AS /Off', f'/Ff {1 << (16 - 1)}']),
-    ('<input checked type="radio" name="foo" value="Some Value">',
-     ['/Btn', '/TU (foo)', '/V (Some Value)', '/AS (Some Value)']),
-    ('<form><input type="radio" name="foo" value="v1"></form>'
+    ('<input checked type="radio" name="foo" value="value">',
+     ['/Btn', '/T (foo)', '/V /dmFsdWU=', '/AS /dmFsdWU=']),
+    ('<form><input type="radio" name="foo" value="v0"></form>'
      '<form><input checked type="radio" name="foo" value="v1"></form>',
-     ['/Btn', '/V (v1)',
-      '/AS (v1)', '/V (v1)',
-      '/AS /Off', '/V /Off']),
+     ['/Btn', '/AS /djE=', '/V /djE=', '/AS /Off', '/V /Off']),
     ('<textarea></textarea>', ['/Tx', '/V ()']),
     ('<select><option value="a">A</option></select>', ['/Ch', '/Opt']),
     ('<select>'

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -510,6 +510,15 @@ def test_partial_pdf_custom_metadata():
     ('<input>', ['/Tx', '/V ()']),
     ('<input value="">', ['/Tx', '/V ()']),
     ('<input type="checkbox">', ['/Btn']),
+    ('<input type="radio">',
+     ['/Btn', '/V /Off', '/AS /Off', f'/Ff {1 << (16 - 1)}']),
+    ('<input checked type="radio" name="foo" value="Some Value">',
+     ['/Btn', '/TU (foo)', '/V (Some Value)', '/AS (Some Value)']),
+    ('<form><input type="radio" name="foo" value="v1"></form>'
+     '<form><input checked type="radio" name="foo" value="v1"></form>',
+     ['/Btn', '/V (v1)',
+      '/AS (v1)', '/V (v1)',
+      '/AS /Off', '/V /Off']),
     ('<textarea></textarea>', ['/Tx', '/V ()']),
     ('<select><option value="a">A</option></select>', ['/Ch', '/Opt']),
     ('<select>'
@@ -525,7 +534,8 @@ def test_partial_pdf_custom_metadata():
 def test_pdf_inputs(html, fields):
     stdout = _run('--pdf-forms --uncompressed-pdf - -', html.encode())
     assert b'AcroForm' in stdout
-    assert all(field.encode() in stdout for field in fields)
+    for field in fields:
+        assert field.encode() in stdout
     stdout = _run('--uncompressed-pdf - -', html.encode())
     assert b'AcroForm' not in stdout
 

--- a/weasyprint/anchors.py
+++ b/weasyprint/anchors.py
@@ -27,8 +27,7 @@ def rectangle_aabb(matrix, pos_x, pos_y, width, height):
     return box_x1, box_y1, box_x2, box_y2
 
 
-def gather_anchors(box, anchors, links, bookmarks, forms,
-                   parent_matrix=None,
+def gather_anchors(box, anchors, links, bookmarks, forms, parent_matrix=None,
                    parent_form=None):
     """Gather anchors and other data related to specific positions in PDF.
 
@@ -123,8 +122,7 @@ def gather_anchors(box, anchors, links, bookmarks, forms,
             anchors[anchor_name] = pos_x, pos_y
 
     for child in box.all_children():
-        gather_anchors(child, anchors, links, bookmarks, forms, matrix,
-                       parent_form=parent_form)
+        gather_anchors(child, anchors, links, bookmarks, forms, matrix, parent_form)
 
 
 def make_page_bookmark_tree(page, skipped_levels, last_by_depth,

--- a/weasyprint/anchors.py
+++ b/weasyprint/anchors.py
@@ -27,10 +27,12 @@ def rectangle_aabb(matrix, pos_x, pos_y, width, height):
     return box_x1, box_y1, box_x2, box_y2
 
 
-def gather_anchors(box, anchors, links, bookmarks, inputs, parent_matrix=None):
+def gather_anchors(box, anchors, links, bookmarks, forms,
+                   parent_matrix=None,
+                   parent_form=None):
     """Gather anchors and other data related to specific positions in PDF.
 
-    Currently finds anchors, links, bookmarks and inputs.
+    Currently finds anchors, links, bookmarks and forms.
 
     """
     # Get box transformation matrix.
@@ -89,6 +91,11 @@ def gather_anchors(box, anchors, links, bookmarks, inputs, parent_matrix=None):
     has_anchor = anchor_name and anchor_name not in anchors
     is_input = box.is_input()
 
+    if box.is_form():
+        parent_form = box.element
+        if parent_form not in forms:
+            forms[parent_form] = []
+
     if has_bookmark or has_link or has_anchor or is_input:
         if is_input:
             pos_x, pos_y = box.content_box_x(), box.content_box_y()
@@ -106,7 +113,7 @@ def gather_anchors(box, anchors, links, bookmarks, inputs, parent_matrix=None):
                 link_type = 'attachment'
             links.append((link_type, target, rectangle, box))
         if is_input:
-            inputs.append((box.element, box.style, rectangle))
+            forms[parent_form].append((box.element, box.style, rectangle))
         if matrix and (has_bookmark or has_anchor):
             pos_x, pos_y = matrix.transform_point(pos_x, pos_y)
         if has_bookmark:
@@ -116,7 +123,8 @@ def gather_anchors(box, anchors, links, bookmarks, inputs, parent_matrix=None):
             anchors[anchor_name] = pos_x, pos_y
 
     for child in box.all_children():
-        gather_anchors(child, anchors, links, bookmarks, inputs, matrix)
+        gather_anchors(child, anchors, links, bookmarks, forms, matrix,
+                       parent_form=parent_form)
 
 
 def make_page_bookmark_tree(page, skipped_levels, last_by_depth,

--- a/weasyprint/css/html5_ua.css
+++ b/weasyprint/css/html5_ua.css
@@ -187,8 +187,10 @@ input[value]::before {
   overflow: hidden;
 }
 input::before,
-input[value=""]::before {
-  content: " ";
+input[value=""]::before,
+input[type="checkbox"]::before,
+input[type="radio"]::before {
+  content: "";
 }
 select {
   background: lightgrey;

--- a/weasyprint/document.py
+++ b/weasyprint/document.py
@@ -28,6 +28,7 @@ class Page:
     instantiated directly.
 
     """
+
     def __init__(self, page_box):
         #: The page width, including margins, in CSS pixels.
         self.width = page_box.margin_width()
@@ -67,14 +68,16 @@ class Page:
         #: ``(x, y)`` point in CSS pixels from the top-left of the page.
         self.anchors = {}
 
-        #: The :obj:`list` of ``(element, attributes, rectangle)`` :obj:`tuples
-        #: <tuple>`. A ``rectangle`` is ``(x, y, width, height)``, in CSS
+        #: The :obj:`dict` mapping form elements to a list
+        #: of ``(element, attributes, rectangle)`` :obj:`tuples <tuple>`.
+        #: A ``rectangle`` is ``(x, y, width, height)``, in CSS
         #: pixels from the top-left of the page. ``atributes`` is a
         #: :obj:`dict` of HTML tag attributes and values.
-        self.inputs = []
+        #: The key ``None`` will contain inputs that are not part of a form.
+        self.forms = {None: []}
 
         gather_anchors(
-            page_box, self.anchors, self.links, self.bookmarks, self.inputs)
+            page_box, self.anchors, self.links, self.bookmarks, self.forms)
         self._page_box = page_box
 
     def paint(self, stream, scale=1):
@@ -105,6 +108,7 @@ class DocumentMetadata:
     New attributes may be added in future versions of WeasyPrint.
 
     """
+
     def __init__(self, title=None, authors=None, description=None,
                  keywords=None, generator=None, created=None, modified=None,
                  attachments=None, lang=None, custom=None):
@@ -162,6 +166,7 @@ class DiskCache:
     (i.e. RasterImage instances) are still stored in memory.
 
     """
+
     def __init__(self, folder):
         self._path = Path(folder)
         self._path.mkdir(parents=True, exist_ok=True)

--- a/weasyprint/document.py
+++ b/weasyprint/document.py
@@ -76,8 +76,7 @@ class Page:
         #: The key ``None`` will contain inputs that are not part of a form.
         self.forms = {None: []}
 
-        gather_anchors(
-            page_box, self.anchors, self.links, self.bookmarks, self.forms)
+        gather_anchors(page_box, self.anchors, self.links, self.bookmarks, self.forms)
         self._page_box = page_box
 
     def paint(self, stream, scale=1):

--- a/weasyprint/formatting_structure/boxes.py
+++ b/weasyprint/formatting_structure/boxes.py
@@ -336,6 +336,12 @@ class Box:
                 return not isinstance(self, (LineBox, TextBox))
         return False
 
+    def is_form(self):
+        """Return whether this box is a form element."""
+        if self.element is None:
+            return False
+        return self.element.tag in 'form'
+
 
 class ParentBox(Box):
     """A box that has children."""

--- a/weasyprint/formatting_structure/boxes.py
+++ b/weasyprint/formatting_structure/boxes.py
@@ -340,7 +340,7 @@ class Box:
         """Return whether this box is a form element."""
         if self.element is None:
             return False
-        return self.element.tag in 'form'
+        return self.element.tag == 'form'
 
 
 class ParentBox(Box):

--- a/weasyprint/pdf/__init__.py
+++ b/weasyprint/pdf/__init__.py
@@ -11,7 +11,7 @@ from .fonts import build_fonts_dictionary
 from .stream import Stream
 
 from .anchors import (  # isort:skip
-    add_annotations, add_inputs, add_links, add_outlines, resolve_links,
+    add_annotations, add_forms, add_links, add_outlines, resolve_links,
     write_pdf_attachment)
 
 VARIANTS = {
@@ -184,8 +184,8 @@ def generate_pdf(document, target, zoom, **options):
         add_annotations(
             links_and_anchors[0], matrix, document, pdf, pdf_page, annot_files,
             compress)
-        add_inputs(
-            page.inputs, matrix, pdf, pdf_page, resources, stream,
+        add_forms(
+            page.forms, matrix, pdf, pdf_page, resources, stream,
             document.font_config.font_map, compress)
         page.paint(stream, scale)
 

--- a/weasyprint/pdf/anchors.py
+++ b/weasyprint/pdf/anchors.py
@@ -92,7 +92,10 @@ def add_outlines(pdf, bookmarks, parent=None):
     return outlines, count
 
 
-def _make_checked_stream(resources, width, height, compress, style, font_size):
+def _make_checked_stream(resources, rectangle, compress, style, font_size,
+                         character):
+    width = rectangle[2] - rectangle[0]
+    height = rectangle[1] - rectangle[3]
     on_stream = pydyf.Stream(extra={
         'Resources': resources.reference,
         'Type': '/XObject',
@@ -107,7 +110,7 @@ def _make_checked_stream(resources, width, height, compress, style, font_size):
     x = (width - font_size * 0.8) / 2
     y = (height - font_size * 0.8) / 2
     on_stream.move_text_to(x, y)
-    on_stream.show_text_string('4')
+    on_stream.show_text_string(character)
     on_stream.end_text()
     on_stream.pop_state()
     return on_stream
@@ -152,10 +155,9 @@ def add_forms(forms, matrix, pdf, page, resources, stream, font_map,
         field_stream.set_color_rgb(*style['color'][:3])
         if input_type == 'checkbox':
             # Checkboxes
-            width = rectangle[2] - rectangle[0]
-            height = rectangle[1] - rectangle[3]
             checked_stream = _make_checked_stream(
-                resources, width, height, compress, style, font_size)
+                resources, rectangle, compress, style, font_size,
+                '4')  # Checkbox character in Dingbats
             pdf.add_object(checked_stream)
 
             checked = 'checked' in element.attrib
@@ -192,10 +194,9 @@ def add_forms(forms, matrix, pdf, page, resources, stream, font_map,
                 page['Annots'].append(new_group.reference)
                 radio_groups[form][input_name] = new_group
             group = radio_groups[form][input_name]
-            width = rectangle[2] - rectangle[0]
-            height = rectangle[1] - rectangle[3]
             on_stream = _make_checked_stream(
-                resources, width, height, compress, style, font_size)
+                resources, rectangle, compress, style, font_size,
+                'l')  # Disc character in Dingbats
             checked = 'checked' in element.attrib
             field = pydyf.Dictionary({
                 'Type': '/Annot',

--- a/weasyprint/pdf/anchors.py
+++ b/weasyprint/pdf/anchors.py
@@ -3,6 +3,7 @@
 import collections
 import io
 import mimetypes
+from base64 import b64encode
 from hashlib import md5
 from os.path import basename
 from urllib.parse import unquote, urlsplit
@@ -199,18 +200,18 @@ def add_forms(forms, matrix, pdf, page, resources, stream, font_map,
                 resources, rectangle, compress, style, font_size,
                 'l')  # Disc character in Dingbats
             checked = 'checked' in element.attrib
+            key = b64encode(input_value.encode(), altchars=b"+-").decode()
             field = pydyf.Dictionary({
                 'Type': '/Annot',
                 'Subtype': '/Widget',
                 'Rect': pydyf.Array(rectangle),
                 'Parent': group.reference,
-                'AS': pydyf.String(input_value) if checked else '/Off',
+                'AS': f'/{key}' if checked else '/Off',
                 'AP': pydyf.Dictionary({'N': pydyf.Dictionary({
-                    pydyf.String(input_value): on_stream.reference,
-                })}),
+                    key: on_stream.reference})}),
             })
             if checked:
-                group['V'] = pydyf.String(input_value)
+                group['V'] = f'/{key}'
             pdf.add_object(field)
             group['Kids'].append(field.reference)
         elif element.tag == 'select':

--- a/weasyprint/pdf/anchors.py
+++ b/weasyprint/pdf/anchors.py
@@ -184,8 +184,7 @@ def add_forms(forms, matrix, pdf, page, resources, stream, font_map,
                     'Ff': 1 << (16 - 1),  # Radio flag
                     'F': 1 << (3 - 1),  # Print flag
                     'P': page.reference,
-                    'T': pydyf.String(f'{hash(form)}-{input_name}'),
-                    'TU': pydyf.String(input_name),
+                    'T': pydyf.String(input_name),
                     'V': '/Off',
                     'Kids': pydyf.Array(),
                 })

--- a/weasyprint/pdf/anchors.py
+++ b/weasyprint/pdf/anchors.py
@@ -184,6 +184,7 @@ def add_forms(forms, matrix, pdf, page, resources, stream, font_map,
                 new_group = pydyf.Dictionary({
                     'Type': '/Annot',
                     'Subtype': '/Widget',
+                    'Rect': pydyf.Array(rectangle),
                     'FT': '/Btn',
                     'Ff': 1 << (16 - 1),  # Radio flag
                     'F': 1 << (3 - 1),  # Print flag

--- a/weasyprint/pdf/anchors.py
+++ b/weasyprint/pdf/anchors.py
@@ -154,9 +154,8 @@ def add_forms(forms, matrix, pdf, page, resources, stream, font_map,
             # Checkboxes
             width = rectangle[2] - rectangle[0]
             height = rectangle[1] - rectangle[3]
-            checked_stream = _make_checked_stream(resources,
-                                                  width, height,
-                                                  compress, style, font_size)
+            checked_stream = _make_checked_stream(
+                resources, width, height, compress, style, font_size)
             pdf.add_object(checked_stream)
 
             checked = 'checked' in element.attrib
@@ -196,9 +195,8 @@ def add_forms(forms, matrix, pdf, page, resources, stream, font_map,
             group = radio_groups[form][input_name]
             width = rectangle[2] - rectangle[0]
             height = rectangle[1] - rectangle[3]
-            on_stream = _make_checked_stream(resources,
-                                             width, height,
-                                             compress, style, font_size)
+            on_stream = _make_checked_stream(
+                resources, width, height, compress, style, font_size)
             checked = 'checked' in element.attrib
             field = pydyf.Dictionary({
                 'Type': '/Annot',
@@ -226,7 +224,7 @@ def add_forms(forms, matrix, pdf, page, resources, stream, font_map,
             selected_values = []
             for option in element:
                 value = pydyf.String(option.attrib.get('value', ''))
-                text = pydyf.String(option.text or "")
+                text = pydyf.String(option.text or '')
                 options.append(pydyf.Array([value, text]))
                 if 'selected' in option.attrib:
                     selected_values.append(value)

--- a/weasyprint/pdf/anchors.py
+++ b/weasyprint/pdf/anchors.py
@@ -177,6 +177,7 @@ def add_forms(forms, matrix, pdf, page, resources, stream, font_map,
                 'AS': '/Yes' if checked else '/Off',
                 'DA': pydyf.String(b' '.join(field_stream.stream)),
             })
+            pdf.add_object(field)
         elif input_type == 'radio':
             if input_name not in radio_groups[form]:
                 new_group = pydyf.Dictionary({
@@ -210,6 +211,7 @@ def add_forms(forms, matrix, pdf, page, resources, stream, font_map,
             })
             if checked:
                 group['V'] = pydyf.String(input_value)
+            pdf.add_object(field)
             group['Kids'].append(field.reference)
         elif element.tag == 'select':
             # Select fields
@@ -248,6 +250,7 @@ def add_forms(forms, matrix, pdf, page, resources, stream, font_map,
                 field['V'] = (
                     selected_values[-1] if selected_values
                     else pydyf.String(''))
+            pdf.add_object(field)
         else:
             # Text, password, textarea, files, and unknown
             font_description = get_font_description(style)
@@ -281,8 +284,8 @@ def add_forms(forms, matrix, pdf, page, resources, stream, font_map,
             maxlength = element.get('maxlength')
             if maxlength and maxlength.isdigit():
                 field['MaxLen'] = element.get('maxlength')
+            pdf.add_object(field)
 
-        pdf.add_object(field)
         page['Annots'].append(field.reference)
         pdf.catalog['AcroForm']['Fields'].append(field.reference)
 

--- a/weasyprint/pdf/anchors.py
+++ b/weasyprint/pdf/anchors.py
@@ -200,6 +200,7 @@ def add_forms(forms, matrix, pdf, page, resources, stream, font_map,
             on_stream = _make_checked_stream(
                 resources, rectangle, compress, style, font_size,
                 'l')  # Disc character in Dingbats
+            pdf.add_object(on_stream)
             checked = 'checked' in element.attrib
             key = b64encode(input_value.encode(), altchars=b"+-").decode()
             field = pydyf.Dictionary({


### PR DESCRIPTION
Hello!

Resolves #1831 

This aims to make radio buttons work in forms.

- 🌎 Currently, inputs are collected and rendered individually.
- ⛔ This means that groups of elements, such as radio buttons which may only have one value checked at once, don't have a way to identify other elements in the group.
- ✅ This PR keeps a concept of "forms" in between "page" and "inputs", and uses those forms to build groups of radio buttons.

This is my first time reading the PDF specification (such fun!) so appreciate any scrutiny of the dictionaries I have it making.

Added a few unit tests as well, but here's a working example:

[example.pdf](https://github.com/Kozea/WeasyPrint/files/15180879/example.pdf)

![example](https://github.com/Kozea/WeasyPrint/assets/15126660/45dd7dee-2ec8-4f31-88ef-0b3b0c626e92)

Created with:

```py
import weasyprint

html = '''
<!DOCTYPE html><html><body>
<form><h2>Form 1</h2>
<p>Radio 1:</p>
    <label>Option One <input type="radio" name="radio1" value="1"/></label>
    <label>Option Two <input type="radio" name="radio1" value="2"/></label>
<p>Radio 2:</p>
    <label>Option One <input type="radio" name="radio2" value="1"/></label>
    <label>Option Two <input type="radio" name="radio2" value="2"/></label>
</form>

<form id="two">
<h2>Form 2</h2>
<p>Radio 1:</p>
    <label>Option One <input type="radio" name="radio1" value="1"/></label>
    <label>Option Two <input type="radio" name="radio1" value="2"/></label>
<p>Radio 2:</p>
    <label>Option One <input type="radio" name="radio2" value="1"/></label>
    <label>Option Two <input type="radio" name="radio2" value="2"/></label>
</form>
</body></html>
'''

weasyprint.HTML(string=html).write_pdf('output.pdf', pdf_forms=True)
```

Thanks for taking a look. Happy to change / reformat as needed!