### PR TITLE
Adding annotations to the PDF to link back its content to its source.

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -127,8 +127,10 @@ def _round_meta(pages):
     """Eliminate errors of floating point arithmetic for metadata."""
     for page in pages:
         anchors = page.anchors
-        for anchor_name, (pos_x, pos_y) in anchors.items():
-            anchors[anchor_name] = round(pos_x, 6), round(pos_y, 6)
+        for anchor_name, (x1, y1, x2, y2) in anchors.items():
+            anchors[anchor_name] = (
+                round(x1, 6), round(y1, 6),
+                round(x2, 6), round(y2, 6))
         links = page.links
         for i, link in enumerate(links):
             link_type, target, rectangle, box = link
@@ -884,8 +886,8 @@ def test_links_1():
         ],
         [('internal', 'hello', (0, 0, 200, 30))],
     ], [
-        {'hello': (0, 200)},
-        {'lipsum': (0, 0)}
+        {'hello': (0, 200, 200, 290)},
+        {'lipsum': (0, 0, 200, 90)}
     ], [
         (
             [
@@ -966,7 +968,7 @@ def test_links_6():
         ''', [[
             ('internal', 'lipsum', (5, 10, 195, 10)),
             ('external', 'https://weasyprint.org/', (0, 10, 200, 10))]],
-        [{'lipsum': (5, 10)}],
+        [{'lipsum': (5, 10, 195, 10)}],
         [([('internal', 'lipsum', (5, 10, 195, 10)),
            ('external', 'https://weasyprint.org/', (0, 10, 200, 10))],
           [('lipsum', 5, 10)])],
@@ -982,7 +984,7 @@ def test_links_7():
                         margin: 10px 5px" id="lipsum">
         ''',
         [[('internal', 'lipsum', (5, 10, 195, 10))]],
-        [{'lipsum': (5, 10)}],
+        [{'lipsum': (5, 10, 195, 10)}],
         [([('internal', 'lipsum', (5, 10, 195, 10))], [('lipsum', 5, 10)])],
         base_url=None)
 
@@ -998,7 +1000,7 @@ def test_links_8():
         ''',
         [[('internal', 'lipsum', (0, 0, 200, 15)),
           ('internal', 'missing', (0, 15, 200, 30))]],
-        [{'lipsum': (0, 15)}],
+        [{'lipsum': (0, 15, 200, 30)}],
         [([('internal', 'lipsum', (0, 0, 200, 15))], [('lipsum', 0, 15)])],
         base_url=None,
         warnings=[
@@ -1014,7 +1016,7 @@ def test_links_9():
                 transform: rotate(90deg) scale(2)">
         ''',
         [[('internal', 'lipsum', (30, 10, 70, 210))]],
-        [{'lipsum': (70, 10)}],
+        [{'lipsum': (70, 10, 30, 210)}],
         [([('internal', 'lipsum', (30, 10, 70, 210))], [('lipsum', 70, 10)])],
         round=True)
 

--- a/weasyprint/anchors.py
+++ b/weasyprint/anchors.py
@@ -27,11 +27,11 @@ def rectangle_aabb(matrix, pos_x, pos_y, width, height):
     return box_x1, box_y1, box_x2, box_y2
 
 
-def gather_anchors(box, anchors, links, bookmarks, forms, parent_matrix=None,
+def gather_anchors(box, anchors, links, bookmarks, forms, debug, parent_matrix=None,
                    parent_form=None):
     """Gather anchors and other data related to specific positions in PDF.
 
-    Currently finds anchors, links, bookmarks and forms.
+    Currently finds anchors, links, bookmarks, forms and debug ids.
 
     """
     # Get box transformation matrix.
@@ -121,8 +121,18 @@ def gather_anchors(box, anchors, links, bookmarks, forms, parent_matrix=None,
         if has_anchor:
             anchors[anchor_name] = pos_x, pos_y
 
+    # And this is what got added for debugging,
+    # everything that's not covered by the previous categories
+    else:
+        # Not sure why, but all elements are here twice?
+        if(box.element is not None and box.element.get("id") is not None) :
+            # print(box.element.tag, box.element.get("id"))
+            pos_x, pos_y, width, height = box.hit_area()
+            rectangle = rectangle_aabb(matrix, pos_x, pos_y, width, height)
+            debug.append((box.element, box.style, rectangle, box))
+
     for child in box.all_children():
-        gather_anchors(child, anchors, links, bookmarks, forms, matrix, parent_form)
+        gather_anchors(child, anchors, links, bookmarks, forms, debug, matrix, parent_form)
 
 
 def make_page_bookmark_tree(page, skipped_levels, last_by_depth,

--- a/weasyprint/anchors.py
+++ b/weasyprint/anchors.py
@@ -132,7 +132,8 @@ def gather_anchors(box, anchors, links, bookmarks, forms, debug, parent_matrix=N
             debug.append((box.element, box.style, rectangle, box))
 
     for child in box.all_children():
-        gather_anchors(child, anchors, links, bookmarks, forms, debug, matrix, parent_form)
+        gather_anchors(child, anchors, links, bookmarks, forms, debug, matrix,
+                       parent_form)
 
 
 def make_page_bookmark_tree(page, skipped_levels, last_by_depth,

--- a/weasyprint/anchors.py
+++ b/weasyprint/anchors.py
@@ -27,11 +27,11 @@ def rectangle_aabb(matrix, pos_x, pos_y, width, height):
     return box_x1, box_y1, box_x2, box_y2
 
 
-def gather_anchors(box, anchors, links, bookmarks, forms, debug, parent_matrix=None,
+def gather_anchors(box, anchors, links, bookmarks, forms, parent_matrix=None,
                    parent_form=None):
     """Gather anchors and other data related to specific positions in PDF.
 
-    Currently finds anchors, links, bookmarks, forms and debug ids.
+    Currently finds anchors, links, bookmarks and forms.
 
     """
     # Get box transformation matrix.
@@ -113,27 +113,20 @@ def gather_anchors(box, anchors, links, bookmarks, forms, debug, parent_matrix=N
             links.append((link_type, target, rectangle, box))
         if is_input:
             forms[parent_form].append((box.element, box.style, rectangle))
-        if matrix and (has_bookmark or has_anchor):
-            pos_x, pos_y = matrix.transform_point(pos_x, pos_y)
         if has_bookmark:
+            if matrix:
+                pos_x, pos_y = matrix.transform_point(pos_x, pos_y)
             bookmark = (bookmark_level, bookmark_label, (pos_x, pos_y), state)
             bookmarks.append(bookmark)
         if has_anchor:
-            anchors[anchor_name] = pos_x, pos_y
-
-    # And this is what got added for debugging,
-    # everything that's not covered by the previous categories
-    else:
-        # Not sure why, but all elements are here twice?
-        if(box.element is not None and box.element.get("id") is not None) :
-            # print(box.element.tag, box.element.get("id"))
-            pos_x, pos_y, width, height = box.hit_area()
-            rectangle = rectangle_aabb(matrix, pos_x, pos_y, width, height)
-            debug.append((box.element, box.style, rectangle, box))
+            pos_x1, pos_y1, pos_x2, pos_y2 = pos_x, pos_y, pos_x + width, pos_y + height
+            if matrix:
+                pos_x1, pos_y1 = matrix.transform_point(pos_x1, pos_y1)
+                pos_x2, pos_y2 = matrix.transform_point(pos_x2, pos_y2)
+            anchors[anchor_name] = (pos_x1, pos_y1, pos_x2, pos_y2)
 
     for child in box.all_children():
-        gather_anchors(child, anchors, links, bookmarks, forms, debug, matrix,
-                       parent_form)
+        gather_anchors(child, anchors, links, bookmarks, forms, matrix, parent_form)
 
 
 def make_page_bookmark_tree(page, skipped_levels, last_by_depth,

--- a/weasyprint/document.py
+++ b/weasyprint/document.py
@@ -79,7 +79,8 @@ class Page:
         #: Appended for the debug PDF
         self.debug = []
 
-        gather_anchors(page_box, self.anchors, self.links, self.bookmarks, self.forms, self.debug)
+        gather_anchors(page_box, self.anchors, self.links, self.bookmarks, self.forms,
+                       self.debug)
         self._page_box = page_box
 
     def paint(self, stream, scale=1):

--- a/weasyprint/document.py
+++ b/weasyprint/document.py
@@ -76,7 +76,10 @@ class Page:
         #: The key ``None`` will contain inputs that are not part of a form.
         self.forms = {None: []}
 
-        gather_anchors(page_box, self.anchors, self.links, self.bookmarks, self.forms)
+        #: Appended for the debug PDF
+        self.debug = []
+
+        gather_anchors(page_box, self.anchors, self.links, self.bookmarks, self.forms, self.debug)
         self._page_box = page_box
 
     def paint(self, stream, scale=1):

--- a/weasyprint/document.py
+++ b/weasyprint/document.py
@@ -76,11 +76,7 @@ class Page:
         #: The key ``None`` will contain inputs that are not part of a form.
         self.forms = {None: []}
 
-        #: Appended for the debug PDF
-        self.debug = []
-
-        gather_anchors(page_box, self.anchors, self.links, self.bookmarks, self.forms,
-                       self.debug)
+        gather_anchors(page_box, self.anchors, self.links, self.bookmarks, self.forms)
         self._page_box = page_box
 
     def paint(self, stream, scale=1):

--- a/weasyprint/pdf/__init__.py
+++ b/weasyprint/pdf/__init__.py
@@ -16,7 +16,7 @@ from .anchors import (  # isort:skip
     add_annotations, add_forms, add_links, add_outlines, resolve_links,
     write_pdf_attachment)
 
-from .debug import (add_debug, resolve_debug)
+from .debug import add_debug, resolve_debug
 
 VARIANTS = {
     name: data for variants in (pdfa.VARIANTS, pdfua.VARIANTS)

--- a/weasyprint/pdf/__init__.py
+++ b/weasyprint/pdf/__init__.py
@@ -16,6 +16,8 @@ from .anchors import (  # isort:skip
     add_annotations, add_forms, add_links, add_outlines, resolve_links,
     write_pdf_attachment)
 
+from .debug import (add_debug, resolve_debug)
+
 VARIANTS = {
     name: data for variants in (pdfa.VARIANTS, pdfua.VARIANTS)
     for (name, data) in variants.items()}
@@ -145,11 +147,14 @@ def generate_pdf(document, target, zoom, **options):
     # Links and anchors
     page_links_and_anchors = list(resolve_links(document.pages))
 
+    # Debug links and anchors
+    page_debug = list(resolve_debug(document.pages))
+
     annot_files = {}
     pdf_pages, page_streams = [], []
     compress = not options['uncompressed_pdf']
-    for page_number, (page, links_and_anchors) in enumerate(
-            zip(document.pages, page_links_and_anchors)):
+    for page_number, (page, links_and_anchors, debug) in enumerate(
+            zip(document.pages, page_links_and_anchors, page_debug)):
         # Draw from the top-left corner
         matrix = Matrix(scale, 0, 0, -scale, 0, page.height * scale)
 
@@ -192,6 +197,9 @@ def generate_pdf(document, target, zoom, **options):
         add_forms(
             page.forms, matrix, pdf, pdf_page, resources, stream,
             document.font_config.font_map, compress)
+        add_debug(debug[0], matrix, pdf, pdf_page, pdf_names, mark)
+        page.paint(stream, scale)
+
         page.paint(stream, scale)
 
         # Bleed

--- a/weasyprint/pdf/__init__.py
+++ b/weasyprint/pdf/__init__.py
@@ -8,7 +8,7 @@ from .. import VERSION, Attachment
 from ..html import W3C_DATE_RE
 from ..logger import LOGGER, PROGRESS_LOGGER
 from ..matrix import Matrix
-from . import pdfa, pdfua
+from . import debug, pdfa, pdfua
 from .fonts import build_fonts_dictionary
 from .stream import Stream
 
@@ -16,10 +16,8 @@ from .anchors import (  # isort:skip
     add_annotations, add_forms, add_links, add_outlines, resolve_links,
     write_pdf_attachment)
 
-from .debug import add_debug, resolve_debug
-
 VARIANTS = {
-    name: data for variants in (pdfa.VARIANTS, pdfua.VARIANTS)
+    name: data for variants in (pdfa.VARIANTS, pdfua.VARIANTS, debug.VARIANTS)
     for (name, data) in variants.items()}
 
 
@@ -147,14 +145,11 @@ def generate_pdf(document, target, zoom, **options):
     # Links and anchors
     page_links_and_anchors = list(resolve_links(document.pages))
 
-    # Debug links and anchors
-    page_debug = list(resolve_debug(document.pages))
-
     annot_files = {}
     pdf_pages, page_streams = [], []
     compress = not options['uncompressed_pdf']
-    for page_number, (page, links_and_anchors, debug) in enumerate(
-            zip(document.pages, page_links_and_anchors, page_debug)):
+    for page_number, (page, links_and_anchors) in enumerate(
+            zip(document.pages, page_links_and_anchors)):
         # Draw from the top-left corner
         matrix = Matrix(scale, 0, 0, -scale, 0, page.height * scale)
 
@@ -197,9 +192,6 @@ def generate_pdf(document, target, zoom, **options):
         add_forms(
             page.forms, matrix, pdf, pdf_page, resources, stream,
             document.font_config.font_map, compress)
-        add_debug(debug[0], matrix, pdf, pdf_page, pdf_names, mark)
-        page.paint(stream, scale)
-
         page.paint(stream, scale)
 
         # Bleed

--- a/weasyprint/pdf/anchors.py
+++ b/weasyprint/pdf/anchors.py
@@ -406,7 +406,7 @@ def resolve_links(pages):
     paged_anchors = []
     for i, page in enumerate(pages):
         paged_anchors.append([])
-        for anchor_name, (point_x, point_y) in page.anchors.items():
+        for anchor_name, (point_x, point_y, _, _) in page.anchors.items():
             if anchor_name not in anchors:
                 paged_anchors[-1].append((anchor_name, point_x, point_y))
                 anchors.add(anchor_name)

--- a/weasyprint/pdf/debug.py
+++ b/weasyprint/pdf/debug.py
@@ -1,6 +1,7 @@
 
 import pydyf
 
+
 def add_debug(debug, matrix, pdf, page, names, mark):
     """Include anchors for each element with an ID in a given PDF page."""
     if not debug:
@@ -11,7 +12,7 @@ def add_debug(debug, matrix, pdf, page, names, mark):
 
     ids = {}
 
-    for i, (element, style, rectangle, box) in enumerate(debug): # style is usused for now?
+    for i, (element, style, rectangle, box) in enumerate(debug):
         id = element.get("id")
         if id.startswith("auto-id"):
             id = "-".join(id.split("-")[:4])
@@ -56,7 +57,6 @@ def add_debug(debug, matrix, pdf, page, names, mark):
 def resolve_debug(pages):
     '''Resolve the added debug IDs. Inspired from resolve_links.
     '''
-    debug = list()
     paged_debug = []
     for i, page in enumerate(pages):
         paged_debug.append([])

--- a/weasyprint/pdf/debug.py
+++ b/weasyprint/pdf/debug.py
@@ -32,6 +32,10 @@ def debug(pdf, metadata, document, page_streams, attachments, compress):
                 'T': pydyf.String(id),  # id added as metadata
             })
 
+            # The next line makes all of this relevent to use
+            # with PDFjs
+            annotation['Dest'] = pydyf.String(id)
+
             pdf.add_object(annotation)
             page['Annots'].append(annotation.reference)
 

--- a/weasyprint/pdf/debug.py
+++ b/weasyprint/pdf/debug.py
@@ -1,0 +1,69 @@
+
+import pydyf
+
+def add_debug(debug, matrix, pdf, page, names, mark):
+    """Include anchors for each element with an ID in a given PDF page."""
+    if not debug:
+        return
+
+    if 'Annots' not in page:
+        page['Annots'] = pydyf.Array()
+
+    ids = {}
+
+    for i, (element, style, rectangle, box) in enumerate(debug): # style is usused for now?
+        id = element.get("id")
+        if id.startswith("auto-id"):
+            id = "-".join(id.split("-")[:4])
+            if id in ids:
+                ids[id] += 1
+            else:
+                ids[id] = 0
+            final_id = id + "-" + str(ids[id])
+            element.set("id", final_id)
+            id = final_id
+            # print("add_debug", element.get("id"))
+        x1, y1 = matrix.transform_point(*rectangle[:2])
+        x2, y2 = matrix.transform_point(*rectangle[2:])
+        box.annotation = pydyf.Dictionary({
+            'Type': '/Annot',
+            'Subtype': '/Link',
+            # 'Subtype': '/Square',
+            'Rect': pydyf.Array([x1, y1, x2, y2]),
+            'P': page.reference,
+            # 'BS': pydyf.Dictionary({'W': 1}), # border style
+            'T': pydyf.String(id), # the title element gets added as metadata
+        })
+
+        # Internal links are deactivated when in local
+        # See: https://github.com/mozilla/pdf.js/issues/12415
+        # box.annotation['A'] = pydyf.Dictionary({
+        #     'Type': '/Action',
+        #     'S': '/URI',
+        #     'URI': pydyf.String("#" + id)
+        # })
+
+        # Internal links - works better with a local version PDFjs... But why?
+        box.annotation['Dest'] = pydyf.String(id)
+
+        # In order to preserve page references
+        names.append([id, pydyf.Array([page.reference, '/XYZ', x1, y1, 0])])
+
+        # Actually adding the PDF object
+        pdf.add_object(box.annotation)
+        page['Annots'].append(box.annotation.reference)
+
+def resolve_debug(pages):
+    '''Resolve the added debug IDs. Inspired from resolve_links.
+    '''
+    debug = list()
+    paged_debug = []
+    for i, page in enumerate(pages):
+        paged_debug.append([])
+        # for (element, style, rectangle, box) in page.debug:
+        #     debug.append(element.get('id'))
+    for page in pages:
+        page_debug = []
+        for m in page.debug:
+            page_debug.append(m)
+        yield page_debug, paged_debug.pop(0)


### PR DESCRIPTION
Hello!

Before anything, a bit of context: this PR is a work in progress, and it is not ready to be merged as such. It will require some more work in order to be eventually added to the main branch, as discussed beforehand with @liZe and @grewn0uille. The idea behind this first draft is to allow WeasyPrint to embed metadata in the PDF for each HTMLElement with an `id` attribute it converts by adding new `\Annot` PDF objects that can then be accessed in the PDF readers.

What it allowed me to do for now is this:

![ezgif-6-1a414276b9](https://github.com/Kozea/WeasyPrint/assets/25752940/f0709a36-7d0a-4707-b5c9-2799e983ef9d)

On the left, you have a webpage; and on the right, you have the PDF produced by this fork of WeasyPrint, previewed with PDF.js. A few event listeners were added to bidirectionally "synchronize" the two visualisations. This is just a proof-of-concept, but from there we basically have what we need to build powerful interfaces that take into account the content of the PDF as semantic data that can be linked back to its source.

We talked about adding a PDF variant for debugging that could be accessible through an option like `--pdf-variant debug`. For now, nothing has been done in this direction, the code I propose here is just "hardcoded" into the default behaviour of WeasyPrint. I guess it will need some cleanup also, as I'm not sure if I understood the spec totally right.

Anyway, I'd be really interested in working with you on this and going in a direction that suits the philosophy of the project. If you feel like I could be of help, please share your thoughts here so that we can discuss what would be the best way to proceed, and how I could contribute further!

I can also share on demand the code of the interface I'm building, even though it is not ready to be made totally public for now, so don't hesitate to ask :)

Thanks for the great job!