### PR TITLE
Update `cache` argument in docs

### DIFF
--- a/docs/first_steps.rst
+++ b/docs/first_steps.rst
@@ -516,7 +516,7 @@ Image Cache and Optimization
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 WeasyPrint provides many options to deal with images: ``optimize_images``,
-``jpeg_quality``, ``dpi`` and ``image_cache``.
+``jpeg_quality``, ``dpi`` and ``cache``.
 
 ``optimize_images`` can enable size optimization for images. When enabled, the
 generated PDF will include smaller images with no quality penalty, but the
@@ -540,7 +540,7 @@ generated PDF.
     HTML('https://weasyprint.org/').write_pdf(
         'weasyprint.pdf', optimize_images=True, jpeg_quality=60, dpi=150)
 
-``image_cache`` gives the possibility to use a cache for images, avoiding to
+``cache`` gives the possibility to use a cache for images, avoiding to
 download, parse and optimize them each time they are used.
 
 By default, the cache is used document by document, but you can share it
@@ -552,12 +552,12 @@ time when you render a lot of documents that use the same images.
     cache = {}
     for i in range(10):
         HTML(f'https://weasyprint.org/').write_pdf(
-            f'example-{i}.pdf', image_cache=cache)
+            f'example-{i}.pdf', cache=cache)
 
 It’s also possible to cache images on disk instead of keeping them in memory.
 The ``--cache-folder`` CLI option can be used to define the folder used to
 store temporary images. You can also provide this folder path as a string for
-``image_cache``.
+``cache``.
 
 
 Logging

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -306,6 +306,15 @@ def test_python_render(assert_pixels_equal, tmp_path):
 
 
 @assert_no_logs
+def test_unknown_options():
+    with capture_logs() as logs:
+        pdf_bytes = FakeHTML(string='test').write_pdf(zoom=2, unknown=True)
+    assert len(logs) == 1
+    assert 'unknown' in logs[0]
+    assert pdf_bytes
+
+
+@assert_no_logs
 def test_command_line_render(tmp_path):
     css = b'''
         @page { margin: 2px; size: 8px }

--- a/weasyprint/__init__.py
+++ b/weasyprint/__init__.py
@@ -210,6 +210,8 @@ class HTML:
         :returns: A :class:`document.Document` object.
 
         """
+        for unknown in set(options) - set(DEFAULT_OPTIONS):
+            LOGGER.warning('Unknown rendering option: %s.', unknown)
         new_options = DEFAULT_OPTIONS.copy()
         new_options.update(options)
         options = new_options

--- a/weasyprint/__main__.py
+++ b/weasyprint/__main__.py
@@ -165,7 +165,8 @@ def main(argv=None, stdout=None, stdin=None, HTML=HTML):  # noqa: N803
     if args.timeout is not None:
         url_fetcher = partial(default_url_fetcher, timeout=args.timeout)
 
-    options = vars(args)
+    options = {
+        key: value for key, value in vars(args).items() if key in DEFAULT_OPTIONS}
 
     # Default to logging to stderr.
     if args.debug:


### PR DESCRIPTION
The `image_cache` option specified in the documentation is not correct. The correct option is `cache`. Using `image_cache` leads to no cache being applied at all, as the option is completely ignored without warning. It would be useful to fail when passing invalid options, to avoid them silently not being applied.