### PR TITLE
Submit PDF forms

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -538,10 +538,10 @@ def test_pdf_no_srgb():
     ('<input type="radio">',
      ['/Btn', '/V /Off', '/AS /Off', '/Ff 49152']),
     ('<input checked type="radio" name="foo" value="value">',
-     ['/Btn', '/T (1)', '/V /dmFsdWU=', '/AS /dmFsdWU=']),
+     ['/Btn', '/T (foo)', '/V /0', '/AS /0']),
     ('<form><input type="radio" name="foo" value="v0"></form>'
      '<form><input checked type="radio" name="foo" value="v1"></form>',
-     ['/Btn', '/AS /djE=', '/V /djE=', '/AS /Off', '/V /Off']),
+     ['/Btn', '/AS /0', '/V /0', '/AS /Off', '/V /Off']),
     ('<textarea></textarea>', ['/Tx', '/V ()']),
     ('<select><option value="a">A</option></select>', ['/Ch', '/Opt']),
     ('<select>'

--- a/weasyprint/css/html5_ua.css
+++ b/weasyprint/css/html5_ua.css
@@ -161,14 +161,14 @@ input[type="reset"]:not([value])::before {
 }
 input[type="checkbox"],
 input[type="radio"] {
-  height: 1.2em;
-  width: 1.2em;
+  height: 0.7em;
+  vertical-align: -0.2em;
+  width: 0.7em;
 }
 input[type="checkbox"][checked]:before,
 input[type="radio"][checked]:before {
   background: black;
   content: "";
-  display: block;
   height: 100%;
 }
 input[type="radio"][checked]:before {
@@ -179,7 +179,6 @@ input[type="hidden"] {
 }
 input[type="radio"] {
   border-radius: 50%;
-  margin: 0.2em 0.2em 0 0.4em;
 }
 input[value]::before {
   content: attr(value);
@@ -191,6 +190,7 @@ input[value=""]::before,
 input[type="checkbox"]::before,
 input[type="radio"]::before {
   content: "";
+  display: block;
 }
 select {
   background: lightgrey;

--- a/weasyprint/css/html5_ua_form.css
+++ b/weasyprint/css/html5_ua_form.css
@@ -3,3 +3,13 @@
 button, input, select, textarea {
   appearance: auto;
 }
+
+select option,
+select:not([multiple])::before,
+input:not([type="submit"])::before {
+  visibility: hidden;
+}
+
+textarea {
+  color: transparent;
+}

--- a/weasyprint/formatting_structure/build.py
+++ b/weasyprint/formatting_structure/build.py
@@ -223,7 +223,7 @@ def element_to_box(element, style_for, get_image_from_uri, base_url,
         if not counter_values[name]:
             counter_values.pop(name)
 
-    box.children = children if style['appearance'] == 'none' else []
+    box.children = children
     process_whitespace(box)
     set_content_lists(
         element, box, style, counter_values, target_collector, counter_style)

--- a/weasyprint/pdf/anchors.py
+++ b/weasyprint/pdf/anchors.py
@@ -143,6 +143,7 @@ def add_forms(forms, matrix, pdf, page, resources, stream, font_map,
                     pdf.add_object(group)
                     pdf.catalog['AcroForm']['Fields'].append(group.reference)
                 group = radio_groups[form][input_name]
+                font_size = style['font_size'] * 0.5
                 character = 'l'  # Disc character in Dingbats
             else:
                 character = '4'  # Check character in Dingbats


### PR DESCRIPTION
Allow submit buttons to send form content to given URL.

It currently works pretty well with Adobe Reader and Foxit. Other tested PDF open source renderers (including Poppler and browsers) don’t support the feature, there are related comments in their code.

Text included in the HTTP request (both name and value fields) only work with ASCII text. If anyone knows if it’s possible to handle Unicode, please add a comment!

Default selected radio buttons are not selected anymore with Adobe Reader. It’s probably a bug in Adobe Reader, as it works everywhere else, including Ghostscript!

Default rendering for form fields has been improved too.

Feedback is welcome!