### PR TITLE
Add extra information to debug logs

### DIFF
--- a/weasyprint/__main__.py
+++ b/weasyprint/__main__.py
@@ -178,7 +178,14 @@ def main(argv=None, stdout=None, stdin=None, HTML=HTML):  # noqa: N803
         LOGGER.setLevel(logging.INFO)
     if not args.quiet:
         handler = logging.StreamHandler()
-        handler.setFormatter(logging.Formatter('%(levelname)s: %(message)s'))
+        if args.debug:
+            # Add extra information when debug logging
+            handler.setFormatter(
+                logging.Formatter(
+                    '%(levelname)s: %(filename)s:%(lineno)d '
+                    '(%(funcName)s): %(message)s'))
+        else:
+            handler.setFormatter(logging.Formatter('%(levelname)s: %(message)s'))
         LOGGER.addHandler(handler)
 
     html = HTML(


### PR DESCRIPTION
Because WeasyPrint has a lot of very deeply nested recursive call chains, it is super easy to get lost in the code.  When adding debugging log messages (which WeasyPrint could really use more of) to trace, it is nice to be able to know what file/line/function they come from.

Possibly useful for bug reporting too?