### PR TITLE
Support XML input and <?xml-stylesheet?> instructions

### DIFF
--- a/weasyprint/__main__.py
+++ b/weasyprint/__main__.py
@@ -8,7 +8,7 @@ from functools import partial
 
 import pydyf
 
-from . import DEFAULT_OPTIONS, HTML, LOGGER, __version__
+from . import DEFAULT_OPTIONS, HTML, XML, LOGGER, __version__
 from .pdf import VARIANTS
 from .text.ffi import pango
 from .urls import default_url_fetcher
@@ -128,6 +128,8 @@ PARSER.add_argument(
 PARSER.add_argument(
     '-q', '--quiet', action='store_true', help='hide logging messages')
 PARSER.add_argument(
+    '-x', '--xml', action='store_true', help='treat input as XML')
+PARSER.add_argument(
     '--version', action='version',
     version=f'WeasyPrint version {__version__}',
     help='print WeasyPrint’s version number and exit')
@@ -187,6 +189,8 @@ def main(argv=None, stdout=None, stdin=None, HTML=HTML):  # noqa: N803
         else:
             handler.setFormatter(logging.Formatter('%(levelname)s: %(message)s'))
         LOGGER.addHandler(handler)
+    if args.xml:
+        HTML = XML
 
     html = HTML(
         source, base_url=args.base_url, encoding=args.encoding,

--- a/weasyprint/document.py
+++ b/weasyprint/document.py
@@ -1,5 +1,6 @@
 """Document generation management."""
 
+import itertools
 import functools
 import io
 from hashlib import md5
@@ -226,7 +227,8 @@ class Document:
             cache = {}
         elif not isinstance(cache, (dict, DiskCache)):
             cache = DiskCache(cache)
-        for css in options['stylesheets'] or []:
+        for css in itertools.chain(getattr(html, "stylesheet_urls", []),
+                                   options['stylesheets'] or []):
             if not hasattr(css, 'matcher'):
                 css = CSS(
                     guess=css, media_type=html.media_type,


### PR DESCRIPTION
Weasyprint already "accidentally" supports XML, because if you give an XML document to html5lib, it assumes that it's a fragment of malformed HTML and wraps it in `<html>` and `<body>` tags.

This is pretty handy since you don't actually have to needlessly apply XSLT to produce HTML before rendering it to PDF.  Also because the usual solutions for transforming XML to PDF are closed source and horrendously expensive, so this is a super useful thing to be able to do.

But it's not clear how robust it is.  So, since html5lib gives you an `ElementTree.Element` anyway, and since `cssselect2` explicitly supports XML already, why not just parse XML as XML?  Seems easy enough, here is a draft PR to do that.

Lacking:
- tests, tests, and more tests
- doesn't also support XSLT (XSLT for extraction/organization + CSS for layout is a fairly obvious use case) - this would require an lxml dependency
- does it support namespaces? probably not, because **I** do not support namespaces (in the sense of "je ne les supporte pas")
- UA stylesheets for HTML5 are probably mostly irrelevant or inappropriate for XML