### PR TITLE
Enable limits to domain/scheme for external resources

### DIFF
--- a/tests/test_url_fetcher.py
+++ b/tests/test_url_fetcher.py
@@ -1,0 +1,62 @@
+"""Test the UrlFetcher class"""
+
+import pytest
+from urllib.request import pathname2url
+import os
+
+from weasyprint.urls import UrlFetcher
+
+
+@pytest.mark.parametrize('url, allowed_schemes', (
+    ('http://weasyprint.org/', ('https',)),
+    ('file:///etc/passwd', ('http', 'https',)),
+))
+def test_forbidden_scheme(url, allowed_schemes):
+    fetcher = UrlFetcher(allowed_schemes=allowed_schemes)
+    with pytest.raises(ValueError):
+        fetcher.validate(url)
+
+
+@pytest.mark.parametrize('url, allowed_schemes', (
+    ('http://weasyprint.org/', ('http', 'https')),
+    ('https://weasyprint.org/', ('http', 'https')),
+    ('https://weasyprint.org/', ('https',)),
+    ('https://weasyprint.org/', None),
+    ('file:///home/me/my_photo.jpg', ('http', 'https', 'file')),
+))
+def test_allowed_scheme(url, allowed_schemes):
+    fetcher = UrlFetcher(allowed_schemes=allowed_schemes)
+    assert fetcher.validate(url) == url
+
+
+@pytest.mark.parametrize('url, allowed_domains', (
+    ('https://evil.net/', ('weasyprint.org',)),
+))
+def test_forbidden_domain(url, allowed_domains):
+    fetcher = UrlFetcher(allowed_domains=allowed_domains)
+    with pytest.raises(ValueError):
+        fetcher.validate(url)
+
+
+@pytest.mark.parametrize('url, allowed_domains', (
+    ('https://weasyprint.org/', ('weasyprint.org',)),
+    ('https://weasyprint.org/', ('weasyprint.org', 'example.com')),
+    ('https://example.com/', ('weasyprint.org', 'example.com')),
+    ('https://weasyprint.org/', None),
+))
+def test_allowed_domain(url, allowed_domains):
+    fetcher = UrlFetcher(allowed_domains=allowed_domains)
+    assert fetcher.validate(url) == url
+
+
+def test_fetch_https():
+    fetcher = UrlFetcher(allowed_domains=('weasyprint.org',), allowed_schemes=('https',))
+    result = fetcher('https://weasyprint.org/css/img/logotype-black.svg')
+    assert 'string' in result or 'file_obj' in result
+
+
+def test_fetch_file():
+    fetcher = UrlFetcher(allowed_schemes=('file',))
+    result = fetcher('file://%s' % pathname2url(os.path.abspath('./resources/icon.png')))
+    assert 'string' in result or 'file_obj' in result
+    

--- a/weasyprint/__main__.py
+++ b/weasyprint/__main__.py
@@ -11,7 +11,7 @@ import pydyf
 from . import DEFAULT_OPTIONS, HTML, LOGGER, __version__
 from .pdf import VARIANTS
 from .text.ffi import pango
-from .urls import default_url_fetcher
+from .urls import UrlFetcher
 
 
 class PrintInfo(argparse.Action):
@@ -137,6 +137,14 @@ PARSER.add_argument(
 PARSER.add_argument(
     '-t', '--timeout', type=int,
     help='Set timeout in seconds for HTTP requests')
+PARSER.add_argument(
+    '--fetch-scheme', action='append',
+    help='limit the schemes allowed when fetching external resources'
+)
+PARSER.add_argument(
+    '--fetch-domain', action='append',
+    help='limit the domains allowed when fetching external resources'
+)
 PARSER.set_defaults(**DEFAULT_OPTIONS)
 
 
@@ -164,9 +172,14 @@ def main(argv=None, stdout=None, stdin=None, HTML=HTML):  # noqa: N803
     else:
         output = args.output
 
-    url_fetcher = default_url_fetcher
+    # Build the URL fetcher
+    url_fetcher = UrlFetcher()
     if args.timeout is not None:
-        url_fetcher = partial(default_url_fetcher, timeout=args.timeout)
+        url_fetcher.timeout=args.timeout
+    if args.fetch_scheme is not None:
+        url_fetcher.allowed_schemes = args.fetch_scheme
+    if args.fetch_domain is not None:
+        url_fetcher.allowed_domains = args.fetch_domain
 
     options = {
         key: value for key, value in vars(args).items() if key in DEFAULT_OPTIONS}


### PR DESCRIPTION
The [WeasyPrint documentation](https://doc.courtbouillon.org/weasyprint/stable/first_steps.html#access-to-local-files) states that, for security reasons, it is best to use a custom URL fetcher that either doesn't allow `file://` URLs, or that filters these to known safe values. However, there is no way to accomplish this via the CLI--only via Python.

This pull request expands the `default_url_fetcher` into an extensible class with two new properties that will allow limiting the fetcher either to certain schemes (thus enabling a user to only allow HTTP and HTTPS resources) or to certain domains (allowing a user to limit resources to coming from trusted domains).

I've also exposed these two new options to the CLI as `--fetch-scheme` and `--fetch-domain`, though I'm open to different names for these. The default behavior if these options are not used remains the same, so this should not break backward compatibility. 

I've added tests for the new code and run the full test suite. One test (layout/test_inline.py::test_font_stretch) is failing, but I do not believe this failure is related to any change that I made.

Using a class for the URL fetcher rather than a function will also open the door to even further improvements in the future, such as potentially allowing file paths but limiting them to certain parent directories, or mapping URLs to paths, etc..., though none of these are part of this PR. However, I think there is value in having a single highly configurable URL fetcher rather than requiring all users to implement their own.