### PR TITLE
Add `plotter` media type to print on a single page that fit automatically the height of content of the document

### DIFF
--- a/weasyprint/document.py
+++ b/weasyprint/document.py
@@ -284,12 +284,17 @@ class Document:
         eod_style = "margin:0;height:1px;width:1px;display:block;background-color:red"
         eod_attrib = {'id': eod_id, 'style': eod_style}
         eod_mark = ElementTree.SubElement(body, f'{eod_id}', attrib=eod_attrib)
-        options['stylesheets'] = [CSS(string="@page {margin-top:0 !important;height:65536px; /* 17,34 meter */}")]
+        css = CSS(string="@page {margin-top:0 !important;height:65536px !important; /* 17,34 meter */}")
+        if options['stylesheets']:
+            options['stylesheets'].append(css)
+        else:
+            options['stylesheets'] = [css]
         # use @media rollingpaper on css
         html.media_type = 'rollingpaper'
         pre_render_page = Document._render(html, font_config, counter_style, options).pages[0]
         eod_y = pre_render_page.anchors[eod_id][1] + 0.05 # + to avoid calculation approximation
-        options['stylesheets'] = [CSS(string=f"@page {{height:{eod_y}px}}")]
+        del options['stylesheets'][-1]
+        options['stylesheets'].append(CSS(string=f"@page {{height:{eod_y}px !important}}"))
         body.remove(eod_mark)
         return Document._render(html, font_config, counter_style, options)
 


### PR DESCRIPTION
Hello,

First I know that this not in the W3C specification, but [I also think that printed on a single page with WeasyPrint would be very useful](https://github.com/Kozea/WeasyPrint/issues/2147).

So, this PR add a dedicated media type named `plotter` to print on a **single page that fit automatically the height of content of the document**. It use the `@media rollingpaper` for the page dimensions  (or default page dimensions if the media don't exist in css).

Using a dedicated media type avoid to add new option or paramater to Weasprint, so the addition does not modify existing APIs and will not be impacted by future developments.

* `weasyprint -s 01.css 01.html 01-print.pdf`
![01-print pdf](https://github.com/user-attachments/assets/ebcfe39b-893f-44dc-adb0-b47eb64549f2)

* `weasyprint -s 01.css -m plotter 01.html 01-plotter.pdf`
![01-plotter pdf](https://github.com/user-attachments/assets/6d1f1b85-dafa-4089-894a-8594d204e2af)

* `01.html`
```html
<body>
    <main>
        <div id="one">
            <h1>ONE</h1>
        </div>
        <div id="two">
            <h1>TWO</h1>
        </div>
        <div id="three">
            <h1>THREE</h1>
        </div>
    </main>
</body>
```
* `01.css`
```css
/* css media used with --media-type plotter */
@media rollingpaper {
    @page {
        size: 12cm;
        margin: 1cm;
        /* 120 x 400mm computed :-) */
    }
}
html, html * {
    margin: 0;
    padding: 0;
}
html,
body {
    background-color: lightgreen;
}
div {
    box-sizing: border-box;
    width: 10cm;
    height: 12cm;
    background-color: blueviolet;
    border: solid 0.2cm black;
    margin-bottom: 1cm;
}
div:last-child {
    margin-bottom: 0;
}
h1 {
    color: aliceblue;
    text-align: center;
    font-family: sans-serif;
    display: flex;
    justify-content: center;
    align-items: center;
    height: 100%;
}
```

[01-print.pdf](https://github.com/user-attachments/files/16922033/01-print.pdf)
[01-plotter.pdf](https://github.com/user-attachments/files/16922032/01-plotter.pdf)

