### PR TITLE
Build macOS executable for M- series Macs

### DIFF
--- a/.github/workflows/m-series-mac-executable.yml
+++ b/.github/workflows/m-series-mac-executable.yml
@@ -1,0 +1,41 @@
+name: WeasyPrint’s M-series macOS binary generation
+on: [push]
+
+jobs:
+  generate:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          brew install pango gobject-introspection cairo glib
+          brew install python@3.12
+          echo "export PATH=\"/opt/homebrew/opt/python@3.12/bin:$PATH\"" >> $GITHUB_ENV
+      - name: Ensure absolute imports
+        run: |
+          sed -i '' 's/^from \. /from weasyprint /' weasyprint/__main__.py
+          sed -i '' 's/^from \./from weasyprint\./' weasyprint/__main__.py
+      - name: Install requirements
+        run: python -m pip install . pyinstaller
+      - name: Create dyld PATH hook
+        run: |
+          echo "import os" > weasyprint/set_dyld_path.py
+          echo "import sys" >> weasyprint/set_dyld_path.py
+          echo "lib_path = os.path.join(sys._MEIPASS, 'lib')" >> weasyprint/set_dyld_path.py
+          echo "os.environ['DYLD_LIBRARY_PATH'] = lib_path" >> weasyprint/set_dyld_path.py
+      - name: Generate executable with included libraries
+        run: |
+          python -m PyInstaller weasyprint/__main__.py -n weasyprint -F --add-binary "/opt/homebrew/Cellar/glib/2.82.0/lib/libgobject-2.0.0.dylib:./lib" --add-binary "/opt/homebrew/lib/libgobject-2.0.dylib:./lib" --add-binary "/opt/homebrew/Cellar/pango/1.54.0/lib/libpango-1.0.0.dylib:./lib" --add-binary "/opt/homebrew/lib/libpango-1.0.dylib:./lib" --add-binary "/opt/homebrew/Cellar/fontconfig/2.15.0/lib/libfontconfig.1.dylib:./lib" --add-binary "/opt/homebrew/lib/libfontconfig.1.dylib:./lib" --add-binary "/opt/homebrew/lib/libfontconfig.dylib:./lib" --add-binary "/opt/homebrew/lib/libpangoft2-1.0.0.dylib:./lib" --add-binary "/opt/homebrew/lib/libpangoft2-1.0.dylib:./lib" --add-binary "/opt/homebrew/Cellar/pango/1.54.0/lib/libpangoft2-1.0.0.dylib:./lib" --runtime-hook weasyprint/set_dyld_path.py
+      - name: Test executable
+        run: dist/weasyprint --info
+      - name: Store executable
+        uses: actions/upload-artifact@v4
+        with:
+          name: weasyprint-macos
+          path: |
+            dist/weasyprint
+            README.rst
+            LICENSE


### PR DESCRIPTION
I noticed there was a GitHub Action that generated a Windows (`.exe`) executable, but nothing for macOS. This pull request adds a GitHub Action to generate an executable binary for macOS.

## Testing
There is a test step in the GitHub Action, so no manually testing should be necessary, however, if you'd like you can download the artifact produced from the GitHub Action run. You'll need to run `chmod +x weasyprint-macos/dist/weasyprint` in order to be able to execute, but once you do, you can run `./weasyprint-macos/dist/weasyprint --info` to verify the executable is working.

## Use cases
This executable can be bundled with [Electron](https://www.electronjs.org) or [Tauri](https://tauri.app) applications so PDF generation is a possibility without requiring users of the built applications to install additional resources.