### PR TITLE
Hyphenation: consider words that contain a NBSP

### DIFF
--- a/weasyprint/text/line_break.py
+++ b/weasyprint/text/line_break.py
@@ -10,6 +10,8 @@ from .ffi import FROM_UNITS, TO_UNITS, ffi, gobject, pango, pangoft2, unicode_to
 from .fonts import font_features, get_font_description
 
 
+NBSP = '\u00a0'
+
 def line_size(line, style):
     """Get logical width and height of the given ``line``.
 
@@ -400,7 +402,7 @@ def split_first_line(text, style, context, max_width, justification_spacing,
             dictionary = pyphen.Pyphen(lang=lang, left=left, right=right)
             context.dictionaries[dictionary_key] = dictionary
         dictionary_iterations = [
-            start for start, end in dictionary.iterate(next_word)]
+            start for start, end in dictionary.iterate(next_word) if start[-1] != NBSP]
     else:
         dictionary_iterations = []
 
@@ -518,6 +520,8 @@ def get_next_word_boundaries(text, lang):
         return None
     bytestring, log_attrs = get_log_attrs(text, lang)
     for i, attr in enumerate(log_attrs):
+        follows_nbsp = (i < len(text) and text[i] == NBSP)
+        if follows_nbsp: continue
         if attr.is_word_end:
             word_end = i
             break


### PR DESCRIPTION
The main goal here is to fix https://github.com/Kozea/WeasyPrint/issues/2270.

My change is simple:
  - adjust the `get_next_word_boundaries` function so it considers the whole *word-nbsp-word* cluster as a single potentially-hyphenable word,
  - ignore suggested hyphenation dictionary item(s) that end with a nbsp

Tests seem to pass. However:
![xVyoSl](https://github.com/user-attachments/assets/881899e7-f022-46b7-85ca-d7da5f6dbc22)
