### PR TITLE
Update install instructions for alpine

### DIFF
--- a/docs/first_steps.rst
+++ b/docs/first_steps.rst
@@ -77,7 +77,13 @@ To install WeasyPrint using your distribution’s package::
 
   apk add weasyprint
 
-To install WeasyPrint, you need the following packages::
+To install WeasyPrint inside a virtualenv using wheels (if possible), you need
+the following packages::
+
+  apk add py3-pip so:libgobject-2.0.so.0 so:libpango-1.0.so.0 so:libharfbuzz.so.0 so:libharfbuzz-subset.so.0 so:libfontconfig.so.1 so:libpangoft2-1.0.so.0
+
+To install WeasyPrint inside a virtualenv without using wheels, you need the
+following packages::
 
   apk add py3-pip gcc musl-dev python3-dev pango zlib-dev jpeg-dev openjpeg-dev g++ libffi-dev harfbuzz-subset
 

--- a/docs/first_steps.rst
+++ b/docs/first_steps.rst
@@ -85,7 +85,8 @@ the following packages::
 To install WeasyPrint inside a virtualenv without using wheels, you need the
 following packages::
 
-  apk add py3-pip gcc musl-dev python3-dev pango zlib-dev jpeg-dev openjpeg-dev g++ libffi-dev harfbuzz-subset
+  apk add py3-pip so:libgobject-2.0.so.0 so:libpango-1.0.so.0 so:libharfbuzz.so.0 so:libharfbuzz-subset.so.0 so:libfontconfig.so.1 so:libpangoft2-1.0.so.0
+  apk add gcc musl-dev python3-dev zlib-dev jpeg-dev openjpeg-dev libwebp-dev g++ libffi-dev
 
 
 Archlinux


### PR DESCRIPTION
As per the discussion in #699, document an easier way to install WeasyPrint from PyPI when using prebuilt wheels.

To keep the document consistent, I copied the context descriptions over from the other Linux flavors.