### PR TITLE
Use CSS 'image-rendering' attribute for images in SVGs

### DIFF
--- a/tests/draw/svg/test_images.py
+++ b/tests/draw/svg/test_images.py
@@ -257,6 +257,27 @@ def test_image_image(assert_pixels):
       </svg>
     ''' % path2url(resource_path('pattern.png')))
 
+@assert_no_logs
+def test_image_image_rendering(assert_pixels):
+    assert_pixels('''
+        rrBBBBBB
+        rrBBBBBB
+        BBBBBBBB
+        BBBBBBBB
+        BBBBBBBB
+        BBBBBBBB
+        BBBBBBBB
+        BBBBBBBB
+    ''', '''
+      <style>
+        @page { size: 8px 8px }
+        svg { display: block }
+      </style>
+      <svg width="8px" height="8px" xmlns="http://www.w3.org/2000/svg">
+        <image width="8px" height="8px" xlink:href="%s"
+            style="image-rendering:pixelated"/>
+      </svg>
+    ''' % path2url(resource_path('pattern.png')))
 
 def test_image_image_wrong(assert_pixels):
     assert_pixels('''

--- a/weasyprint/svg/images.py
+++ b/weasyprint/svg/images.py
@@ -70,5 +70,7 @@ def image(svg, node, font_size):
     svg.stream.push_state()
     svg.stream.transform(a=scale_x, d=scale_y, e=translate_x, f=translate_y)
     image.draw(
-        svg.stream, intrinsic_width, intrinsic_height, image_rendering='auto')
+        svg.stream, intrinsic_width, intrinsic_height,
+        image_rendering=node.attrib.get('image-rendering', 'auto'),
+    )
     svg.stream.pop_state()


### PR DESCRIPTION
Currently the `image-rendering` attribute is not passed to the draw function. 
In the case of `image-rendering: pixelated;` this leads to blurry images inside SVGs if the defined size is larger than the source image.