### PR TITLE
Use setLevel to restore logger level in capture_logs

### DIFF
--- a/weasyprint/logger.py
+++ b/weasyprint/logger.py
@@ -55,4 +55,4 @@ def capture_logs(logger='weasyprint', level=None):
         yield messages
     finally:
         logger.handlers = previous_handlers
-        logger.level = previous_level
+        logger.setLevel(previous_level)


### PR DESCRIPTION
This replaces the direct assignment of the logger level in `capture_logs`. This causes an issue due to internal caching in the logging module, which is not refreshed when assigning directly.