### PR TITLE
Align png emojis to the surrounding text

### DIFF
--- a/weasyprint/draw/text.py
+++ b/weasyprint/draw/text.py
@@ -235,7 +235,7 @@ def draw_first_line(stream, textbox, text_overflow, block_ellipsis, matrix):
                     pango.pango_font_get_glyph_extents(
                         pango_font, glyph, stream.ink_rect,
                         stream.logical_rect)
-                    f = -stream.logical_rect.y - stream.logical_rect.height
+                    f = -stream.logical_rect.y
                     f = f * FROM_UNITS / font_size - font_size
                     emojis.append([image, font, a, d, x_advance, f])
 


### PR DESCRIPTION
Fixes #2355.

This solution was arrived at experimentally. Although I have read the code briefly, I don't completely understand why `stream.logical_rect.height` was ever involved in the vertical offset.

Before:
<img width="174" alt="Screenshot 2025-01-21 at 5 23 48 AM" src="https://github.com/user-attachments/assets/d382f2f7-43dd-421f-b383-345bf929f4bc" />
After:
<img width="158" alt="after" src="https://github.com/user-attachments/assets/76cf8e10-cf79-475f-a074-04f6d4e898ac" />