### PR TITLE
Improve text layout heuristics and use layout log attributes

### DIFF
--- a/weasyprint/text/ffi.py
+++ b/weasyprint/text/ffi.py
@@ -272,6 +272,8 @@ ffi.cdef('''
     void pango_layout_line_get_extents (
         PangoLayoutLine *line, PangoRectangle *ink_rect, PangoRectangle *logical_rect);
     PangoLayoutLine * pango_layout_get_line_readonly (PangoLayout *layout, int line);
+    const PangoLogAttr* pango_layout_get_log_attrs_readonly (
+        PangoLayout* layout, gint* n_attrs);
 
     hb_font_t * pango_font_get_hb_font (PangoFont *font);
 


### PR DESCRIPTION
This change gives amazing speeding results with long texts. We can expect an overall 5~10% speedup for documents with a lot of text, and 90% (10× faster) for very long walls of plain text, such as WeasyPerf’s Raw JSON sample.

Fix #2347.