### PR TITLE
allow no output filename

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -355,6 +355,9 @@ def test_command_line_render(tmp_path):
         _run('combined.html out2.pdf')
         assert (tmp_path / 'out2.pdf').read_bytes() == pdf_bytes
 
+        _run('combined.html')
+        assert (tmp_path / 'combined.html.pdf').read_bytes() == pdf_bytes
+
         _run('combined-UTF-16BE.html out3.pdf --encoding UTF-16BE')
         assert (tmp_path / 'out3.pdf').read_bytes() == pdf_bytes
 

--- a/weasyprint/__main__.py
+++ b/weasyprint/__main__.py
@@ -67,7 +67,8 @@ PARSER = Parser(prog='weasyprint', description='Render web pages to PDF.')
 PARSER.add_argument(
     'input', help='URL or filename of the HTML input, or - for stdin')
 PARSER.add_argument(
-    'output', help='filename where output is written, or - for stdout')
+    'output', help='filename where output is written, or - for stdout',
+    nargs="?", default=None)
 PARSER.add_argument(
     '-e', '--encoding', help='force the input character encoding')
 PARSER.add_argument(
@@ -161,6 +162,8 @@ def main(argv=None, stdout=None, stdin=None, HTML=HTML):  # noqa: N803
 
     if args.output == '-':
         output = stdout or sys.stdout.buffer
+    elif args.output is None and args.input != '-':
+        output = args.input + '.pdf'
     else:
         output = args.output
 


### PR DESCRIPTION
Allow to call weasyprint CLI without output filename. The default output filename is input filename followed by `.pdf`.

(Everytime I use weasyprint, I forget to provide output filename…)