### PR TITLE
Migrate to modern Python Logger API

### DIFF
--- a/weasyprint/pdf/stream.py
+++ b/weasyprint/pdf/stream.py
@@ -105,7 +105,7 @@ class Stream(pydyf.Stream):
             lightness, a, b = color.to('lab').coordinates
             self.set_color_special(None, stroke, lightness, a, b)
         else:
-            LOGGER.warn('Unsupported color space %s, use sRGB instead', color.space)
+            LOGGER.warning('Unsupported color space %s, use sRGB instead', color.space)
             self.set_color_rgb(*channels, stroke)
 
     def set_font_size(self, font, size):


### PR DESCRIPTION
# PR Summary
This PR resolves the deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```