### PR TITLE
Include out-of-flow boxes in page layout progress

### DIFF
--- a/tests/draw/test_float.py
+++ b/tests/draw/test_float.py
@@ -833,3 +833,39 @@ def test_float_split_15(assert_pixels):
           a a
         </div>
         <div>bbbbb bbbbb bbbbb bbbbb bbbbb</div>''')
+
+
+@assert_no_logs
+def test_float_split_clear(assert_pixels):
+    assert_pixels('''
+        BBBB
+        BBBB
+        BBBB
+        BBBB
+        BBBB
+        BBBB
+        BBBB
+        BBBB
+        BBBB
+        BBBB
+        rrrr
+        rrrr
+    ''', '''
+        <style>
+            @page {
+                size: 4px;
+            }
+            body {
+                color: red;
+                font: 2px / 1 weasyprint;
+            }
+            div {
+                color: blue;
+                float: left;
+            }
+            article {
+                clear: left;
+            }
+        </style>
+        <div>bb bb bb bb bb</div>
+        <article>aa</article>''')

--- a/weasyprint/formatting_structure/boxes.py
+++ b/weasyprint/formatting_structure/boxes.py
@@ -81,6 +81,7 @@ class Box:
     footnote = None
     cached_counter_values = None
     missing_link = None
+    force_fragmentation = False
 
     # Default, overriden on some subclasses
     def all_children(self):

--- a/weasyprint/layout/block.py
+++ b/weasyprint/layout/block.py
@@ -768,7 +768,7 @@ def block_container_layout(context, box, bottom_space, skip_stack,
     else:
         resume_at = None
 
-    box_is_fragmented = resume_at is not None
+    box_is_fragmented = resume_at is not None or box.force_fragmentation
     if box.style['continue'] == 'discard':
         resume_at = None
 


### PR DESCRIPTION
The current way of breaking pages separates in-flow and out-of-flow boxes, maybe we could merge all the flows together in the future, even if it could cause other problems when broken out-of-flow containers are already fully drawn.

Fix #2459.