### PR TITLE
Preserve page groups during layout repagination

### DIFF
--- a/tests/layout/test_page.py
+++ b/tests/layout/test_page.py
@@ -1036,6 +1036,34 @@ def test_page_groups_first_nth():
         assert (page.width, page.height) == (50, 50)
     assert (page4.width, page4.height) == (100, 100)
 
+@assert_no_logs
+def test_page_groups_counters():
+    # Regression test for #2485.
+    pages = render_pages('''
+      <style>
+        html { counter-reset: h1-counter }
+        h1 { page-break-before: always; counter-increment: h1-counter; }
+        div.main-content { page: main-content-page-group; break-before: page; }
+        @page { size: 1000px }
+        @page :nth(1 of main-content-page-group) { counter-reset: page 1; size: 500px; }
+        a::after { content: target-counter(attr(href), h1-counter) '.' target-counter(attr(href), page); }
+      </style>
+      <html>
+      <body>
+        INTRO PAGE
+        <div class="main-content">
+        <h1 id="t2">First title</h1>
+        <h1>Title3</h1>
+        <a href="#t2">Second title</a>
+        </div>
+      </body>
+      </html>
+    ''')
+    page1, page2, page3  = pages
+    assert (page1.width, page1.height) == (1000, 1000)
+    assert (page2.width, page2.height) == (500, 500)
+    assert (page3.width, page3.height) == (1000, 1000)
+
 
 @assert_no_logs
 @pytest.mark.parametrize('style, line_counts', (

--- a/weasyprint/layout/__init__.py
+++ b/weasyprint/layout/__init__.py
@@ -117,6 +117,7 @@ def layout_document(html, root_box, context, max_loops=8):
     pages = []
     original_footnotes = []
     actual_total_pages = 0
+    page_groups = []
 
     for loop in range(max_loops):
         if loop > 0:
@@ -127,7 +128,7 @@ def layout_document(html, root_box, context, max_loops=8):
         initial_total_pages = actual_total_pages
         if loop == 0:
             original_footnotes = context.footnotes.copy()
-        pages = list(make_all_pages(context, root_box, html, pages))
+        pages = list(make_all_pages(context, root_box, html, pages, page_groups))
         actual_total_pages = len(pages)
 
         # Check whether another round is required

--- a/weasyprint/layout/page.py
+++ b/weasyprint/layout/page.py
@@ -971,7 +971,7 @@ def remake_page(index, page_groups, context, root_box, html):
     return page, resume_at
 
 
-def make_all_pages(context, root_box, html, pages):
+def make_all_pages(context, root_box, html, pages, page_groups):
     """Return a list of laid out pages without margin boxes.
 
     Re-make pages only if necessary.
@@ -979,7 +979,6 @@ def make_all_pages(context, root_box, html, pages):
     """
     i = 0
     reported_footnotes = None
-    page_groups = []
     while True:
         remake_state = context.page_maker[i][-1]
         if (len(pages) == 0 or


### PR DESCRIPTION
The page groups are not preserved during layout repagination.
If a counter is reset in a page group with `nth`, the reset might happen multiple times.

Fix #2429.