### PR TITLE
Add shared cache for cli usage

### DIFF
--- a/weasyprint/__init__.py
+++ b/weasyprint/__init__.py
@@ -84,6 +84,7 @@ DEFAULT_OPTIONS = {
     'full_fonts': False,
     'hinting': False,
     'cache': None,
+    'shared_cache': False,
 }
 
 __all__ = [

--- a/weasyprint/__main__.py
+++ b/weasyprint/__main__.py
@@ -120,6 +120,9 @@ PARSER.add_argument(
     help='store cache on disk instead of memory, folder is '
     'created if needed and cleaned after the PDF is generated')
 PARSER.add_argument(
+    '--shared-cache', action='store_true',
+    help='keep the cache folder after PDF generation for sharing between multiple runs (only works with --cache-folder)')
+PARSER.add_argument(
     '-D', '--dpi', type=int,
     help='set maximum resolution of images embedded in the PDF')
 PARSER.add_argument(
@@ -172,6 +175,7 @@ def main(argv=None, stdout=None, stdin=None, HTML=HTML):  # noqa: N803
 
     options = {
         key: value for key, value in vars(args).items() if key in DEFAULT_OPTIONS}
+    options['shared_cache'] = args.shared_cache
 
     # Default to logging to stderr.
     if args.debug:


### PR DESCRIPTION
Add `--shared-cache` parameter to preserve image cache across multiple PDF generations. Only works together with `--cache-folder`.

### Problem
When using WeasyPrint from the CLI with image caching enabled, the cache is automatically cleared after each PDF is created. This behavior forces images to be re-downloaded for every PDF generation, which is inefficient when creating multiple PDFs that share common images.

### Proposed Solution

Add a new `--shared-cache` CLI parameter that allows users to manually manage cache persistence. When this flag is used, the image cache will be preserved after PDF creation, enabling reuse across multiple PDF generations.

External system will be responsible for reseting/removing cached files.

###  Implementation Details

The new parameter is opt-in and does not affect existing behavior
When `--shared-cache` is not specified, the current cache-clearing behavior is maintained
This change only affects CLI usage; Python script usage remains unchanged
Users can manually manage cache lifecycle when needed

### Benefits

- Improved performance when generating multiple PDFs with shared images
- Reduced bandwidth usage and faster generation times
- Backward compatibility maintained
- Provides flexibility for different use cases

### Usage Example

```bash
# Generate multiple PDFs while preserving cache
weasyprint --shared-cache --cache-folder "/tmp/cache" input1.html output1.pdf
weasyprint --shared-cache --cache-folder "/tmp/cache" input2.html output2.pdf
weasyprint --shared-cache --cache-folder "/tmp/cache" input3.html output3.pdf
```
This enhancement provides better control over caching behavior while maintaining full backward compatibility with existing workflows.