### PR TITLE
Use pattern matching instead of scan-time edits for @font-face rules

### DIFF
--- a/weasyprint/text/fonts.py
+++ b/weasyprint/text/fonts.py
@@ -188,23 +188,25 @@ class FontConfiguration:
             # Create Fontconfig XML config file.
             mode = 'assign_replace'
             root = Element('fontconfig')
-            match = SubElement(root, 'match', target='scan')
-            test = SubElement(match, 'test', name='file', compare='eq')
-            SubElement(test, 'string').text = str(font_path)
-            edit = SubElement(match, 'edit', name='family', mode=mode)
-            SubElement(edit, 'string').text = rule_descriptors['font_family']
+
+            match = SubElement(root, 'match', target='pattern')
+            test = SubElement(match, 'test', name='family', compare='eq')
+            SubElement(test, 'string').text = rule_descriptors['font_family']
             if 'font_style' in rule_descriptors:
-                edit = SubElement(match, 'edit', name='slant', mode=mode)
+                test = SubElement(match, 'test', name='slant', compare='eq')
                 text = FONTCONFIG_STYLE[rule_descriptors['font_style']]
-                SubElement(edit, 'const').text = text
+                SubElement(test, 'const').text = text
             if 'font_weight' in rule_descriptors:
-                edit = SubElement(match, 'edit', name='weight', mode=mode)
+                test = SubElement(match, 'test', name='weight', compare='eq')
                 integer = FONTCONFIG_WEIGHT[rule_descriptors['font_weight']]
-                SubElement(edit, 'int').text = str(integer)
+                SubElement(test, 'int').text = str(integer)
             if 'font_stretch' in rule_descriptors:
-                edit = SubElement(match, 'edit', name='width', mode=mode)
+                test = SubElement(match, 'test', name='width', compare='eq')
                 text = FONTCONFIG_STRETCH[rule_descriptors['font_stretch']]
-                SubElement(edit, 'const').text = text
+                SubElement(test, 'const').text = text
+            edit = SubElement(match, 'edit', name='file', mode=mode)
+            SubElement(edit, 'string').text = str(font_path)
+
             match = SubElement(root, 'match', target='font')
             test = SubElement(match, 'test', name='file', compare='eq')
             SubElement(test, 'string').text = str(font_path)
@@ -225,6 +227,7 @@ class FontConfiguration:
                     range_ = SubElement(charset, 'range')
                     for value in (unicode_range.start, unicode_range.end):
                         SubElement(range_, 'int').text = f'0x{value:x}'
+
             header = (
                 b'<?xml version="1.0"?>',
                 b'<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">')


### PR DESCRIPTION
The logic is equivalent, but Pango seems to like this solution better. It also ensures that the font is used instead of using a system font with the same name.

There are 2 problems left with this solution:
- we don’t change the family name of the font, so the font in the PDF has the original name of the font (that’s why one test fails),
- we don’t mask the original name of the font for pattern matching, so it’s still possible to reference an `@font-face` font with `font-family: Original Font Family` (that is the case before this PR too).

These two problems could go away with extra FontConfig configuration lines, but they currently make Pango crash.

It’s just a draft for now, not ready for production. But feedback would be really appreciated for anyone who uses `@font-face` rules.

Fix #1073, fix #2507.