### PR TITLE
Fix: Add support for color-hint in CSS gradients

### DIFF
--- a/weasyprint/css/utils.py
+++ b/weasyprint/css/utils.py
@@ -622,8 +622,8 @@ def get_image(token, base_url):
     name = token.lower_name
     if name in ('linear-gradient', 'repeating-linear-gradient'):
         direction, color_stops = parse_linear_gradient_parameters(arguments)
-        color_stops, color_hint = get_color_stop_and_hint(color_stops)
         if color_stops:
+            color_stops, color_hint = get_color_stop_and_hint(color_stops)
             return 'linear-gradient', LinearGradient(
                 [parse_color_stop(stop) for stop in color_stops],
                 direction, 'repeating' in name,

--- a/weasyprint/css/utils.py
+++ b/weasyprint/css/utils.py
@@ -5,6 +5,7 @@ import math
 from abc import ABC, abstractmethod
 from urllib.parse import unquote, urljoin
 
+from tinycss2.ast import PercentageToken
 from tinycss2.color4 import parse_color
 
 from .. import LOGGER

--- a/weasyprint/css/utils.py
+++ b/weasyprint/css/utils.py
@@ -620,11 +620,13 @@ def get_image(token, base_url):
     arguments = split_on_comma(remove_whitespace(token.arguments))
     name = token.lower_name
     if name in ('linear-gradient', 'repeating-linear-gradient'):
-        direction, color_stops = parse_linear_gradient_parameters(arguments)
+        direction, color_stops, color_hint = parse_linear_gradient_parameters(arguments)
+        color_stops, color_hint = get_color_stop_and_hint(color_stops)
         if color_stops:
             return 'linear-gradient', LinearGradient(
                 [parse_color_stop(stop) for stop in color_stops],
-                direction, 'repeating' in name)
+                direction, 'repeating' in name,
+                color_hint = [get_length(hint, negative=False, percentage=True) for hint in color_hint])
     elif name in ('radial-gradient', 'repeating-radial-gradient'):
         result = parse_radial_gradient_parameters(arguments)
         if result is not None:
@@ -635,9 +637,12 @@ def get_image(token, base_url):
             position = 'left', FIFTY_PERCENT, 'top', FIFTY_PERCENT
             color_stops = arguments
         if color_stops:
+            color_stops, color_hint = get_color_stop_and_hint(color_stops)
             return 'radial-gradient', RadialGradient(
                 [parse_color_stop(stop) for stop in color_stops],
-                shape, size, position, 'repeating' in name)
+                shape, size, position, 'repeating' in name,
+                color_hint=[get_length(hint, negative=False, percentage=True) for hint in color_hint]
+            )
 
 
 def _get_url_tuple(string, base_url):

--- a/weasyprint/css/utils.py
+++ b/weasyprint/css/utils.py
@@ -228,6 +228,24 @@ def get_single_keyword(tokens):
             return token.lower_value
 
 
+def get_color_stop_and_hint(color_stop_hint):
+    color_stop = [color_stop_hint[0]]
+    color_hint = []
+    prev_was_color_stop = True
+
+    for arg in color_stop_hint[1:]:
+        if len(arg) == 1 and arg[0].type == 'percentage':
+            color_hint.append(arg[0])
+            prev_was_color_stop = False
+        elif prev_was_color_stop:
+            color_hint.append(PercentageToken(arg[-1].source_line, arg[-1].source_column, 50.0, 50, str(50)))
+            color_stop.append(arg)
+            prev_was_color_stop = True
+        else:
+            color_stop.append(arg)
+    return color_stop, color_hint
+
+
 def single_keyword(function):
     """Decorator for validators that only accept a single keyword."""
     @functools.wraps(function)

--- a/weasyprint/css/utils.py
+++ b/weasyprint/css/utils.py
@@ -621,7 +621,7 @@ def get_image(token, base_url):
     arguments = split_on_comma(remove_whitespace(token.arguments))
     name = token.lower_name
     if name in ('linear-gradient', 'repeating-linear-gradient'):
-        direction, color_stops, color_hint = parse_linear_gradient_parameters(arguments)
+        direction, color_stops = parse_linear_gradient_parameters(arguments)
         color_stops, color_hint = get_color_stop_and_hint(color_stops)
         if color_stops:
             return 'linear-gradient', LinearGradient(

--- a/weasyprint/images.py
+++ b/weasyprint/images.py
@@ -466,12 +466,14 @@ def gradient_average_color(colors, positions):
 
 
 class Gradient:
-    def __init__(self, color_stops, repeating):
+    def __init__(self, color_stops, repeating, color_hint=None):
         assert color_stops
         # List of (r, g, b, a)
         self.colors = tuple(color for color, _ in color_stops)
         # List of Dimensions
         self.stop_positions = tuple(position for _, position in color_stops)
+        # List of Dimensions
+        self.color_hint = color_hint
         # Boolean
         self.repeating = repeating
 
@@ -565,8 +567,8 @@ class Gradient:
 
 
 class LinearGradient(Gradient):
-    def __init__(self, color_stops, direction, repeating):
-        Gradient.__init__(self, color_stops, repeating)
+    def __init__(self, color_stops, direction, repeating, color_hint=None):
+        Gradient.__init__(self, color_stops, repeating, color_hint)
         # ('corner', keyword) or ('angle', radians)
         self.direction_type, self.direction = direction
 
@@ -656,8 +658,8 @@ class LinearGradient(Gradient):
 
 
 class RadialGradient(Gradient):
-    def __init__(self, color_stops, shape, size, center, repeating):
-        Gradient.__init__(self, color_stops, repeating)
+    def __init__(self, color_stops, shape, size, center, repeating, color_hint=None):
+        Gradient.__init__(self, color_stops, repeating, color_hint)
         # Center of the ending shape. (origin_x, pos_x, origin_y, pos_y)
         self.center = center
         # Type of ending shape: 'circle' or 'ellipse'

--- a/weasyprint/images.py
+++ b/weasyprint/images.py
@@ -491,9 +491,15 @@ class Gradient:
             return
 
         alphas = [color[3] for color in colors]
-        alpha_couples = [
-            (alphas[i], alphas[i + 1])
-            for i in range(len(alphas) - 1)]
+        if self.color_hint:
+            alpha_couples = [
+                (alphas[i] * (self.color_hint[i][0] / 100), alphas[i + 1] * (1 - self.color_hint[i][0] / 100) )
+                for hint_i, i in enumerate(range(len(alphas) - 1))]
+        # Todo: remove else block
+        else:
+            alpha_couples = [
+                (alphas[i], alphas[i + 1])
+                for i in range(len(alphas) - 1)]
         # TODO: handle other color spaces.
         color_couples = [
             [colors[i].to('srgb')[:3], colors[i + 1].to('srgb')[:3], 1]
@@ -530,6 +536,7 @@ class Gradient:
                 0, 0, concrete_width, concrete_height)
 
             shading_type = 2 if type_ == 'linear' else 3
+            # Todo: the static value 1 has to respect color_hint
             sub_functions = (
                 stream.create_interpolation_function((0, 1), (c0,), (c1,), 1)
                 for c0, c1 in alpha_couples)


### PR DESCRIPTION
This pull request resolves the issue where the parser fails to recognize the color-hint syntax in CSS gradient definitions.

As noted in the original issue, the current parser expects every comma separated item in a gradient's stop list to be a full color stop. It throws an error when it encounters a color hint, which is a percentage value used to control the transition midpoint between two color-stops.

It is still a draft, need to add test cases, review is needed

Fixes #1961 