### PR TITLE
Remove Subtype key for font descriptor

### DIFF
--- a/weasyprint/pdf/fonts.py
+++ b/weasyprint/pdf/fonts.py
@@ -566,8 +566,6 @@ def _build_vector_font_dictionary(font_dictionary, pdf, font, widths, compress,
             compress=compress)
         pdf.add_object(stream)
         font_descriptor['CIDSet'] = stream.reference
-    if font.type == 'otf':
-        font_descriptor['Subtype'] = '/OpenType'
     pdf.add_object(font_descriptor)
 
     pdf_widths = pydyf.Array()


### PR DESCRIPTION
It’s not in the PDF specification and has been there since we use pydyf.

Fix unicode-org/core-spec#499.