### PR TITLE
fix TypeError: 'NoneType' object is not iterable for arguments.extend(resolve_var())

### DIFF
--- a/tests/css/test_variables.py
+++ b/tests/css/test_variables.py
@@ -604,3 +604,21 @@ def test_variable_in_function_in_variable():
     assert div1.children[0].children[0].children[0].text == 'I'
     assert div2.children[0].children[0].children[0].text == 'II'
     assert div3.children[0].children[0].children[0].text == 'iii'
+
+
+@assert_no_logs
+def test_variable_and_function_in_function():
+    page, = render_pages('''
+      <style>
+        html { --counter-name: page }
+        a::after { content: target-counter(attr(href), var(--counter-name)) }
+      </style>
+      <a id="link" href="#link"></a>
+    ''')
+    html, = page.children
+    body, = html.children
+    line, = body.children
+    a, _ = line.children
+    after, = a.children
+    textbox, = after.children
+    assert textbox.text == '1'

--- a/weasyprint/css/__init__.py
+++ b/weasyprint/css/__init__.py
@@ -585,8 +585,14 @@ def resolve_var(computed, token, parent_style, known_variables=None):
         arguments = []
         for i, argument in enumerate(token.arguments):
             if argument.type == 'function':
-                arguments.extend(resolve_var(
-                    computed, argument, parent_style, known_variables))
+                # arguments.extend(resolve_var(
+                #     computed, argument, parent_style, known_variables))
+                # fix arguments.extend(resolve_var(
+                # TypeError: 'NoneType' object is not iterable
+                resolved_var = resolve_var(
+                    computed, argument, parent_style, known_variables)
+                if resolved_var:
+                    arguments.extend(resolved_var)
             else:
                 arguments.append(argument)
         token = tinycss2.ast.FunctionBlock(

--- a/weasyprint/css/__init__.py
+++ b/weasyprint/css/__init__.py
@@ -585,14 +585,9 @@ def resolve_var(computed, token, parent_style, known_variables=None):
         arguments = []
         for i, argument in enumerate(token.arguments):
             if argument.type == 'function':
-                # arguments.extend(resolve_var(
-                #     computed, argument, parent_style, known_variables))
-                # fix arguments.extend(resolve_var(
-                # TypeError: 'NoneType' object is not iterable
-                resolved_var = resolve_var(
+                resolved = resolve_var(
                     computed, argument, parent_style, known_variables)
-                if resolved_var:
-                    arguments.extend(resolved_var)
+                arguments.extend((argument,) if resolved is None else resolved)
             else:
                 arguments.append(argument)
         token = tinycss2.ast.FunctionBlock(


### PR DESCRIPTION
I get TypeError: 'NoneType' object is not iterable when running arguments.extend(resolve_var()) in css/__init__.py.
i add a check for the result of resolve_var(). now it works.