### PR TITLE
Fix functions

### DIFF
--- a/tests/css/test_fonts.py
+++ b/tests/css/test_fonts.py
@@ -6,7 +6,7 @@ import pytest
 
 from weasyprint import CSS
 from weasyprint.css import get_all_computed_styles
-from weasyprint.css.computed_values import strut_layout
+from weasyprint.text.line_break import strut
 
 from ..testing_utils import FakeHTML, assert_no_logs, render_pages
 
@@ -64,10 +64,10 @@ def test_line_height_inheritance():
     assert html.style['font_size'] == 10
     assert div.style['font_size'] == 20
     # 140% of 10px = 14px is inherited from html
-    assert strut_layout(div.style)[0] == 14
+    assert strut(div.style)[0] == 14
     assert div.style['vertical_align'] == 7  # 50 % of 14px
 
     assert paragraph.style['font_size'] == 20
     # 1.4 is inherited from p, 1.4 * 20px on em = 28px
-    assert strut_layout(paragraph.style)[0] == 28
+    assert strut(paragraph.style)[0] == 28
     assert paragraph.style['vertical_align'] == 14  # 50% of 28px

--- a/tests/css/test_target.py
+++ b/tests/css/test_target.py
@@ -10,7 +10,7 @@ def test_target_counter():
         div:first-child { counter-reset: div }
         div { counter-increment: div }
         #id1::before { content: target-counter('#id4', div) }
-        #id2::before { content: 'test ' target-counter('#id1' div) }
+        #id2::before { content: 'test ' target-counter('#id1', div) }
         #id3::before { content: target-counter(url(#id4), div, lower-roman) }
         #id4::before { content: target-counter('#id3', div) }
       </style>

--- a/tests/css/test_validation.py
+++ b/tests/css/test_validation.py
@@ -76,8 +76,7 @@ def test_empty_property_value(prop):
 @assert_no_logs
 @pytest.mark.parametrize('rule, value', (
     ('1px, 3em, auto, auto', ((1, 'px'), (3, 'em'), 'auto', 'auto')),
-    ('1px, 3em, auto auto', ((1, 'px'), (3, 'em'), 'auto', 'auto')),
-    ('1px 3em auto 1px', ((1, 'px'), (3, 'em'), 'auto', (1, 'px'))),
+    ('1px,3em,auto,1px', ((1, 'px'), (3, 'em'), 'auto', (1, 'px'))),
 ))
 def test_clip(rule, value):
     assert get_value(f'clip: rect({rule})') == value
@@ -86,6 +85,7 @@ def test_clip(rule, value):
 @assert_no_logs
 @pytest.mark.parametrize('rule', (
     'clip: square(1px, 3em, auto, auto)',
+    'clip: rect(1px 3em auto auto)',
     'clip: rect(1px, 3em, auto)',
     'clip: rect(1px, 3em / auto)',
 ))
@@ -199,7 +199,6 @@ def test_size_invalid(rule):
     ('translate(-4px, 0)', (('translate', ((-4, 'px'), (0, None))),)),
     ('translate(6px, 20%)', (('translate', ((6, 'px'), (20, '%'))),)),
     ('scale(2)', (('scale', (2, 2)),)),
-    ('translate(6px 20%)', (('translate', ((6, 'px'), (20, '%'))),)),
 ))
 def test_transform(rule, value):
     assert get_value(f'transform: {rule}') == value
@@ -211,6 +210,7 @@ def test_transform(rule, value):
     'foo',
     'scale(2) foo',
     '6px',
+    'translate(6px 20%)',
 ))
 def test_transform_invalid(rule):
     assert_invalid(f'transform: {rule}')
@@ -637,7 +637,6 @@ def test_string_set(rule, value):
     'test test1',
     'test content(test)',
     'test unknown()',
-    'test attr(id, class)',
 ))
 def test_string_set_invalid(rule):
     assert_invalid(f'string-set: {rule}')

--- a/tests/draw/test_background.py
+++ b/tests/draw/test_background.py
@@ -599,7 +599,7 @@ def test_background_transform(assert_pixels):
         body { position: absolute;
                width: 5px; height: 5px;
                top: -5px; left: -5px;
-               transform: translate(6px 6px);
+               transform: translate(6px,6px);
                background: red }
       </style>
       <body>''')

--- a/tests/layout/test_page.py
+++ b/tests/layout/test_page.py
@@ -1589,7 +1589,7 @@ def test_running_elements(argument, texts):
         @page {
           margin: 50px;
           size: 200px;
-          @bottom-center { content: element(title %s) }
+          @bottom-center { content: element(title, %s) }
         }
         article { break-after: page }
         h1 { position: running(title) }

--- a/weasyprint/css/__init__.py
+++ b/weasyprint/css/__init__.py
@@ -592,13 +592,16 @@ def resolve_var(computed, token, parent_style, known_variables=None):
             token.source_line, token.source_column, token.name, arguments)
         return resolve_var(computed, token, parent_style, known_variables) or (token,)
 
-    args = parse_function(token)[1]
-    variable_name = args.pop(0).value.replace('-', '_')  # first arg is name
+    function = parse_function(token)
+    args = function.split_comma(single_tokens=False, trailing=True)
+    if not args or len(args[0]) != 1:
+        return []
+    variable_name = args[0][0].value.replace('-', '_')  # first arg is name
     if variable_name in known_variables:
-        return []  # endless recursion, returned value is nothing
+        return []  # endless recursion
     else:
         known_variables.add(variable_name)
-    default = args  # next args are default value
+    default = args[1] if len(args) > 1 else []
     computed_value = []
     for value in (computed[variable_name] or default):
         resolved = resolve_var(computed, value, parent_style, known_variables)

--- a/weasyprint/css/__init__.py
+++ b/weasyprint/css/__init__.py
@@ -26,13 +26,11 @@ from ..logger import LOGGER, PROGRESS_LOGGER
 from ..urls import URLFetchingError, get_url_attribute, url_join
 from . import counters, media_queries
 from .computed_values import COMPUTER_FUNCTIONS
+from .functions import check_var, parse_function
 from .properties import INHERITED, INITIAL_NOT_COMPUTED, INITIAL_VALUES, ZERO_PIXELS
+from .tokens import InvalidValues, Pending, get_url, remove_whitespace
 from .validation import preprocess_declarations
 from .validation.descriptors import preprocess_descriptors
-
-from .utils import (  # isort:skip
-    InvalidValues, Pending, check_var_function, get_url, parse_function,
-    remove_whitespace)
 
 # Reject anything not in here:
 PSEUDO_ELEMENTS = (
@@ -575,7 +573,7 @@ def declaration_precedence(origin, importance):
 
 def resolve_var(computed, token, parent_style, known_variables=None):
     """Return token with resolved CSS variables."""
-    if not check_var_function(token):
+    if not check_var(token):
         return
 
     if known_variables is None:

--- a/weasyprint/css/computed_values.py
+++ b/weasyprint/css/computed_values.py
@@ -1,16 +1,15 @@
 """Convert specified property values into computed values."""
 
 from math import pi
-from urllib.parse import unquote
 
 from tinycss2.color4 import parse_color
 
 from ..logger import LOGGER
 from ..text.ffi import FROM_UNITS, ffi, pango
 from ..text.line_break import Layout, first_line_metrics
-from ..urls import get_link_attribute
+from ..urls import get_link_attribute, get_url_tuple
 from .properties import INITIAL_VALUES, ZERO_PIXELS, Dimension
-from .utils import ANGLE_TO_RADIANS, LENGTH_UNITS, LENGTHS_TO_PIXELS, safe_urljoin
+from .units import ANGLE_TO_RADIANS, LENGTH_UNITS, LENGTHS_TO_PIXELS
 
 # Value in pixels of font-size for <absolute-size> keywords: 12pt (16px) for
 # medium, and scaling factors given in CSS3 for others:
@@ -172,11 +171,7 @@ def compute_attr(style, values):
         if type_or_unit == 'string':
             pass  # Keep the string
         elif type_or_unit == 'url':
-            if attr_value.startswith('#'):
-                attr_value = ('internal', unquote(attr_value[1:]))
-            else:
-                attr_value = (
-                    'external', safe_urljoin(style.base_url, attr_value))
+            attr_value = get_url_tuple(attr_value, style.base_url)
         elif type_or_unit == 'color':
             attr_value = parse_color(attr_value.strip())
         elif type_or_unit == 'integer':

--- a/weasyprint/css/computed_values.py
+++ b/weasyprint/css/computed_values.py
@@ -5,11 +5,10 @@ from math import pi
 from tinycss2.color4 import parse_color
 
 from ..logger import LOGGER
-from ..text.ffi import FROM_UNITS, ffi, pango
-from ..text.line_break import Layout, first_line_metrics
+from ..text.line_break import strut
 from ..urls import get_link_attribute, get_url_tuple
 from .properties import INITIAL_VALUES, ZERO_PIXELS, Dimension
-from .units import ANGLE_TO_RADIANS, LENGTH_UNITS, LENGTHS_TO_PIXELS
+from .units import ANGLE_TO_RADIANS, LENGTH_UNITS, to_pixels
 
 # Value in pixels of font-size for <absolute-size> keywords: 12pt (16px) for
 # medium, and scaling factors given in CSS3 for others:
@@ -120,34 +119,11 @@ PAGE_SIZES = {
 assert all(width.value < height.value for width, height in PAGE_SIZES.values())
 
 INITIAL_PAGE_SIZE = PAGE_SIZES['a4']
-INITIAL_VALUES['size'] = tuple(
-    size.value * LENGTHS_TO_PIXELS[size.unit] for size in INITIAL_PAGE_SIZE)
+INITIAL_VALUES['size'] = tuple(to_pixels(size) for size in INITIAL_PAGE_SIZE)
 
 
 # Maps property names to functions returning the computed values
 COMPUTER_FUNCTIONS = {}
-
-
-def _font_style_cache_key(style, include_size=False):
-    key = str((
-        style['font_family'],
-        style['font_style'],
-        style['font_stretch'],
-        style['font_weight'],
-        style['font_variant_ligatures'],
-        style['font_variant_position'],
-        style['font_variant_caps'],
-        style['font_variant_numeric'],
-        style['font_variant_alternates'],
-        style['font_variant_east_asian'],
-        style['font_feature_settings'],
-        style['font_variation_settings'],
-        style['font_language_override'],
-        style['lang'],
-    ))
-    if include_size:
-        key += str(style['font_size']) + str(style['line_height'])
-    return key
 
 
 def register_computer(name):
@@ -268,40 +244,14 @@ def length(style, name, value, font_size=None, pixels_only=False):
     """Compute a length ``value``."""
     if value in ('auto', 'content', 'from-font'):
         return value
-    if value.value == 0:
+    elif value.value == 0:
         return 0 if pixels_only else ZERO_PIXELS
-
-    unit = value.unit
-    if unit == 'px':
-        return value.value if pixels_only else value
-    elif unit in LENGTHS_TO_PIXELS:
-        # Convert absolute lengths to pixels
-        result = value.value * LENGTHS_TO_PIXELS[unit]
-    elif unit in ('em', 'ex', 'ch', 'rem', 'lh', 'rlh'):
-        if font_size is None:
-            font_size = style['font_size']
-        if unit == 'ex':
-            # TODO: use context to use @font-face fonts
-            ratio = character_ratio(style, 'x')
-            result = value.value * font_size * ratio
-        elif unit == 'ch':
-            ratio = character_ratio(style, '0')
-            result = value.value * font_size * ratio
-        elif unit == 'em':
-            result = value.value * font_size
-        elif unit == 'rem':
-            result = value.value * style.root_style['font_size']
-        elif unit == 'lh':
-            line_height, _ = strut_layout(style)
-            result = value.value * line_height
-        elif unit == 'rlh':
-            line_height, _ = strut_layout(style.root_style)
-            result = value.value * line_height
-    else:
+    elif value.unit not in LENGTH_UNITS:
         # A percentage or 'auto': no conversion needed.
         return value
 
-    return result if pixels_only else Dimension(result, 'px')
+    pixels = to_pixels(value, style, font_size)
+    return pixels if pixels_only else Dimension(pixels, 'px')
 
 
 @register_computer('bleed-left')
@@ -745,7 +695,7 @@ def vertical_align(style, name, value):
     elif value == 'sub':
         return style['font_size'] * -0.5
     elif value.unit == '%':
-        height, _ = strut_layout(style)
+        height, _ = strut(style)
         return height * value.value / 100
     else:
         return length(style, name, value, pixels_only=True)
@@ -758,75 +708,3 @@ def word_spacing(style, name, value):
         return 0
     else:
         return length(style, name, value, pixels_only=True)
-
-
-def strut_layout(style, context=None):
-    """Return a tuple of the used value of ``line-height`` and the baseline.
-
-    The baseline is given from the top edge of line height.
-
-    """
-    if style['font_size'] == 0:
-        return 0, 0
-
-    if context:
-        key = _font_style_cache_key(style, include_size=True)
-        if key in context.strut_layouts:
-            return context.strut_layouts[key]
-
-    layout = Layout(context, style)
-    layout.set_text(' ')
-    line, _ = layout.get_first_line()
-    _, _, _, _, text_height, baseline = first_line_metrics(
-        line, '', layout, resume_at=None, space_collapse=False, style=style)
-    if style['line_height'] == 'normal':
-        result = text_height, baseline
-        if context:
-            context.strut_layouts[key] = result
-        return result
-    type_, line_height = style['line_height']
-    if type_ == 'NUMBER':
-        line_height *= style['font_size']
-    result = line_height, baseline + (line_height - text_height) / 2
-    if context:
-        context.strut_layouts[key] = result
-    return result
-
-
-def character_ratio(style, character):
-    """Return the ratio of 1ex/font_size or 1ch/font_size."""
-    # TODO: use context to use @font-face fonts
-
-    assert character in ('x', '0')
-
-    cache = style.cache[f'ratio_{"ex" if character == "x" else "ch"}']
-    cache_key = _font_style_cache_key(style)
-    if cache_key in cache:
-        return cache[cache_key]
-
-    # Avoid recursion for letter-spacing and word-spacing properties
-    style = style.copy()
-    style['letter_spacing'] = 'normal'
-    style['word_spacing'] = 0
-    # Random big value
-    style['font_size'] = 1000
-
-    layout = Layout(context=None, style=style)
-    layout.set_text(character)
-    line, _ = layout.get_first_line()
-
-    ink_extents = ffi.new('PangoRectangle *')
-    logical_extents = ffi.new('PangoRectangle *')
-    pango.pango_layout_line_get_extents(line, ink_extents, logical_extents)
-    if character == 'x':
-        measure = -ink_extents.y * FROM_UNITS
-    else:
-        measure = logical_extents.width * FROM_UNITS
-    ffi.release(ink_extents)
-    ffi.release(logical_extents)
-
-    # Zero means some kind of failure, fallback is 0.5.
-    # We round to try keeping exact values that were altered by Pango.
-    ratio = round(measure / style['font_size'], 5) or 0.5
-    cache[cache_key] = ratio
-    return ratio

--- a/weasyprint/css/computed_values.py
+++ b/weasyprint/css/computed_values.py
@@ -138,7 +138,8 @@ def register_computer(name):
 
 
 def compute_attr(style, values):
-    # TODO: use real token parsing instead of casting with Python types
+    # TODO: use real token parsing instead of casting with Python types, and follow new
+    # syntax. See https://drafts.csswg.org/css-values-5/#attr-notation.
     func_name, value = values
     assert func_name == 'attr()'
     attr_name, type_or_unit, fallback = value
@@ -163,6 +164,8 @@ def compute_attr(style, values):
         elif type_or_unit in ANGLE_TO_RADIANS:
             attr_value = Dimension(float(attr_value.strip()), type_or_unit)
             type_or_unit = 'angle'
+        else:
+            return
     except Exception:
         return
     return (type_or_unit, attr_value)

--- a/weasyprint/css/counters.py
+++ b/weasyprint/css/counters.py
@@ -7,7 +7,7 @@ https://www.w3.org/TR/css-counter-styles-3/#counter-style-system
 
 from math import inf
 
-from .utils import remove_whitespace
+from .tokens import remove_whitespace
 
 
 def symbol(string_or_url):

--- a/weasyprint/css/functions.py
+++ b/weasyprint/css/functions.py
@@ -1,0 +1,165 @@
+"""CSS functions parsers."""
+
+from .properties import Dimension
+from .units import ANGLE_UNITS, LENGTH_UNITS
+
+ATTR_FALLBACKS = {
+    'string': ('string', ''),
+    'color': ('ident', 'currentcolor'),
+    'url': ('external', 'about:invalid'),
+    'integer': ('number', 0),
+    'number': ('number', 0),
+    '%': ('number', 0),
+}
+for unit in LENGTH_UNITS:
+    ATTR_FALLBACKS[unit] = ('length', Dimension('0', unit))
+for unit in ANGLE_UNITS:
+    ATTR_FALLBACKS[unit] = ('angle', Dimension('0', unit))
+
+
+def parse_function(function_token):
+    """Parse functional notation.
+
+    Return ``(name, args)`` if the given token is a function with comma- or
+    space-separated arguments. Return ``None`` otherwise.
+
+    """
+    if function_token.type != 'function':
+        return
+
+    content = list(function_token.arguments)
+    arguments = []
+    last_is_comma = False
+    while content:
+        token = content.pop(0)
+        if token.type in ('whitespace', 'comment'):
+            continue
+        is_comma = token.type == 'literal' and token.value == ','
+        if last_is_comma and is_comma:
+            return
+        if is_comma:
+            last_is_comma = True
+        else:
+            last_is_comma = False
+            if token.type == 'function':
+                argument_function = parse_function(token)
+                if argument_function is None:
+                    return
+            arguments.append(token)
+    if last_is_comma:
+        return
+    return function_token.lower_name, arguments
+
+
+def check_attr(token, allowed_type=None):
+    function = parse_function(token)
+    if function is None:
+        return
+    name, args = function
+    if name == 'attr' and len(args) in (1, 2, 3):
+        if args[0].type != 'ident':
+            return
+        attr_name = args[0].value
+        if len(args) == 1:
+            type_or_unit = 'string'
+            fallback = ''
+        else:
+            if args[1].type != 'ident':
+                return
+            type_or_unit = args[1].value
+            if type_or_unit not in ATTR_FALLBACKS:
+                return
+            if len(args) == 2:
+                fallback = ATTR_FALLBACKS[type_or_unit]
+            else:
+                fallback_type = args[2].type
+                if fallback_type == 'string':
+                    fallback = args[2].value
+                else:
+                    # TODO: handle other fallback types
+                    return
+        if allowed_type in (None, type_or_unit):
+            return ('attr()', (attr_name, type_or_unit, fallback))
+
+
+def check_counter(token, allowed_type=None):
+    from .validation.properties import list_style_type
+
+    function = parse_function(token)
+    if function is None:
+        return
+    name, args = function
+    arguments = []
+    if (name == 'counter' and len(args) in (1, 2)) or (
+            name == 'counters' and len(args) in (2, 3)):
+        ident = args.pop(0)
+        if ident.type != 'ident':
+            return
+        arguments.append(ident.value)
+
+        if name == 'counters':
+            string = args.pop(0)
+            if string.type != 'string':
+                return
+            arguments.append(string.value)
+
+        if args:
+            counter_style = list_style_type((args.pop(0),))
+            if counter_style is None:
+                return
+            arguments.append(counter_style)
+        else:
+            arguments.append('decimal')
+
+        return (f'{name}()', tuple(arguments))
+
+
+def check_content(token):
+    function = parse_function(token)
+    if function is None:
+        return
+    name, args = function
+    if name == 'content':
+        if len(args) == 0:
+            return ('content()', 'text')
+        elif len(args) == 1:
+            ident = args.pop(0)
+            if ident.type == 'ident' and ident.lower_value in (
+                    'text', 'before', 'after', 'first-letter', 'marker'):
+                return ('content()', ident.lower_value)
+
+
+def check_string_or_element(string_or_element, token):
+    function = parse_function(token)
+    if function is None:
+        return
+    name, args = function
+    if name == string_or_element and len(args) in (1, 2):
+        custom_ident = args.pop(0)
+        if custom_ident.type != 'ident':
+            return
+        custom_ident = custom_ident.value
+
+        if args:
+            ident = args.pop(0)
+            if ident.type != 'ident' or ident.lower_value not in (
+                    'first', 'start', 'last', 'first-except'):
+                return
+            ident = ident.lower_value
+        else:
+            ident = 'first'
+
+        return (f'{string_or_element}()', (custom_ident, ident))
+
+
+def check_var(token):
+    if function := parse_function(token):
+        name, args = function
+        if name == 'var' and args:
+            ident = args.pop(0)
+            # TODO: we should check authorized tokens
+            # https://drafts.csswg.org/css-syntax-3/#typedef-declaration-value
+            return ident.type == 'ident' and ident.value.startswith('--')
+        for arg in args:
+            if check_var(arg):
+                return True

--- a/weasyprint/css/media_queries.py
+++ b/weasyprint/css/media_queries.py
@@ -7,7 +7,7 @@ https://www.w3.org/TR/mediaqueries-4/
 import tinycss2
 
 from ..logger import LOGGER
-from .utils import remove_whitespace, split_on_comma
+from .tokens import remove_whitespace, split_on_comma
 
 
 def evaluate_media_query(query_list, device_media_type):

--- a/weasyprint/css/tokens.py
+++ b/weasyprint/css/tokens.py
@@ -249,19 +249,6 @@ def split_on_comma(tokens):
     return tuple(parts)
 
 
-def split_on_optional_comma(tokens):
-    """Split a list of tokens on optional commas, ie ``LiteralToken(',')``."""
-    parts = []
-    for split_part in split_on_comma(tokens):
-        if not split_part:
-            # Happens when there's a comma at the beginning, at the end, or
-            # when two commas are next to each other.
-            return
-        for part in split_part:
-            parts.append(part)
-    return parts
-
-
 def remove_whitespace(tokens):
     """Remove any top-level whitespace and comments in a token list."""
     return tuple(
@@ -348,22 +335,22 @@ def get_image(token, base_url):
     """Parse an <image> token."""
     from ..images import LinearGradient, RadialGradient
 
-    parsed_url = get_url(token, base_url)
-    if parsed_url:
+    if parsed_url := get_url(token, base_url):
         assert parsed_url[0] == 'url'
         if parsed_url[1][0] == 'external':
             return 'url', parsed_url[1][1]
-    if token.type != 'function':
+    if not (function := functions.parse_function(token)):
         return
-    arguments = split_on_comma(remove_whitespace(token.arguments))
-    name = token.lower_name
-    if name in ('linear-gradient', 'repeating-linear-gradient'):
+    if not (arguments := function.split_comma(single_tokens=False)):
+        return
+    repeating = function.name.startswith('repeating-')
+    if function.name in ('linear-gradient', 'repeating-linear-gradient'):
         direction, color_stops = parse_linear_gradient_parameters(arguments)
         if color_stops:
             return 'linear-gradient', LinearGradient(
                 [parse_color_stop(stop) for stop in color_stops],
-                direction, 'repeating' in name)
-    elif name in ('radial-gradient', 'repeating-radial-gradient'):
+                direction, repeating)
+    elif function.name in ('radial-gradient', 'repeating-radial-gradient'):
         result = parse_radial_gradient_parameters(arguments)
         if result is not None:
             shape, size, position, color_stops = result
@@ -375,7 +362,7 @@ def get_image(token, base_url):
         if color_stops:
             return 'radial-gradient', RadialGradient(
                 [parse_color_stop(stop) for stop in color_stops],
-                shape, size, position, 'repeating' in name)
+                shape, size, position, repeating)
 
 
 def get_url(token, base_url):
@@ -411,21 +398,19 @@ def get_quote(token):
 
 def get_target(token, base_url):
     """Parse a <target> token."""
-    function = functions.parse_function(token)
-    if function is None:
-        return
-    name, args = function
-    args = split_on_optional_comma(args)
-    if not args:
+    if not (function := functions.parse_function(token)):
         return
 
-    if name == 'target-counter':
+    if not (args := function.split_comma()):
+        return
+
+    if function.name == 'target-counter':
         if len(args) not in (2, 3):
             return
-    elif name == 'target-counters':
+    elif function.name == 'target-counters':
         if len(args) not in (3, 4):
             return
-    elif name == 'target-text':
+    elif function.name == 'target-text':
         if len(args) not in (1, 2):
             return
     else:
@@ -443,16 +428,13 @@ def get_target(token, base_url):
     else:
         values.append(string_link)
 
-    if name.startswith('target-counter'):
-        if not args:
-            return
-
+    if function.name.startswith('target-counter'):
         ident = args.pop(0)
         if ident.type != 'ident':
             return
         values.append(ident.value)
 
-        if name == 'target-counters':
+        if function.name == 'target-counters':
             string = get_string(args.pop(0))
             if string is None:
                 return
@@ -472,7 +454,7 @@ def get_target(token, base_url):
             content = 'content'
         values.append(content)
 
-    return (f'{name}()', tuple(values))
+    return (f'{function.name}()', tuple(values))
 
 
 def get_content_list(tokens, base_url):
@@ -486,11 +468,10 @@ def get_content_list(tokens, base_url):
 
 def get_content_list_token(token, base_url):
     """Parse one of the <content-list> tokens."""
-    # See https://www.w3.org/TR/css-content-3/#typedef-content-list
+    # See https://drafts.csswg.org/css-content-3/#content-values.
 
     # <string>
-    string = get_string(token)
-    if string is not None:
+    if (string := get_string(token)) is not None:
         return string
 
     # contents
@@ -498,27 +479,23 @@ def get_content_list_token(token, base_url):
         return ('content()', 'text')
 
     # <uri>
-    url = get_url(token, base_url)
-    if url is not None:
+    if (url := get_url(token, base_url)) is not None:
         return url
 
     # <quote>
-    quote = get_quote(token)
-    if quote is not None:
+    if (quote := get_quote(token)) is not None:
         return ('quote', quote)
 
     # <target>
-    target = get_target(token, base_url)
-    if target is not None:
+    if (target := get_target(token, base_url)) is not None:
         return target
 
-    function = functions.parse_function(token)
-    if function is None:
+    if (function := functions.parse_function(token)) is None:
         return
-    name, args = function
+    args = function.split_comma()
 
     # <leader()>
-    if name == 'leader':
+    if function.name == 'leader':
         if len(args) != 1:
             return
         arg, = args
@@ -536,7 +513,7 @@ def get_content_list_token(token, base_url):
         return ('leader()', ('string', string))
 
     # <element()>
-    elif name == 'element':
+    elif function.name == 'element':
         return functions.check_string_or_element('element', token)
 
 

--- a/weasyprint/css/units.py
+++ b/weasyprint/css/units.py
@@ -1,0 +1,40 @@
+"""Constants and helpers for units."""
+
+import math
+
+# How many radians is one <unit>?
+# https://drafts.csswg.org/css-values-4/#angles
+ANGLE_TO_RADIANS = {
+    'rad': 1,
+    'turn': 2 * math.pi,
+    'deg': math.pi / 180,
+    'grad': math.pi / 200,
+}
+
+# How many CSS pixels is one <unit>?
+# https://www.w3.org/TR/CSS21/syndata.html#length-units
+LENGTHS_TO_PIXELS = {
+    'px': 1,
+    'pt': 1 / 0.75,
+    'pc': 16,
+    'in': 96,
+    'cm': 96 / 2.54,
+    'mm': 96 / 25.4,
+    'q': 96 / 25.4 / 4,
+}
+
+# How many ddpx is one <unit>?
+# https://drafts.csswg.org/css-values/#resolution
+RESOLUTION_TO_DPPX = {
+    'dppx': 1,
+    'dpi': 1 / LENGTHS_TO_PIXELS['in'],
+    'dpcm': 1 / LENGTHS_TO_PIXELS['cm'],
+}
+
+# Sets of units.
+# https://drafts.csswg.org/css-values-4/#lengths
+FONT_UNITS = {'ex', 'em', 'ch', 'rem', 'lh', 'rlh'}
+ABSOLUTE_UNITS = set(LENGTHS_TO_PIXELS)
+LENGTH_UNITS = ABSOLUTE_UNITS | FONT_UNITS
+# https://drafts.csswg.org/css-values-4/#angles
+ANGLE_UNITS = set(ANGLE_TO_RADIANS)

--- a/weasyprint/css/units.py
+++ b/weasyprint/css/units.py
@@ -2,6 +2,8 @@
 
 import math
 
+from ..text.line_break import character_ratio, strut
+
 # How many radians is one <unit>?
 # https://drafts.csswg.org/css-values-4/#angles
 ANGLE_TO_RADIANS = {
@@ -38,3 +40,33 @@ ABSOLUTE_UNITS = set(LENGTHS_TO_PIXELS)
 LENGTH_UNITS = ABSOLUTE_UNITS | FONT_UNITS
 # https://drafts.csswg.org/css-values-4/#angles
 ANGLE_UNITS = set(ANGLE_TO_RADIANS)
+
+
+def to_pixels(value, style=None, font_size=None):
+    """Get number of pixels corresponding to a length."""
+    if (unit := value.unit) == 'px':
+        return value.value
+    elif unit in LENGTHS_TO_PIXELS:
+        # Convert absolute lengths to pixels
+        return value.value * LENGTHS_TO_PIXELS[unit]
+    elif unit in FONT_UNITS:
+        assert style is not None
+        if font_size is None:
+            font_size = style['font_size']
+        if unit == 'ex':
+            # TODO: use context to use @font-face fonts
+            ratio = character_ratio(style, 'x')
+            return value.value * font_size * ratio
+        elif unit == 'ch':
+            ratio = character_ratio(style, '0')
+            return value.value * font_size * ratio
+        elif unit == 'em':
+            return value.value * font_size
+        elif unit == 'rem':
+            return value.value * style.root_style['font_size']
+        elif unit == 'lh':
+            line_height, _ = strut(style)
+            return value.value * line_height
+        elif unit == 'rlh':
+            line_height, _ = strut(style.root_style)
+            return value.value * line_height

--- a/weasyprint/css/validation/__init__.py
+++ b/weasyprint/css/validation/__init__.py
@@ -5,7 +5,7 @@ from tinycss2 import parse_blocks_contents, serialize
 from tinycss2.ast import FunctionBlock, IdentToken, LiteralToken, WhitespaceToken
 
 from ... import LOGGER
-from ..utils import InvalidValues, remove_whitespace
+from ..tokens import InvalidValues, remove_whitespace
 from .expanders import EXPANDERS
 from .properties import PREFIX, PROPRIETARY, UNSTABLE, validate_non_shorthand
 

--- a/weasyprint/css/validation/descriptors.py
+++ b/weasyprint/css/validation/descriptors.py
@@ -7,10 +7,10 @@ import tinycss2
 from ...logger import LOGGER
 from . import properties
 
-from ..utils import (  # isort:skip
+from ..tokens import (  # isort:skip
     InvalidValues, comma_separated_list, get_custom_ident, get_keyword,
-    get_single_keyword, get_url, remove_whitespace, single_keyword,
-    single_token, split_on_comma)
+    get_single_keyword, get_url, remove_whitespace, single_keyword, single_token,
+    split_on_comma)
 
 DESCRIPTORS = {
     'font-face': {},

--- a/weasyprint/css/validation/expanders.py
+++ b/weasyprint/css/validation/expanders.py
@@ -5,12 +5,12 @@ import functools
 from tinycss2.ast import DimensionToken, IdentToken, NumberToken
 from tinycss2.color4 import parse_color
 
+from ..functions import check_var
 from ..properties import INITIAL_VALUES
 from .descriptors import expand_font_variant
 
-from ..utils import (  # isort:skip
-    InvalidValues, Pending, check_var_function, get_keyword, get_single_keyword,
-    split_on_comma)
+from ..tokens import ( # isort:skip
+    InvalidValues, Pending, get_keyword, get_single_keyword, split_on_comma)
 from .properties import ( # isort:skip
     background_attachment, background_image, background_position, background_repeat,
     background_size, block_ellipsis, border_image_source, border_image_slice,
@@ -42,7 +42,7 @@ class PendingExpander(Pending):
 def _find_var(tokens, expander, expanded_names):
     """Return pending expanders when var is found in tokens."""
     for token in tokens:
-        if check_var_function(token):
+        if check_var(token):
             # Found CSS variable, keep pending-substitution values.
             pending = PendingExpander(tokens, expander)
             return {name: pending for name in expanded_names}

--- a/weasyprint/css/validation/properties.py
+++ b/weasyprint/css/validation/properties.py
@@ -10,13 +10,13 @@ from tinycss2 import parse_component_value_list
 from tinycss2.color4 import parse_color
 
 from .. import computed_values
+from ..functions import check_var, parse_function
 from ..properties import KNOWN_PROPERTIES, ZERO_PIXELS, Dimension
 
-from ..utils import (  # isort:skip
-    InvalidValues, Pending, check_var_function, comma_separated_list,
-    get_angle, get_content_list, get_content_list_token, get_custom_ident,
-    get_image, get_keyword, get_length, get_resolution, get_single_keyword,
-    get_url, parse_2d_position, parse_function, parse_position,
+from ..tokens import (  # isort:skip
+    InvalidValues, Pending, comma_separated_list, get_angle, get_content_list,
+    get_content_list_token, get_custom_ident, get_image, get_keyword, get_length,
+    get_resolution, get_single_keyword, get_url, parse_2d_position, parse_position,
     remove_whitespace, single_keyword, single_token)
 
 PREFIX = '-weasy-'
@@ -94,7 +94,7 @@ def validate_non_shorthand(tokens, name, base_url=None, required=False):
 
     function = PROPERTIES[name]
     for token in tokens:
-        if check_var_function(token):
+        if check_var(token):
             # Found CSS variable, return pending-substitution values.
             return ((name, PendingProperty(tokens, name)),)
 

--- a/weasyprint/layout/inline.py
+++ b/weasyprint/layout/inline.py
@@ -4,9 +4,7 @@ import unicodedata
 from math import inf
 
 from ..css import computed_from_cascaded
-from ..css.computed_values import character_ratio, strut_layout
 from ..formatting_structure import boxes, build
-from ..text.line_break import can_break_text, create_layout, split_first_line
 from .absolute import AbsolutePlaceholder, absolute_layout
 from .flex import flex_layout
 from .float import avoid_collisions, float_layout
@@ -17,6 +15,9 @@ from .percent import resolve_one_percentage, resolve_percentages
 from .preferred import inline_min_content_width, shrink_to_fit, trailing_whitespace_size
 from .replaced import inline_replaced_box_layout
 from .table import find_in_flow_baseline, table_wrapper_width
+
+from ..text.line_break import (  # isort:skip
+    can_break_text, character_ratio, create_layout, split_first_line, strut)
 
 
 def iter_line_boxes(context, box, position_y, bottom_space, skip_stack,
@@ -75,7 +76,7 @@ def get_next_linebox(context, linebox, position_y, bottom_space, skip_stack,
         # Width and height must be calculated to avoid floats
         linebox.width = inline_min_content_width(
             context, linebox, skip_stack=skip_stack, first_line=True)
-        linebox.height, _ = strut_layout(linebox.style, context)
+        linebox.height, _ = strut(linebox.style, context)
     else:
         # No float, width and height will be set by the lines
         linebox.width = linebox.height = 0
@@ -858,7 +859,7 @@ def split_inline_box(context, box, position_x, max_x, bottom_space, skip_stack,
         new_box.width = position_x - content_box_left
         new_box.translate(dx=float_widths['left'], ignore_floats=True)
 
-    line_height, new_box.baseline = strut_layout(box.style, context)
+    line_height, new_box.baseline = strut(box.style, context)
     new_box.height = box.style['font_size']
     half_leading = (line_height - new_box.height) / 2
     # Set margins to the half leading but also compensate for borders and
@@ -922,7 +923,7 @@ def split_text_box(context, box, available_width, skip, is_line_start=True):
         # "only the 'line-height' is used when calculating the height
         #  of the line box."
         # Set margins so that margin_height() == line_height
-        line_height, _ = strut_layout(box.style, context)
+        line_height, _ = strut(box.style, context)
         half_leading = (line_height - height) / 2
         box.margin_top = half_leading
         box.margin_bottom = half_leading

--- a/weasyprint/svg/utils.py
+++ b/weasyprint/svg/utils.py
@@ -25,7 +25,7 @@ def normalize(string):
 
 def size(string, font_size=None, percentage_reference=None):
     """Compute size from string, resolving units and percentages."""
-    from ..css.utils import LENGTHS_TO_PIXELS
+    from ..css.units import LENGTHS_TO_PIXELS
 
     if not string:
         return 0

--- a/weasyprint/urls.py
+++ b/weasyprint/urls.py
@@ -122,6 +122,16 @@ def get_url_attribute(element, attr_name, base_url, allow_relative=False):
             (element.tag, attr_name, value))
 
 
+def get_url_tuple(url, base_url):
+    """Get tuple describing internal or external URI."""
+    if url.startswith('#'):
+        return ('internal', unquote(url[1:]))
+    elif url_is_absolute(url):
+        return ('external', iri_to_uri(url))
+    elif base_url:
+        return ('external', iri_to_uri(urljoin(base_url, url)))
+
+
 def url_join(base_url, url, allow_relative, context, context_args):
     """Like urllib.urljoin, but warn if base_url is required but missing."""
     if url_is_absolute(url):


### PR DESCRIPTION
The previous code was allowing parameters to be only separated by spaces, but for many functions they actually require commas.

This is an opportunity to remove the dirty `utils` module and move some functions to a better place.