### PR TITLE
[FEATURE] add support logical operator only

### DIFF
--- a/weasyprint/css/media_queries.py
+++ b/weasyprint/css/media_queries.py
@@ -10,6 +10,18 @@ from ..logger import LOGGER
 from .tokens import remove_whitespace, split_on_comma
 
 
+MEDIA_TYPES = {
+    'all',
+    'print',
+    'screen'
+}
+
+# For now support for only operator
+LOGICAL_OPERATORS = {
+    'only'
+}
+
+
 def evaluate_media_query(query_list, device_media_type):
     """Return the boolean evaluation of `query_list` for the given
     `device_media_type`.
@@ -19,6 +31,20 @@ def evaluate_media_query(query_list, device_media_type):
 
     """
     # TODO: actual support for media queries, not just media types
+    if 'only' in query_list:
+        if len(query_list) <= 1:
+            LOGGER.warning(
+                "Invalid media query: The 'only' keyword was used by itself and must be "
+                "followed by a media type (e.g., 'only screen').")
+            return False
+        if query_list.index('only') != 0:
+            LOGGER.warning(
+                "Invalid media query: The 'only' keyword must appear at the very beginning.")
+            return False
+        if query_list[1] not in MEDIA_TYPES:
+            LOGGER.warning("Invalid media query: The 'only' keyword must be immediately followed by a "
+                "valid media type (like 'screen' or 'print'")
+            return False
     return 'all' in query_list or device_media_type in query_list
 
 
@@ -29,11 +55,11 @@ def parse_media_query(tokens):
     else:
         media = []
         for part in split_on_comma(tokens):
-            types = [token.type for token in part]
-            if types == ['ident']:
-                media.append(part[0].lower_value)
-            else:
-                LOGGER.warning(
-                    'Expected a media type, got %r', tinycss2.serialize(part))
-                return
+            for token in tokens:
+                if token.type == 'ident' and (token.value in MEDIA_TYPES or token.value in LOGICAL_OPERATORS):
+                    media.append(token.lower_value)
+                else:
+                    LOGGER.warning(
+                        'Expected a media type or logical operator, got %r', tinycss2.serialize(part))
+                    return
         return media


### PR DESCRIPTION
This pull request support for the only keyword in CSS media queries to improve compliance with the W3C specification.

It is still a draft, need to add test cases, review is needed.

Fixes https://github.com/Kozea/WeasyPrint/issues/2140