### PR TITLE
Don’t avoid float collisions for atomic flex items

### DIFF
--- a/tests/layout/test_flex.py
+++ b/tests/layout/test_flex.py
@@ -1951,3 +1951,19 @@ def test_flex_image_min_width():
     article, = body.children
     img, div = article.children
     assert article.height == img.height == img.width == div.height == 10
+
+
+@assert_no_logs
+def test_flex_image_justify_content():
+    page, = render_pages('''
+      <article style="width: 100px; display: flex; justify-content: end">
+        <img src="pattern.png">
+      </article>
+    ''')
+    html, = page.children
+    body, = html.children
+    article, = body.children
+    img, = article.children
+    assert article.height == img.height == img.width == 4
+    assert article.width == 100
+    assert img.position_x == 96

--- a/weasyprint/layout/replaced.py
+++ b/weasyprint/layout/replaced.py
@@ -281,10 +281,13 @@ def block_replaced_box_layout(context, box, containing_block):
         block_replaced_width(box, containing_block)
         replaced_box_height(box)
 
-    # Don't collide with floats
-    # https://www.w3.org/TR/CSS21/visuren.html#floats
-    box.position_x, box.position_y, _ = avoid_collisions(
-        context, box, containing_block, outer=False)
+    # TODO: flex items shouldn't be block boxes, this condition
+    # would then be useless when this is fixed.
+    if not box.is_flex_item:
+        # Don't collide with floats
+        # https://www.w3.org/TR/CSS21/visuren.html#floats
+        box.position_x, box.position_y, _ = avoid_collisions(
+            context, box, containing_block, outer=False)
     resume_at = None
     next_page = {'break': 'any', 'page': None}
     adjoining_margins = []


### PR DESCRIPTION
This is just the same workaround as the one for non-atomic boxes. The real fix would be to avoid calling `block_level_layout_switch()` in flex layout, as flex items are not block boxes.

But we can keep this real fix for later, as we need the same fix for grid, tables, columns, etc.

Fix #2479.