### PR TITLE
feat(lang): Add language-aware text transformation for uppercase and lowercase

### DIFF
--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -1319,24 +1319,27 @@ def test_text_transform_lang_lowercase(lang, uppercase, lowercase):
 
 @assert_no_logs
 @pytest.mark.parametrize(
-    ('original', 'transformed'), [
-        ('abc def ghi', 'Abc Def Ghi'),
-        ('AbC def ghi', 'AbC Def Ghi'),
-        ('I’m SO cool', 'I’m SO Cool'),
-        ('Wow.wow!wow', 'Wow.wow!wow'),
-        ('!now not tomorrow', '!Now Not Tomorrow'),
-        ('SUPER cool', 'SUPER Cool'),
-        ('i 😻 non‑breaking characters', 'I 😻 Non‑breaking Characters'),
-        ('3lite 3lite', '3lite 3lite'),
-        ('one/two/three', 'One/two/three'),
-        ('supernatural,super', 'Supernatural,super'),
-        ('éternel αιώνια', 'Éternel Αιώνια'),
+    ('original', 'transformed', 'lang_code'), [
+        ('abc def ghi', 'Abc Def Ghi', None),
+        ('AbC def ghi', 'AbC Def Ghi', None),
+        ('I’m SO cool', 'I’m SO Cool', None),
+        ('Wow.wow!wow', 'Wow.wow!wow', None),
+        ('!now not tomorrow', '!Now Not Tomorrow', None),
+        ('SUPER cool', 'SUPER Cool', None),
+        ('i 😻 non‑breaking characters', 'I 😻 Non‑breaking Characters', None),
+        ('3lite 3lite', '3lite 3lite', None),
+        ('one/two/three', 'One/two/three', None),
+        ('supernatural,super', 'Supernatural,super', None),
+        ('éternel αιώνια', 'Éternel Αιώνια', None),
+        ('great ijland', 'Great Ijland', 'fr'),
+        ('great ijland', 'Great IJland', 'nl'),
+        ('great ijland', 'Great İjland', 'az'),
     ]
 )
-def test_text_transform_capitalize(original, transformed):
+def test_text_transform_capitalize(original, transformed, lang_code):
     # Results are different for different browsers, we almost get the same
     # results as Firefox, that’s good enough!
-    assert capitalize(original) == transformed
+    assert capitalize(original, lang_code) == transformed
 
 
 @assert_no_logs


### PR DESCRIPTION
Fixes incorrect uppercase/lowercase transformations for Greek and Turkish text when using CSS `text-transform` (#1749). Python's default `.upper()` and `.lower()` don't handle language-specific rules (e.g., Turkish `i` → `İ`, Greek accented characters). Modified `uppercase()` and `lowercase()` to accept `lang` parameter from `box.style['lang']`, added `is_greek_lang()` and `is_turkish_lang()` helper functions, and implemented naive character mappings for Turkish (i/İ/ı/I) and Greek accented characters. Tested with Greek (`lang="el"`) and Turkish (`lang="tr"`) HTML files to verify correct transformations and backwards compatibility.