### PR TITLE
Get rid of zopfli dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,9 @@ dependencies = [
   'cssselect2 >=0.8.0',
   'Pyphen >=0.9.1',
   'Pillow >=9.1.0',
-  'fonttools[woff] >=4.59.2',
+  'fonttools >=4.60.1',
+  'brotli >= 1.0.1; platform_python_implementation == "CPython"',
+  'brotlicffi >= 0.8.0; platform_python_implementation != "CPython"',
 ]
 classifiers = [
   'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Update `fonttools` version; remove the "woff" fonttools extra to get rid of the `zopfli` dependency and add `brotli` dependencies directly to keep WOFF2 font support.

The `zopfli` dependency is not needed to decompress WOFF fonts and is problematic because it lags behind in supplying wheels for new Python versions. It can be removed because WOFF (v1) fonts can be decompressed without it, and WOFF (v1) is a legacy format anyway.

`brotli` is required to decompress WOFF2 fonts, so I added the brotli dependencies directly to weasyprint.