### PR TITLE
fix: incomplete document generated because of an overflow issue

### DIFF
--- a/weasyprint/layout/block.py
+++ b/weasyprint/layout/block.py
@@ -804,9 +804,12 @@ def block_container_layout(context, box, bottom_space, skip_stack, page_is_empty
         elif stop:
             if box.height != 'auto':
                 if context.overflows(box.position_y + box.border_height(), position_y):
-                    # Box heigh is fixed and it doesn’t overflow page, forget
-                    # overflowing children.
-                    resume_at = None
+                    if not box.is_for_root_element:
+                        # Box heigh is fixed and it doesn’t overflow page, forget
+                        # overflowing children. But don't do this for a root element
+                        # because otherwise page generation may stop incorrectly
+                        # before the whole document is generated.
+                        resume_at = None
             adjoining_margins = []
             break
 


### PR DESCRIPTION
I don't know if this is the correct way to fix it, but it works for my mkdocs project. Without this patch, my document stopped at page 159 of 250, but a similar issue occurred on other pages too, usually when changing a font size or something else which shifted page layouts.