### PR TITLE
Calculate relative offsets for grid and flex children.

### DIFF
--- a/tests/layout/test_position.py
+++ b/tests/layout/test_position.py
@@ -1,5 +1,7 @@
 """Tests for position property."""
 
+import pytest
+
 from ..testing_utils import assert_no_logs, render_pages
 
 
@@ -489,3 +491,52 @@ def test_grid_relative_positioning():
     div1, div2 = article.children
 
     assert (div2.position_x, div2.position_y) == (30, 10)
+
+
+@assert_no_logs
+@pytest.mark.xfail
+def test_flex_absolute_positioning():
+    """TODO: Order is not kept when out-of-flow and in-flow children are mixed."""
+    page, = render_pages('''
+      <style>
+        @page { size: 100px 100px }
+        article { display: flex; position: relative }
+        .box { width: 20px; height: 20px }
+        .absolute { position: absolute; top: 10px; left: 10px }
+      </style>
+      <article>
+        <div class="box"></div>
+        <div class="box absolute"></div>
+      </article>
+    ''')
+    html, = page.children
+    body, = html.children
+    article, = body.children
+    # That’s currently div2, div1
+    div1, div2 = article.children
+
+    assert (div2.position_x, div2.position_y) == (10, 10)
+
+
+@assert_no_logs
+@pytest.mark.xfail
+def test_grid_absolute_positioning():
+    """TODO: Absolutely positioned grid items are not replaced by placeholders ."""
+    page, = render_pages('''
+      <style>
+        @page { size: 100px 100px }
+        article { display: grid; grid-template-columns: 20px 20px; position: relative }
+        .box { width: 20px; height: 20px }
+        .absolute { position: absolute; top: 10px; left: 10px }
+      </style>
+      <article>
+        <div class="box"></div>
+        <div class="box absolute"></div>
+      </article>
+    ''')
+    html, = page.children
+    body, = html.children
+    article, = body.children
+    div1, div2 = article.children
+
+    assert (div1.position_x, div1.position_y) == (10, 10)

--- a/weasyprint/layout/flex.py
+++ b/weasyprint/layout/flex.py
@@ -923,7 +923,6 @@ def flex_layout(context, box, bottom_space, skip_stack, containing_block, page_i
                             resume_index, = resume_at
                             first_level_skip += resume_index
                         resume_at = {first_level_skip + index: child_resume_at}
-                    block.relative_positioning(new_child, (box.width, box.height))
                 if resume_at:
                     break
 
@@ -937,6 +936,9 @@ def flex_layout(context, box, bottom_space, skip_stack, containing_block, page_i
         for absolute_box in absolute_boxes:
             absolute_layout(
                 context, absolute_box, box, fixed_boxes, bottom_space, skip_stack=None)
+
+    for child in box.children:
+        block.relative_positioning(child, (box.width, box.height))
 
     # TODO: Use real algorithm, see https://www.w3.org/TR/css-flexbox-1/#flex-baselines.
     if isinstance(box, boxes.InlineFlexBox):


### PR DESCRIPTION
My attempt at fixing #2617.

It's working, but I'm not sure if there's a better place to have slipped in the calls to block.relative_positioning(). Both grid_layout() and flex_layout() are pretty long and I started getting a little lost when following along with them.

I also added a new pair of tests to test_position.py, one for grid and one for flex. I also tested it on my HTML Resume I've been trying to faithfully PDF-ify.