### PR TITLE
Add public method to cleanup font configuration temporary directory

### DIFF
--- a/tests/test_fonts.py
+++ b/tests/test_fonts.py
@@ -1,5 +1,5 @@
 """Test the fonts features."""
-
+from weasyprint.text.fonts import FontConfiguration
 from .testing_utils import assert_no_logs, render_pages
 
 
@@ -166,3 +166,12 @@ def test_woff_simple():
     assert span1.width == span3.width
     # the default font does not match the loaded fonts
     assert span1.width != span4.width
+
+
+@assert_no_logs
+def test_font_cleanup():
+    font_config = FontConfiguration()
+    font_folder = font_config.font_folder
+    assert font_folder.exists()
+    font_config.cleanup()
+    assert not font_folder.exists()


### PR DESCRIPTION
The temp directory used store some downloaded bytes for fonts is sometimes not being cleaned up automatically via the `__del__` dunder method. This commit exposes a `cleanup` method to allow users to handle this cleanup themselves if it affects their workflow.

tests:
```
➜ ~/work/fork/WeasyPrint (expose-font-cleanup-method) [weasyprint] $ pytest tests/test_fonts.py
================================================================================================================ test session starts ================================================================================================================
platform darwin -- Python 3.10.18, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/maxblau/work/fork/WeasyPrint
configfile: pyproject.toml
collected 8 items

tests/test_fonts.py ........                                                                                                                                                                                                                  [100%]

================================================================================================================= 8 passed in 0.14s =================================================================================================================
```