### PR TITLE
Support legacy 0 value for angles

### DIFF
--- a/tests/css/test_validation.py
+++ b/tests/css/test_validation.py
@@ -196,6 +196,7 @@ def test_size_invalid(rule):
     ('none', ()),
     ('translate(6px) rotate(90deg)', (
         ('translate', ((6, 'px'), (0, 'px'))), ('rotate', pi / 2))),
+    ('rotate(0)', (('rotate', 0),)),
     ('translate(-4px, 0)', (('translate', ((-4, 'px'), (0, None))),)),
     ('translate(6px, 20%)', (('translate', ((6, 'px'), (20, '%'))),)),
     ('scale(2)', (('scale', (2, 2)),)),

--- a/weasyprint/css/tokens.py
+++ b/weasyprint/css/tokens.py
@@ -432,7 +432,10 @@ def get_angle(token):
         token = resolve_math(token) or token
     except (PercentageInMath, FontUnitInMath):
         return
-    if token.type == 'dimension':
+    if token.type == 'number' and token.value == 0:
+        # Legacy syntax: https://drafts.csswg.org/css-values-4/#angles.
+        return 0
+    elif token.type == 'dimension':
         factor = ANGLE_TO_RADIANS.get(token.unit.lower())
         if factor is not None:
             return token.value * factor


### PR DESCRIPTION
This syntax is for example used by Tailwind.