### PR TITLE
Process whitespace after checking all pending targets

### DIFF
--- a/tests/css/test_target.py
+++ b/tests/css/test_target.py
@@ -133,6 +133,26 @@ def test_target_text():
 
 
 @assert_no_logs
+def test_target_text_whitespace_around_target():
+    # Regression test for #1875.
+    page, = render_pages('''
+      <style>
+        a::before { content: target-text(attr(href)) }
+      </style>
+      <p>before <a href="#ref"></a> after</p>
+      <h2 id="ref">text</h2>
+    ''')
+    html, = page.children
+    body, = html.children
+    p, h2 = body.children
+    line, = p.children
+    before, a, after = line.children
+    assert before.text == 'before '
+    assert after.text == ' after'
+    assert a.children[0].children[0].text == 'text'
+
+
+@assert_no_logs
 def test_target_float():
     page, = render_pages('''
       <style>

--- a/tests/draw/test_absolute.py
+++ b/tests/draw/test_absolute.py
@@ -867,7 +867,7 @@ def test_absolute_in_absolute_break(assert_pixels):
           }
         </style>
         <div style="background: blue">
-          <br><br><br><br>
+          <br><br><br><br><br>
           <div style="background: red">
             <br><br>
           </div>

--- a/tests/test_boxes.py
+++ b/tests/test_boxes.py
@@ -47,7 +47,7 @@ def test_inline_in_block_1():
                     ('div', 'Text', 'Hello, '),
                     ('em', 'Inline', [
                         ('em', 'Text', 'World')]),
-                    ('div', 'Text', '! ')])]),
+                    ('div', 'Text', '!\n')])]),
             ('p', 'Block', [
                 ('p', 'Line', [
                     ('p', 'Text', 'Lipsum.')])])])]
@@ -69,7 +69,7 @@ def test_inline_in_block_2():
                     ('div', 'Text', 'Hello, '),
                     ('em', 'Inline', [
                         ('em', 'Text', 'World')]),
-                    ('div', 'Text', '! ')])])])]
+                    ('div', 'Text', '!\n')])])])]
     box = parse(source)
     box = build.inline_in_block(box)
     assert_tree(box, expected)
@@ -134,7 +134,7 @@ def test_block_in_inline():
                             ('span', 'Block', [  # This block is "pulled up"
                                 ('span', 'Line', [
                                     ('span', 'Text', 'sit')])]),
-                            ('strong', 'Text', ' '),
+                            ('strong', 'Text', '\n      '),
                             ('span', 'Block', [  # This block is "pulled up"
                                 ('span', 'Line', [
                                     ('span', 'Text', 'amet,')])])]),
@@ -162,7 +162,7 @@ def test_block_in_inline():
                     ('p', 'Line', [
                         ('em', 'Inline', [
                             ('strong', 'Inline', [
-                                ('strong', 'Text', ' ')])])])]),
+                                ('strong', 'Text', '\n      ')])])])]),
                 ('span', 'Block', [
                     ('span', 'Line', [
                         ('span', 'Text', 'amet,')])]),
@@ -243,7 +243,7 @@ def test_whitespace():
         ('pre', 'Block', [
             ('pre', 'Line', [
                 # pre-line
-                ('pre', 'Text', ' foo\n')])])])
+                ('pre', 'Text', 'foo\n')])])])
 
 
 @assert_no_logs


### PR DESCRIPTION
Whitespace management and text transformation should be done after all referenced targets (especially for target text) are replaced. Without this change, spaces may be removed because of missing strings replaced by empty strings.

The main tree requires whitespace management to be done on target text, but target text requires whitespace management to be done on the parts of the tree they rely on. To avoid side effects, we must copy the boxes referenced by target text and apply whitespace management on these copies.

Some tests have changed in this commit:

- `test_inline_in_block*` and `test_block_in_inline` rely on `parse()`, that doesn’t handle whitespace management anymore;
- `test_whitespace` expected a leading space with `pre-line`, not sure why, but this space has to be removed during the layout anyway;
- `test_absolute_in_absolute_break` was missing a `<br>`, as 5 `<br>`s create 6 lines, with the last one being removed as a block is present after (other browsers agree on that).

Fix #1875.