### PR TITLE
Don’t use isolated transparency groups

### DIFF
--- a/weasyprint/pdf/stream.py
+++ b/weasyprint/pdf/stream.py
@@ -201,8 +201,6 @@ class Stream(pydyf.Stream):
             'Group': pydyf.Dictionary({
                 'Type': '/Group',
                 'S': '/Transparency',
-                'I': 'true',
-                'CS': '/DeviceRGB',
             }),
         })
         group = self.clone(resources=resources, extra=extra)


### PR DESCRIPTION
This allows us to not define the color space, and not force RGB for CMYK output for example. We should only need isolation if we ever use filters.

Fix #2631.