### PR TITLE
Add CLI for Factur-X / ZUGFeRD

### DIFF
--- a/docs/common_use_cases.rst
+++ b/docs/common_use_cases.rst
@@ -208,63 +208,58 @@ Here is an example of Factur-X document generation.
 
 .. code-block:: xml
 
-  <x:xmpmeta
-      xmlns:x="adobe:ns:meta/"
+  <rdf:RDF
       xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-      xmlns:pdf="http://ns.adobe.com/pdf/1.3/"
       xmlns:fx="urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"
       xmlns:pdfaExtension="http://www.aiim.org/pdfa/ns/extension/"
       xmlns:pdfaSchema="http://www.aiim.org/pdfa/ns/schema#"
       xmlns:pdfaProperty="http://www.aiim.org/pdfa/ns/property#">
-    <!-- placeholder -->
-    <rdf:RDF>
-      <rdf:Description rdf:about="">
-        <fx:ConformanceLevel>MINIMUM</fx:ConformanceLevel>
-        <fx:DocumentFileName>factur-x.xml</fx:DocumentFileName>
-        <fx:DocumentType>INVOICE</fx:DocumentType>
-        <fx:Version>1.0</fx:Version>
-      </rdf:Description>
-      <rdf:Description rdf:about="">
-        <pdfaExtension:schemas>
-          <rdf:Bag>
-            <rdf:li rdf:parseType="Resource">
-              <pdfaSchema:schema>Factur-X PDFA Extension Schema</pdfaSchema:schema>
-              <pdfaSchema:namespaceURI>urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#</pdfaSchema:namespaceURI>
-              <pdfaSchema:prefix>fx</pdfaSchema:prefix>
-              <pdfaSchema:property>
-                <rdf:Seq>
-                  <rdf:li rdf:parseType="Resource">
-                    <pdfaProperty:name>DocumentFileName</pdfaProperty:name>
-                    <pdfaProperty:valueType>Text</pdfaProperty:valueType>
-                    <pdfaProperty:category>external</pdfaProperty:category>
-                    <pdfaProperty:description>name of the embedded XML invoice file</pdfaProperty:description>
-                  </rdf:li>
-                  <rdf:li rdf:parseType="Resource">
-                    <pdfaProperty:name>DocumentType</pdfaProperty:name>
-                    <pdfaProperty:valueType>Text</pdfaProperty:valueType>
-                    <pdfaProperty:category>external</pdfaProperty:category>
-                    <pdfaProperty:description>INVOICE</pdfaProperty:description>
-                  </rdf:li>
-                  <rdf:li rdf:parseType="Resource">
-                    <pdfaProperty:name>Version</pdfaProperty:name>
-                    <pdfaProperty:valueType>Text</pdfaProperty:valueType>
-                    <pdfaProperty:category>external</pdfaProperty:category>
-                    <pdfaProperty:description>The actual version of the Factur-X XML schema</pdfaProperty:description>
-                  </rdf:li>
-                  <rdf:li rdf:parseType="Resource">
-                    <pdfaProperty:name>ConformanceLevel</pdfaProperty:name>
-                    <pdfaProperty:valueType>Text</pdfaProperty:valueType>
-                    <pdfaProperty:category>external</pdfaProperty:category>
-                    <pdfaProperty:description>The conformance level of the embedded Factur-X data</pdfaProperty:description>
-                  </rdf:li>
-                </rdf:Seq>
-              </pdfaSchema:property>
-            </rdf:li>
-          </rdf:Bag>
-        </pdfaExtension:schemas>
-      </rdf:Description>
-    </rdf:RDF>
-  </x:xmpmeta>
+    <rdf:Description rdf:about="">
+      <fx:ConformanceLevel>MINIMUM</fx:ConformanceLevel>
+      <fx:DocumentFileName>factur-x.xml</fx:DocumentFileName>
+      <fx:DocumentType>INVOICE</fx:DocumentType>
+      <fx:Version>1.0</fx:Version>
+    </rdf:Description>
+    <rdf:Description rdf:about="">
+      <pdfaExtension:schemas>
+        <rdf:Bag>
+          <rdf:li rdf:parseType="Resource">
+            <pdfaSchema:schema>Factur-X PDFA Extension Schema</pdfaSchema:schema>
+            <pdfaSchema:namespaceURI>urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#</pdfaSchema:namespaceURI>
+            <pdfaSchema:prefix>fx</pdfaSchema:prefix>
+            <pdfaSchema:property>
+              <rdf:Seq>
+                <rdf:li rdf:parseType="Resource">
+                  <pdfaProperty:name>DocumentFileName</pdfaProperty:name>
+                  <pdfaProperty:valueType>Text</pdfaProperty:valueType>
+                  <pdfaProperty:category>external</pdfaProperty:category>
+                  <pdfaProperty:description>name of the embedded XML invoice file</pdfaProperty:description>
+                </rdf:li>
+                <rdf:li rdf:parseType="Resource">
+                  <pdfaProperty:name>DocumentType</pdfaProperty:name>
+                  <pdfaProperty:valueType>Text</pdfaProperty:valueType>
+                  <pdfaProperty:category>external</pdfaProperty:category>
+                  <pdfaProperty:description>INVOICE</pdfaProperty:description>
+                </rdf:li>
+                <rdf:li rdf:parseType="Resource">
+                  <pdfaProperty:name>Version</pdfaProperty:name>
+                  <pdfaProperty:valueType>Text</pdfaProperty:valueType>
+                  <pdfaProperty:category>external</pdfaProperty:category>
+                  <pdfaProperty:description>The actual version of the Factur-X XML schema</pdfaProperty:description>
+                </rdf:li>
+                <rdf:li rdf:parseType="Resource">
+                  <pdfaProperty:name>ConformanceLevel</pdfaProperty:name>
+                  <pdfaProperty:valueType>Text</pdfaProperty:valueType>
+                  <pdfaProperty:category>external</pdfaProperty:category>
+                  <pdfaProperty:description>The conformance level of the embedded Factur-X data</pdfaProperty:description>
+                </rdf:li>
+              </rdf:Seq>
+            </pdfaSchema:property>
+          </rdf:li>
+        </rdf:Bag>
+      </pdfaExtension:schemas>
+    </rdf:Description>
+  </rdf:RDF>
 
 ``factur-x.xml``:
 
@@ -329,33 +324,35 @@ Here is an example of Factur-X document generation.
     </rsm:SupplyChainTradeTransaction>
   </rsm:CrossIndustryInvoice>
 
-``invoice.py``:
+``invoice.html``:
+
+.. code-block:: html
+
+  <h1>Invoice</h1>
+
+Command-line::
+
+  weasyprint invoice.html invoice.pdf --attachment=factur-x.xml --attachment-relationship=Data --xmp-metadata=rdf.xml --pdf-variant=pdf/a-3a
+
+Or Python API:
 
 .. code-block:: python
 
-  from pathlib import Path
   from weasyprint import Attachment, HTML
 
-  def generate_rdf_metadata(metadata, variant, version, conformance):
-      original_rdf = generate_original_rdf_metadata(metadata, variant, version, conformance)
-      return Path("rdf.xml").read_bytes().replace(b"<!-- placeholder -->", original_rdf)
-
-  document = HTML(string="<h1>Invoice</h1>").render()
-  generate_original_rdf_metadata = document.metadata.generate_rdf_metadata
+  document = HTML("invoice.html").render()
 
   factur_x_xml = Path("factur-x.xml").read_text()
   attachment = Attachment(string=factur_x_xml, name="factur-x.xml", relationship="Data")
   document.metadata.attachments = [attachment]
 
-  document.metadata.generate_rdf_metadata = generate_rdf_metadata
+  xmp_metadata = Path("rdf.xml").read_text().encode()
+  document.metadata.xmp_metadata = [xmp_metadata]
+
   document.write_pdf("invoice.pdf", pdf_variant="pdf/a-3b")
 
 Of course, the content of these files has to be adapted to the content of real
-invoices. Using XML generators instead of plain text manipulation is also
-highly recommended.
-
-A more detailed blog article is available on `Binary Butterfly’s website
-<https://binary-butterfly.de/artikel/factur-x-zugferd-e-invoices-with-python/>`_.
+invoices.
 
 
 Include PDF Forms

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -19,7 +19,6 @@ from PIL import Image
 
 from weasyprint import CSS, HTML, __main__, default_url_fetcher
 from weasyprint.pdf.anchors import resolve_links
-from weasyprint.pdf.metadata import generate_rdf_metadata
 
 from .draw import parse_pixels
 from .testing_utils import FakeHTML, assert_no_logs, capture_logs, resource_path
@@ -1427,7 +1426,7 @@ def assert_meta(html, **meta):
     meta.setdefault('attachments', [])
     meta.setdefault('lang', None)
     meta.setdefault('custom', {})
-    meta.setdefault('generate_rdf_metadata', generate_rdf_metadata)
+    meta.setdefault('xmp_metadata', [])
     assert vars(FakeHTML(string=html).render().metadata) == meta
 
 

--- a/weasyprint/__main__.py
+++ b/weasyprint/__main__.py
@@ -109,6 +109,9 @@ group.add_argument(
     '--uncompressed-pdf', action='store_true',
     help='do not compress PDF content, mainly for debugging purpose')
 group.add_argument(
+    '--xmp-metadata', action='append',
+    help='URL or filename of a file to include into the XMP metadata')
+group.add_argument(
     '--custom-metadata', action='store_true',
     help='include custom HTML meta tags in PDF metadata')
 group.add_argument(

--- a/weasyprint/document.py
+++ b/weasyprint/document.py
@@ -18,7 +18,7 @@ from .layout import LayoutContext, layout_document
 from .logger import PROGRESS_LOGGER
 from .matrix import Matrix
 from .pdf import VARIANTS, generate_pdf
-from .pdf.metadata import generate_rdf_metadata
+from .pdf.metadata import DocumentMetadata
 from .text.fonts import FontConfiguration
 
 
@@ -85,64 +85,6 @@ class Page:
         with stream.stacked():
             stream.transform(a=scale, d=scale)
             draw_page(self._page_box, stream)
-
-
-class DocumentMetadata:
-    """Meta-information belonging to a whole :class:`Document`.
-
-    New attributes may be added in future versions of WeasyPrint.
-    """
-    def __init__(self, title=None, authors=None, description=None, keywords=None,
-                 generator=None, created=None, modified=None, attachments=None,
-                 lang=None, custom=None, generate_rdf_metadata=generate_rdf_metadata):
-        #: The title of the document, as a string or :obj:`None`.
-        #: Extracted from the ``<title>`` element in HTML
-        #: and written to the ``/Title`` info field in PDF.
-        self.title = title
-        #: The authors of the document, as a list of strings.
-        #: (Defaults to the empty list.)
-        #: Extracted from the ``<meta name=author>`` elements in HTML
-        #: and written to the ``/Author`` info field in PDF.
-        self.authors = authors or []
-        #: The description of the document, as a string or :obj:`None`.
-        #: Extracted from the ``<meta name=description>`` element in HTML
-        #: and written to the ``/Subject`` info field in PDF.
-        self.description = description
-        #: Keywords associated with the document, as a list of strings.
-        #: (Defaults to the empty list.)
-        #: Extracted from ``<meta name=keywords>`` elements in HTML
-        #: and written to the ``/Keywords`` info field in PDF.
-        self.keywords = keywords or []
-        #: The name of one of the software packages
-        #: used to generate the document, as a string or :obj:`None`.
-        #: Extracted from the ``<meta name=generator>`` element in HTML
-        #: and written to the ``/Creator`` info field in PDF.
-        self.generator = generator
-        #: The creation date of the document, as a string or :obj:`None`.
-        #: Dates are in one of the six formats specified in
-        #: `W3C’s profile of ISO 8601 <https://www.w3.org/TR/NOTE-datetime>`_.
-        #: Extracted from the ``<meta name=dcterms.created>`` element in HTML
-        #: and written to the ``/CreationDate`` info field in PDF.
-        self.created = created
-        #: The modification date of the document, as a string or :obj:`None`.
-        #: Dates are in one of the six formats specified in
-        #: `W3C’s profile of ISO 8601 <https://www.w3.org/TR/NOTE-datetime>`_.
-        #: Extracted from the ``<meta name=dcterms.modified>`` element in HTML
-        #: and written to the ``/ModDate`` info field in PDF.
-        self.modified = modified
-        #: A list of :class:`attachments <weasyprint.Attachment>`, empty by default.
-        #: Extracted from the ``<link rel=attachment>`` elements in HTML
-        #: and written to the ``/EmbeddedFiles`` dictionary in PDF.
-        self.attachments = attachments or []
-        #: Document language as BCP 47 language tags.
-        #: Extracted from ``<html lang=lang>`` in HTML.
-        self.lang = lang
-        #: Custom metadata, as a dict whose keys are the metadata names and
-        #: values are the metadata values.
-        self.custom = custom or {}
-        #: Custom RDF metadata generator, which will replace the default generator.
-        #: The function should return bytes containing an RDF XML.
-        self.generate_rdf_metadata = generate_rdf_metadata
 
 
 class DiskCache:

--- a/weasyprint/pdf/__init__.py
+++ b/weasyprint/pdf/__init__.py
@@ -9,6 +9,7 @@ from .. import VERSION, Attachment
 from ..html import W3C_DATE_RE
 from ..logger import LOGGER, PROGRESS_LOGGER
 from ..matrix import Matrix
+from ..urls import select_source
 from . import debug, pdfa, pdfua, pdfx
 from .fonts import build_fonts_dictionary
 from .stream import Stream
@@ -273,6 +274,14 @@ def generate_pdf(document, target, zoom, **options):
             key = key.encode('ascii', errors='ignore').decode()
             if key:
                 pdf.info[key] = pydyf.String(value)
+    if options['xmp_metadata']:
+        for url in options['xmp_metadata']:
+            result = select_source(url)
+            with result as (file_obj, base_url, charset, _):
+                xmp_metadata = file_obj.read()
+                if charset:
+                    xmp_metadata = xmp_metadata.decode(charset).encode()
+                metadata.xmp_metadata.append(xmp_metadata)
 
     # Embedded files
     attachments = metadata.attachments.copy()

--- a/weasyprint/pdf/metadata.py
+++ b/weasyprint/pdf/metadata.py
@@ -11,6 +11,7 @@ from .. import __version__
 NS = {
     'rdf': 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
     'dc': 'http://purl.org/dc/elements/1.1/',
+    '': '',
     'xmp': 'http://ns.adobe.com/xap/1.0/',
     'xmpMM': 'http://ns.adobe.com/xap/1.0/mm/',
     'pdf': 'http://ns.adobe.com/pdf/1.3/',
@@ -23,106 +24,164 @@ for key, value in NS.items():
     register_namespace(key, value)
 
 
-def add_metadata(pdf, metadata, variant, version, conformance, compress):
-    """Add PDF stream of metadata.
+class DocumentMetadata:
+    """Meta-information belonging to a whole :class:`Document`.
 
-    Described in ISO-32000-1:2008, 14.3.2.
-
+    New attributes may be added in future versions of WeasyPrint.
     """
-    header = b'<?xpacket begin="" id="W5M0MpCehiHzreSzNTczkc9d"?>'
-    footer = b'<?xpacket end="r"?>'
-    xml_data = metadata.generate_rdf_metadata(metadata, variant, version, conformance)
-    stream_content = b'\n'.join((header, xml_data, footer))
-    extra = {'Type': '/Metadata', 'Subtype': '/XML'}
-    metadata = pydyf.Stream([stream_content], extra, compress)
-    pdf.add_object(metadata)
-    pdf.catalog['Metadata'] = metadata.reference
+    def __init__(self, title=None, authors=None, description=None, keywords=None,
+                 generator=None, created=None, modified=None, attachments=None,
+                 lang=None, custom=None, xmp_metadata=None):
+        #: The title of the document, as a string or :obj:`None`.
+        #: Extracted from the ``<title>`` element in HTML
+        #: and written to the ``/Title`` info field in PDF.
+        self.title = title
+        #: The authors of the document, as a list of strings.
+        #: (Defaults to the empty list.)
+        #: Extracted from the ``<meta name=author>`` elements in HTML
+        #: and written to the ``/Author`` info field in PDF.
+        self.authors = authors or []
+        #: The description of the document, as a string or :obj:`None`.
+        #: Extracted from the ``<meta name=description>`` element in HTML
+        #: and written to the ``/Subject`` info field in PDF.
+        self.description = description
+        #: Keywords associated with the document, as a list of strings.
+        #: (Defaults to the empty list.)
+        #: Extracted from ``<meta name=keywords>`` elements in HTML
+        #: and written to the ``/Keywords`` info field in PDF.
+        self.keywords = keywords or []
+        #: The name of one of the software packages
+        #: used to generate the document, as a string or :obj:`None`.
+        #: Extracted from the ``<meta name=generator>`` element in HTML
+        #: and written to the ``/Creator`` info field in PDF.
+        self.generator = generator
+        #: The creation date of the document, as a string or :obj:`None`.
+        #: Dates are in one of the six formats specified in
+        #: `W3C’s profile of ISO 8601 <https://www.w3.org/TR/NOTE-datetime>`_.
+        #: Extracted from the ``<meta name=dcterms.created>`` element in HTML
+        #: and written to the ``/CreationDate`` info field in PDF.
+        self.created = created
+        #: The modification date of the document, as a string or :obj:`None`.
+        #: Dates are in one of the six formats specified in
+        #: `W3C’s profile of ISO 8601 <https://www.w3.org/TR/NOTE-datetime>`_.
+        #: Extracted from the ``<meta name=dcterms.modified>`` element in HTML
+        #: and written to the ``/ModDate`` info field in PDF.
+        self.modified = modified
+        #: A list of :class:`attachments <weasyprint.Attachment>`, empty by default.
+        #: Extracted from the ``<link rel=attachment>`` elements in HTML
+        #: and written to the ``/EmbeddedFiles`` dictionary in PDF.
+        self.attachments = attachments or []
+        #: Document language as BCP 47 language tags.
+        #: Extracted from ``<html lang=lang>`` in HTML.
+        self.lang = lang
+        #: Custom metadata, as a dict whose keys are the metadata names and
+        #: values are the metadata values.
+        self.custom = custom or {}
+        #: A list of XML bytestrings to add into the XMP metadata.
+        self.xmp_metadata = xmp_metadata or []
 
 
-def generate_rdf_metadata(metadata, variant, version, conformance):
-    """Generate RDF metadata as a bytestring."""
-    namespace = f'pdf{variant}id'
-    rdf = Element(f'{{{NS["rdf"]}}}RDF')
+    def include_in_pdf(self, pdf, variant, version, conformance, compress):
+        """Add PDF stream of metadata.
 
-    if version:
-        element = SubElement(rdf, f'{{{NS["rdf"]}}}Description')
-        element.attrib[f'{{{NS["rdf"]}}}about'] = ''
-        element.attrib[f'{{{NS[namespace]}}}part'] = str(version)
-    if conformance:
-        assert version
-        if variant == 'x':
-            for key in (
-                f'{{{NS["pdfxid"]}}}GTS_PDFXVersion',
-                f'{{{NS["pdfx"]}}}GTS_PDFXVersion',
-                f'{{{NS["pdfx"]}}}GTS_PDFXConformance',
-            ):
-                subelement = SubElement(element, key)
-                subelement.text = conformance
-            subelement = SubElement(element, f'{{{NS["pdf"]}}}Trapped')
-            subelement.text = 'False'
-            if version >= 4:
-                # TODO: these values could be useful instead of using random values.
-                assert metadata.modified
-                subelement = SubElement(element, f'{{{NS["xmp"]}}}MetadataDate')
-                subelement.text = metadata.modified
-                subelement = SubElement(element, f'{{{NS["xmpMM"]}}}DocumentID')
-                subelement.text = f'xmp.did:{uuid4()}'
-                subelement = SubElement(element, f'{{{NS["xmpMM"]}}}RenditionClass')
-                subelement.text = 'proof:pdf'
-                subelement = SubElement(element, f'{{{NS["xmpMM"]}}}VersionID')
-                subelement.text = '1'
-        else:
-            element.attrib[f'{{{NS[namespace]}}}conformance'] = conformance
-            if variant == 'a' and version == 4:
-                subelement = SubElement(element, f'{{{NS["pdfaid"]}}}rev')
-                subelement.text = '2020'
+        Described in ISO-32000-1:2008, 14.3.2.
 
-    element = SubElement(rdf, f'{{{NS["rdf"]}}}Description')
-    element.attrib[f'{{{NS["rdf"]}}}about'] = ''
-    element.attrib[f'{{{NS["pdf"]}}}Producer'] = f'WeasyPrint {__version__}'
+        """
+        header = b'<?xpacket begin="" id="W5M0MpCehiHzreSzNTczkc9d"?>\n'
+        header += b'<x:xmpmeta xmlns:x="adobe:ns:meta/">'
+        footer = b'</x:xmpmeta>\n<?xpacket end="r"?>'
+        xml_data = self.generate_rdf_metadata(variant, version, conformance)
+        stream_content = b'\n'.join((header, xml_data, *self.xmp_metadata, footer))
+        extra = {'Type': '/Metadata', 'Subtype': '/XML'}
+        metadata = pydyf.Stream([stream_content], extra, compress)
+        pdf.add_object(metadata)
+        pdf.catalog['Metadata'] = metadata.reference
 
-    if metadata.title:
+
+    def generate_rdf_metadata(self, variant, version, conformance):
+        """Generate RDF metadata as a bytestring."""
+        namespace = f'pdf{variant}id'
+        rdf = Element(f'{{{NS["rdf"]}}}RDF')
+
+        if version:
+            element = SubElement(rdf, f'{{{NS["rdf"]}}}Description')
+            element.attrib[f'{{{NS["rdf"]}}}about'] = ''
+            element.attrib[f'{{{NS[namespace]}}}part'] = str(version)
+        if conformance:
+            assert version
+            if variant == 'x':
+                for key in (
+                    f'{{{NS["pdfxid"]}}}GTS_PDFXVersion',
+                    f'{{{NS["pdfx"]}}}GTS_PDFXVersion',
+                    f'{{{NS["pdfx"]}}}GTS_PDFXConformance',
+                ):
+                    subelement = SubElement(element, key)
+                    subelement.text = conformance
+                subelement = SubElement(element, f'{{{NS["pdf"]}}}Trapped')
+                subelement.text = 'False'
+                if version >= 4:
+                    # TODO: these values could be useful instead of using random values.
+                    assert self.modified
+                    subelement = SubElement(element, f'{{{NS["xmp"]}}}MetadataDate')
+                    subelement.text = self.modified
+                    subelement = SubElement(element, f'{{{NS["xmpMM"]}}}DocumentID')
+                    subelement.text = f'xmp.did:{uuid4()}'
+                    subelement = SubElement(element, f'{{{NS["xmpMM"]}}}RenditionClass')
+                    subelement.text = 'proof:pdf'
+                    subelement = SubElement(element, f'{{{NS["xmpMM"]}}}VersionID')
+                    subelement.text = '1'
+            else:
+                element.attrib[f'{{{NS[namespace]}}}conformance'] = conformance
+                if variant == 'a' and version == 4:
+                    subelement = SubElement(element, f'{{{NS["pdfaid"]}}}rev')
+                    subelement.text = '2020'
+
         element = SubElement(rdf, f'{{{NS["rdf"]}}}Description')
         element.attrib[f'{{{NS["rdf"]}}}about'] = ''
-        element = SubElement(element, f'{{{NS["dc"]}}}title')
-        element = SubElement(element, f'{{{NS["rdf"]}}}Alt')
-        element = SubElement(element, f'{{{NS["rdf"]}}}li')
-        element.attrib['xml:lang'] = 'x-default'
-        element.text = metadata.title
-    if metadata.authors:
-        element = SubElement(rdf, f'{{{NS["rdf"]}}}Description')
-        element.attrib[f'{{{NS["rdf"]}}}about'] = ''
-        element = SubElement(element, f'{{{NS["dc"]}}}creator')
-        element = SubElement(element, f'{{{NS["rdf"]}}}Seq')
-        for author in metadata.authors:
-            author_element = SubElement(element, f'{{{NS["rdf"]}}}li')
-            author_element.text = author
-    if metadata.description:
-        element = SubElement(rdf, f'{{{NS["rdf"]}}}Description')
-        element.attrib[f'{{{NS["rdf"]}}}about'] = ''
-        element = SubElement(element, f'{{{NS["dc"]}}}subject')
-        element = SubElement(element, f'{{{NS["rdf"]}}}Bag')
-        element = SubElement(element, f'{{{NS["rdf"]}}}li')
-        element.attrib['xml:lang'] = 'x-default'
-        element.text = metadata.description
-    if metadata.keywords:
-        element = SubElement(rdf, f'{{{NS["rdf"]}}}Description')
-        element.attrib[f'{{{NS["rdf"]}}}about'] = ''
-        element = SubElement(element, f'{{{NS["pdf"]}}}Keywords')
-        element.text = ', '.join(metadata.keywords)
-    if metadata.generator:
-        element = SubElement(rdf, f'{{{NS["rdf"]}}}Description')
-        element.attrib[f'{{{NS["rdf"]}}}about'] = ''
-        element = SubElement(element, f'{{{NS["xmp"]}}}CreatorTool')
-        element.text = metadata.generator
-    if metadata.created:
-        element = SubElement(rdf, f'{{{NS["rdf"]}}}Description')
-        element.attrib[f'{{{NS["rdf"]}}}about'] = ''
-        element = SubElement(element, f'{{{NS["xmp"]}}}CreateDate')
-        element.text = metadata.created
-    if metadata.modified:
-        element = SubElement(rdf, f'{{{NS["rdf"]}}}Description')
-        element.attrib[f'{{{NS["rdf"]}}}about'] = ''
-        element = SubElement(element, f'{{{NS["xmp"]}}}ModifyDate')
-        element.text = metadata.modified
-    return tostring(rdf, encoding='utf-8')
+        element.attrib[f'{{{NS["pdf"]}}}Producer'] = f'WeasyPrint {__version__}'
+
+        if self.title:
+            element = SubElement(rdf, f'{{{NS["rdf"]}}}Description')
+            element.attrib[f'{{{NS["rdf"]}}}about'] = ''
+            element = SubElement(element, f'{{{NS["dc"]}}}title')
+            element = SubElement(element, f'{{{NS["rdf"]}}}Alt')
+            element = SubElement(element, f'{{{NS["rdf"]}}}li')
+            element.attrib['xml:lang'] = 'x-default'
+            element.text = self.title
+        if self.authors:
+            element = SubElement(rdf, f'{{{NS["rdf"]}}}Description')
+            element.attrib[f'{{{NS["rdf"]}}}about'] = ''
+            element = SubElement(element, f'{{{NS["dc"]}}}creator')
+            element = SubElement(element, f'{{{NS["rdf"]}}}Seq')
+            for author in self.authors:
+                author_element = SubElement(element, f'{{{NS["rdf"]}}}li')
+                author_element.text = author
+        if self.description:
+            element = SubElement(rdf, f'{{{NS["rdf"]}}}Description')
+            element.attrib[f'{{{NS["rdf"]}}}about'] = ''
+            element = SubElement(element, f'{{{NS["dc"]}}}subject')
+            element = SubElement(element, f'{{{NS["rdf"]}}}Bag')
+            element = SubElement(element, f'{{{NS["rdf"]}}}li')
+            element.attrib['xml:lang'] = 'x-default'
+            element.text = self.description
+        if self.keywords:
+            element = SubElement(rdf, f'{{{NS["rdf"]}}}Description')
+            element.attrib[f'{{{NS["rdf"]}}}about'] = ''
+            element = SubElement(element, f'{{{NS["pdf"]}}}Keywords')
+            element.text = ', '.join(self.keywords)
+        if self.generator:
+            element = SubElement(rdf, f'{{{NS["rdf"]}}}Description')
+            element.attrib[f'{{{NS["rdf"]}}}about'] = ''
+            element = SubElement(element, f'{{{NS["xmp"]}}}CreatorTool')
+            element.text = self.generator
+        if self.created:
+            element = SubElement(rdf, f'{{{NS["rdf"]}}}Description')
+            element.attrib[f'{{{NS["rdf"]}}}about'] = ''
+            element = SubElement(element, f'{{{NS["xmp"]}}}CreateDate')
+            element.text = self.created
+        if self.modified:
+            element = SubElement(rdf, f'{{{NS["rdf"]}}}Description')
+            element.attrib[f'{{{NS["rdf"]}}}about'] = ''
+            element = SubElement(element, f'{{{NS["xmp"]}}}ModifyDate')
+            element.text = self.modified
+        return tostring(rdf, encoding='utf-8')

--- a/weasyprint/pdf/pdfa.py
+++ b/weasyprint/pdf/pdfa.py
@@ -4,8 +4,6 @@ from functools import partial
 
 import pydyf
 
-from .metadata import add_metadata
-
 
 def pdfa(pdf, metadata, document, page_streams, attachments, compress,
          version, variant):
@@ -65,7 +63,7 @@ def pdfa(pdf, metadata, document, page_streams, attachments, compress,
     if version == 1:
         # Metadata compression is forbidden for version 1.
         compress = False
-    add_metadata(pdf, metadata, 'a', version, variant, compress)
+    metadata.include_in_pdf(pdf, 'a', version, variant, compress)
 
     # Remove document information.
     if version >= 4:

--- a/weasyprint/pdf/pdfua.py
+++ b/weasyprint/pdf/pdfua.py
@@ -2,13 +2,11 @@
 
 from functools import partial
 
-from .metadata import add_metadata
-
 
 def pdfua(pdf, metadata, document, page_streams, attachments, compress, version):
     """Set metadata for PDF/UA documents."""
     # Common PDF metadata stream
-    add_metadata(pdf, metadata, 'ua', version, conformance=None, compress=compress)
+    metadata.include_in_pdf(pdf, 'ua', version, conformance=None, compress=compress)
 
 
 VARIANTS = {

--- a/weasyprint/pdf/pdfx.py
+++ b/weasyprint/pdf/pdfx.py
@@ -5,8 +5,6 @@ from time import localtime
 
 import pydyf
 
-from .metadata import add_metadata
-
 
 def pdfx(pdf, metadata, document, page_streams, attachments, compress, version,
          variant):
@@ -47,7 +45,7 @@ def pdfx(pdf, metadata, document, page_streams, attachments, compress, version,
         ])
 
     # Common PDF metadata stream.
-    add_metadata(pdf, metadata, 'x', version, conformance, compress=compress)
+    metadata.include_in_pdf(pdf, 'x', version, conformance, compress=compress)
 
 
 VARIANTS = {


### PR DESCRIPTION
The new API is:

`weasyprint invoice.html invoice.pdf --attachment=factur-x.xml --attachment-relationship=Data --xmp-metadata=rdf.xml --pdf-variant=pdf/a-3a`

The Python API has also been simplified:

```python
from weasyprint import Attachment, HTML

document = HTML("invoice.html").render()

factur_x_xml = Path("factur-x.xml").read_text()
attachment = Attachment(string=factur_x_xml, name="factur-x.xml", relationship="Data")
document.metadata.attachments = [attachment]

xmp_metadata = Path("rdf.xml").read_text().encode()
document.metadata.xmp_metadata = [xmp_metadata]

document.write_pdf("invoice.pdf", pdf_variant="pdf/a-3b")
```

Fix #2583.