### PR TITLE
Add dc:description to pdf/a meta data

### DIFF
--- a/weasyprint/pdf/metadata.py
+++ b/weasyprint/pdf/metadata.py
@@ -164,6 +164,14 @@ class DocumentMetadata:
             element = SubElement(element, f'{{{NS["rdf"]}}}li')
             element.attrib['xml:lang'] = 'x-default'
             element.text = self.description
+            
+            element = SubElement(rdf, f'{{{NS["rdf"]}}}Description')
+            element.attrib[f'{{{NS["rdf"]}}}about'] = ''
+            element = SubElement(element, f'{{{NS["dc"]}}}description')
+            element = SubElement(element, f'{{{NS["rdf"]}}}Alt')
+            element = SubElement(element, f'{{{NS["rdf"]}}}li')
+            element.attrib['xml:lang'] = 'x-default'
+            element.text = self.description
         if self.keywords:
             element = SubElement(rdf, f'{{{NS["rdf"]}}}Description')
             element.attrib[f'{{{NS["rdf"]}}}about'] = ''

--- a/weasyprint/pdf/metadata.py
+++ b/weasyprint/pdf/metadata.py
@@ -159,14 +159,6 @@ class DocumentMetadata:
         if self.description:
             element = SubElement(rdf, f'{{{NS["rdf"]}}}Description')
             element.attrib[f'{{{NS["rdf"]}}}about'] = ''
-            element = SubElement(element, f'{{{NS["dc"]}}}subject')
-            element = SubElement(element, f'{{{NS["rdf"]}}}Bag')
-            element = SubElement(element, f'{{{NS["rdf"]}}}li')
-            element.attrib['xml:lang'] = 'x-default'
-            element.text = self.description
-            
-            element = SubElement(rdf, f'{{{NS["rdf"]}}}Description')
-            element.attrib[f'{{{NS["rdf"]}}}about'] = ''
             element = SubElement(element, f'{{{NS["dc"]}}}description')
             element = SubElement(element, f'{{{NS["rdf"]}}}Alt')
             element = SubElement(element, f'{{{NS["rdf"]}}}li')


### PR DESCRIPTION
<img width="905" height="914" alt="Bildschirmfoto vom 2026-02-11 16-30-36" src="https://github.com/user-attachments/assets/8625a88d-3d29-4698-b78a-1b65b7954583" />

As you can see the current version is not compliant as apparently `dc:description` is missing.
I added this to the current implementation, so that it is not missing anymore and veraPDF does not complain.