### PR TITLE
Always describe font using absolute sizes

### DIFF
--- a/weasyprint/text/ffi.py
+++ b/weasyprint/text/ffi.py
@@ -329,7 +329,7 @@ ffi.cdef('''
 
     char * pango_font_description_to_string (const PangoFontDescription *desc);
 
-    PangoFontDescription * pango_font_describe (PangoFont *font);
+    PangoFontDescription * pango_font_describe_with_absolute_size (PangoFont *font);
     const char * pango_font_description_get_family (const PangoFontDescription *desc);
     guint pango_font_description_hash (const PangoFontDescription *desc);
 

--- a/weasyprint/text/fonts.py
+++ b/weasyprint/text/fonts.py
@@ -383,7 +383,8 @@ def get_pango_font_key(pango_font):
     # the same address for two different Pango maps. We should cache it in the
     # FontConfiguration object. See issue #2144.
     description = ffi.gc(
-        pango.pango_font_describe(pango_font), pango.pango_font_description_free)
+        pango.pango_font_describe_with_absolute_size(pango_font),
+        pango.pango_font_description_free)
     font_size = pango.pango_font_description_get_size(description) * FROM_UNITS
     mask = pango.PANGO_FONT_MASK_SIZE + pango.PANGO_FONT_MASK_GRAVITY
     pango.pango_font_description_unset_fields(description, mask)


### PR DESCRIPTION
It avoids problems with custom dpi scales set by users.

Note that forcing dpi values at the system level (such as done in #2606) may break small/petite caps, as Pango wants to change this value to generate fake variants when they’re missing in the font.

Fix #2687.