### PR TITLE
Fix tests for Debian Testing

### DIFF
--- a/tests/draw/test_column.py
+++ b/tests/draw/test_column.py
@@ -93,7 +93,7 @@ def test_column_rule_normal(assert_pixels):
       <style>
         img { display: inline-block; width: 1px; height: 1px }
         div { columns: 2; column-gap: normal }
-        body { margin: 0; font-size: 3px; line-height: 0 }
+        body { margin: 0; font: 3px/0 weasyprint }
         @page { margin: 0; size: 5PX 3px }
       </style>
       <div>

--- a/tests/draw/test_transform.py
+++ b/tests/draw/test_transform.py
@@ -6,89 +6,86 @@ from ..testing_utils import assert_no_logs
 @assert_no_logs
 def test_2d_transform_1(assert_pixels):
     assert_pixels('''
-        ________
-        ________
-        __BBBr__
-        __BBBB__
-        __BBBB__
-        __BBBB__
-        ________
-        ________
+        __________
+        __________
+        __BBBr____
+        __BBBB____
+        __BBBB____
+        __BBBB____
+        __________
+        __________
+        __________
+        __________
     ''', '''
       <style>
-        @page { size: 8px; margin: 2px; }
-        div { transform: rotate(90deg); font-size: 0 }
+        @page { size: 10px; margin: 2px }
+        body { font-size: 0 }
+        img { transform: rotate(90deg) }
       </style>
-      <div><img src="pattern.png"></div>''')
+      <body><img src="pattern.png">''')
 
 
 @assert_no_logs
 def test_2d_transform_2(assert_pixels):
     assert_pixels('''
-        ____________
-        ____________
-        _____BBBr___
-        _____BBBB___
-        _____BBBB___
-        _____BBBB___
-        ____________
-        ____________
-        ____________
-        ____________
-        ____________
-        ____________
+        __________
+        __________
+        _____BBBr_
+        _____BBBB_
+        _____BBBB_
+        _____BBBB_
+        __________
+        __________
+        __________
+        __________
     ''', '''
       <style>
-        @page { size: 12px; margin: 2px; }
-        div { transform: translateX(3px) rotate(90deg);
-              font-size: 0; width: 4px }
+        @page { size: 10px; margin: 2px }
+        body { font-size: 0 }
+        img { transform: translateX(3px) rotate(90deg) }
       </style>
-      <div><img src="pattern.png"></div>''')
+      <body><img src="pattern.png">''')
 
 
 @assert_no_logs
 def test_2d_transform_3(assert_pixels):
     # A translateX after the rotation is actually a translateY
     assert_pixels('''
-        ____________
-        ____________
-        ____________
-        ____________
-        ____________
-        __BBBr______
-        __BBBB______
-        __BBBB______
-        __BBBB______
-        ____________
-        ____________
-        ____________
+        __________
+        __________
+        __________
+        __________
+        __________
+        __BBBr____
+        __BBBB____
+        __BBBB____
+        __BBBB____
+        __________
     ''', '''
       <style>
-        @page { size: 12px; margin: 2px; }
-        div { transform: rotate(90deg) translateX(3px);
-              font-size: 0; width: 4px }
+        @page { size: 10px; margin: 2px }
+        body { font-size: 0 }
+        img { transform: rotate(90deg) translateX(3px) }
       </style>
-      <div><img src="pattern.png"></div>''')
+      <body><img src="pattern.png">''')
 
 
 @assert_no_logs
 def test_2d_transform_4(assert_pixels):
     assert_pixels('''
-        ____________
-        ____________
-        ____________
-        ____________
-        ____________
-        __BBBr______
-        __BBBB______
-        __BBBB______
-        __BBBB______
-        ____________
-        ____________
-        ____________
+        __________
+        __________
+        __________
+        __________
+        __________
+        __BBBr____
+        __BBBB____
+        __BBBB____
+        __BBBB____
+        __________
     ''', '''
       <style>
-        @page { size: 12px; margin: 2px; }
+        @page { size: 10px; margin: 2px }
         div { transform: rotate(90deg); font-size: 0; width: 4px }
         img { transform: translateX(3px) }
       </style>

--- a/tests/draw/test_visibility.py
+++ b/tests/draw/test_visibility.py
@@ -5,8 +5,8 @@ from ..testing_utils import assert_no_logs
 visibility_source = '''
   <style>
     @page { size: 12px 7px }
-    body { font: 1px/1 serif }
-    img { margin: 1px 0 0 1px; }
+    body { font-size: 0; line-height: 0 }
+    img { margin: 1px 0 0 1px }
     %s
   </style>
   <div>


### PR DESCRIPTION
Changes in Debian Testing break some tests.

The source of some problems are caused by default system fonts: test_column_rule_normal and visibility_source were depending on default fonts, and being more specific in rules fix the bug. The only surprise here is that we didn’t met problems with other distributions earlier.

The reason why test_visibility_* was broken is more cryptic. The image rotation seems to give small rounding errors that result in a very small vertical shift that Ghostscript handles strangely when rasterization is done.

Why this problem appeared in Debian Testing is another mystery, as it seems to be unrelated to fonts, and not much has changed in Ghostscript between Stable and Testing. Other distributions with recent packages (at least Debian, Gentoo, Fedora) and older Debian versions are not impacted by these problems.

Fix #2651.