### PR TITLE
Fix PDF text extraction for outside list markers

### DIFF
--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -1,5 +1,6 @@
 """Test PDF-related code, including metadata, bookmarks and hyperlinks."""
 
+from collections import defaultdict
 import hashlib
 import io
 import re
@@ -9,6 +10,7 @@ import pytest
 
 from weasyprint import Attachment
 from weasyprint.document import Document, DocumentMetadata
+from weasyprint.pdf.stream import Stream
 from weasyprint.text.fonts import FontConfiguration
 from weasyprint.urls import path2url
 
@@ -760,3 +762,111 @@ def test_pdf_tags_inline_table():
     FakeHTML(string='''
       <html lang="en"><table style="display: inline"><td>abc
     ''').write_pdf(pdf_tags=True)
+
+
+def _assert_text_objects_do_not_split_lines(html):
+    streams = []
+
+    def capture_streams(document, pdf):
+        streams.extend(
+            list(object_.stream) for object_ in pdf.objects if isinstance(object_, Stream))
+
+    FakeHTML(string=html).write_pdf(finisher=capture_streams)
+
+    for stream in streams:
+        text_objects = []
+        current_object = None
+        for command in stream:
+            if command == b'BT':
+                current_object = []
+            elif command == b'ET':
+                text_objects.append(current_object)
+                current_object = None
+            elif current_object is not None:
+                current_object.append(command)
+
+        object_y_positions = defaultdict(int)
+        for text_object in text_objects:
+            y_positions = {
+                float(command.split()[5])
+                for command in text_object
+                if command.endswith(b' Tm')
+            }
+            for y_position in y_positions:
+                object_y_positions[y_position] += 1
+
+        assert max(object_y_positions.values(), default=0) <= 1
+
+
+@assert_no_logs
+def test_list_markers_share_text_object():
+    # Regression test for extra standalone bullet markers in extracted PDF text.
+    _assert_text_objects_do_not_split_lines('''
+      <style>
+        ul { margin: 1em 0; padding-left: 40px }
+        li { display: list-item }
+      </style>
+      <ul>
+        <li>One short bullet</li>
+        <li>Two short bullet</li>
+        <li>Three short bullet</li>
+      </ul>
+    ''')
+
+
+@assert_no_logs
+def test_nested_list_markers_share_text_object():
+    _assert_text_objects_do_not_split_lines('''
+      <style>
+        ul { margin: 1em 0; padding-left: 40px }
+        li { display: list-item }
+      </style>
+      <ul>
+        <li>One short bullet
+          <ul>
+            <li>Nested item one</li>
+            <li>Nested item two</li>
+          </ul>
+        </li>
+        <li>Two short bullet</li>
+      </ul>
+    ''')
+
+
+@assert_no_logs
+def test_rtl_list_markers_share_text_object():
+    _assert_text_objects_do_not_split_lines('''
+      <style>
+        ul { margin: 1em 0; padding-left: 40px }
+        li { display: list-item }
+      </style>
+      <div dir="rtl">
+        <ul>
+          <li>One short bullet</li>
+          <li>Two short bullet</li>
+          <li>Three short bullet</li>
+        </ul>
+      </div>
+    ''')
+
+
+@assert_no_logs
+def test_page_break_list_markers_share_text_object():
+    _assert_text_objects_do_not_split_lines('''
+      <style>
+        @page { size: 80px 100px }
+        body { margin: 0 }
+        ul { margin: 0; padding-left: 18px }
+        li { display: list-item; margin: 0 0 6px }
+      </style>
+      <ul>
+        <li>One short bullet</li>
+        <li>Two short bullet</li>
+        <li>Three short bullet</li>
+        <li>Four short bullet</li>
+        <li>Five short bullet</li>
+        <li>Six short bullet</li>
+        <li>Seven short bullet</li>
+        <li>Eight short bullet</li>
+      </ul>
+    ''')

--- a/weasyprint/stacking.py
+++ b/weasyprint/stacking.py
@@ -70,10 +70,11 @@ def _dispatch(box, page, child_contexts, blocks, floats, blocks_and_cells):
     if isinstance(box, AbsolutePlaceholder):
         box = box._box
     style = box.style
+    positioned = style['position'] != 'static' and not box.is_outside_marker
 
     # Remove boxes defining a new stacking context from the children list.
     defines_stacking_context = (
-        (style['position'] != 'static' and style['z_index'] != 'auto') or
+        (positioned and style['z_index'] != 'auto') or
         (box.is_grid_item and style['z_index'] != 'auto') or
         style['opacity'] < 1 or
         style['transform'] or  # 'transform: none' gives a "falsy" empty list
@@ -83,7 +84,7 @@ def _dispatch(box, page, child_contexts, blocks, floats, blocks_and_cells):
         return
 
     stacking_classes = (boxes.InlineBlockBox, boxes.InlineFlexBox, boxes.InlineGridBox)
-    if style['position'] != 'static':
+    if positioned:
         assert style['z_index'] == 'auto'
         # "Fake" context: sub-contexts will go in this `child_contexts` list.
         # Insert at the position before creating the sub-context.


### PR DESCRIPTION
Fixes https://github.com/Kozea/WeasyPrint/issues/2715

Outside list markers were being emitted as separate positioned text runs, which caused extractors like PyMuPDF to see stray bullet-only spans.

Avoid treating outside markers as positioned stacking contexts during PDF painting, and add regression coverage for list marker text-object emission.

## Summary

This fixes PDF text extraction for outside list markers.

Previously, native ul/li markers could be emitted as separate positioned PDF text runs from their corresponding list item text. In practice, tools like PyMuPDF could then extract stray bullet-only spans such
  as •  instead of a single line like • One short bullet.

This change keeps outside list markers out of the separate positioned stacking-context path during painting, so marker and item text are emitted together in the same PDF text object for a given line.

## What Changed

  - Update C:/DevGit/AndyBevan/Github/WeasyPrint/weasyprint/stacking.py so is_outside_marker boxes are not treated as positioned stacking contexts for painting.
  - Add regression coverage in C:/DevGit/AndyBevan/Github/WeasyPrint/tests/test_pdf.py for:
      - basic outside list markers
      - nested lists
      - RTL lists
      - lists spanning multiple pages

  ## Why This Fix

  The issue was not in CSS parsing or marker box creation. The marker boxes were laid out correctly, but during painting they were handled as separate positioned content, which split marker and item text into
  different PDF text runs.

  By keeping outside markers in normal paint order, the emitted PDF stream no longer splits the bullet from the line’s text, and extraction matches the visual reading order.

  ## Verification

  Focused checks:

  - tests/test_pdf.py -k list_markers
  - tests/draw/test_list.py

  Full suite on this machine:

  - 4022 passed
  - 6 failed
  - 41 xfailed

 The remaining 6 failures are pre-existing local platform/font pixel-test failures unrelated to this change:

  - C:/DevGit/AndyBevan/Github/WeasyPrint/tests/draw/test_text.py
  - C:/DevGit/AndyBevan/Github/WeasyPrint/tests/test_acid2.py

  ## Issue

  Fixes #2715