### PR TITLE
Replace .isdigit() with ASCII-only digit check

### DIFF
--- a/tests/test_html_utils.py
+++ b/tests/test_html_utils.py
@@ -1,0 +1,30 @@
+"""Tests for HTML microsyntax parsing utilities."""
+
+from weasyprint.html_utils import is_ascii_digits
+
+
+def test_is_ascii_digits_basic():
+    assert is_ascii_digits('123')
+    assert is_ascii_digits('0')
+    assert is_ascii_digits('007')
+
+
+def test_is_ascii_digits_rejects_empty():
+    assert not is_ascii_digits('')
+
+
+def test_is_ascii_digits_rejects_non_digits():
+    assert not is_ascii_digits('abc')
+    assert not is_ascii_digits('12px')
+    assert not is_ascii_digits('100%')
+    assert not is_ascii_digits(' 5')
+    assert not is_ascii_digits('+3')
+    assert not is_ascii_digits('-1')
+
+
+def test_is_ascii_digits_rejects_non_ascii_digits():
+    # Python's str.isdigit() returns True for these, but HTML spec
+    # requires ASCII digits only.
+    assert not is_ascii_digits('\u0660\u0661')  # Arabic-Indic digits
+    assert not is_ascii_digits('\u0966')  # Devanagari digit
+    assert not is_ascii_digits('3\u0660')  # mixed ASCII and non-ASCII

--- a/weasyprint/css/__init__.py
+++ b/weasyprint/css/__init__.py
@@ -25,6 +25,7 @@ import tinycss2.nth
 from PIL.ImageCms import ImageCmsProfile
 
 from .. import CSS
+from ..html_utils import is_ascii_digits
 from ..logger import LOGGER, PROGRESS_LOGGER
 from ..text.fonts import FontConfiguration
 from ..urls import URLFetchingError, fetch, get_url_attribute, url_join
@@ -399,7 +400,7 @@ def find_style_attributes(tree, presentational_hints=False, base_url=None):
                     element, f'border-spacing:{element.get("cellspacing")}px')
             if element.get('cellpadding'):
                 cellpadding = element.get('cellpadding')
-                if cellpadding.isdigit():
+                if is_ascii_digits(cellpadding):
                     cellpadding += 'px'
                 # TODO: don't match subtables cells
                 for subelement in element.iter():
@@ -412,24 +413,24 @@ def find_style_attributes(tree, presentational_hints=False, base_url=None):
                             f'padding-bottom:{cellpadding};')
             if element.get('hspace'):
                 hspace = element.get('hspace')
-                if hspace.isdigit():
+                if is_ascii_digits(hspace):
                     hspace += 'px'
                 yield specificity, check_style_attribute(
                     element, f'margin-left:{hspace};margin-right:{hspace}')
             if element.get('vspace'):
                 vspace = element.get('vspace')
-                if vspace.isdigit():
+                if is_ascii_digits(vspace):
                     vspace += 'px'
                 yield specificity, check_style_attribute(
                     element, f'margin-top:{vspace};margin-bottom:{vspace}')
             if element.get('width'):
                 style_attribute = f'width:{element.get("width")}'
-                if element.get('width').isdigit():
+                if is_ascii_digits(element.get('width')):
                     style_attribute += 'px'
                 yield specificity, check_style_attribute(element, style_attribute)
             if element.get('height'):
                 style_attribute = f'height:{element.get("height")}'
-                if element.get('height').isdigit():
+                if is_ascii_digits(element.get('height')):
                     style_attribute += 'px'
                 yield specificity, check_style_attribute(element, style_attribute)
             if element.get('background'):
@@ -462,13 +463,13 @@ def find_style_attributes(tree, presentational_hints=False, base_url=None):
             if element.tag in ('tr', 'td', 'th'):
                 if element.get('height'):
                     style_attribute = f'height:{element.get("height")}'
-                    if element.get('height').isdigit():
+                    if is_ascii_digits(element.get('height')):
                         style_attribute += 'px'
                     yield specificity, check_style_attribute(element, style_attribute)
                 if element.tag in ('td', 'th'):
                     if element.get('width'):
                         style_attribute = f'width:{element.get("width")}'
-                        if element.get('width').isdigit():
+                        if is_ascii_digits(element.get('width')):
                             style_attribute += 'px'
                         yield specificity, check_style_attribute(
                             element, style_attribute)
@@ -482,7 +483,7 @@ def find_style_attributes(tree, presentational_hints=False, base_url=None):
         elif element.tag == 'col':
             if element.get('width'):
                 style_attribute = f'width:{element.get("width")}'
-                if element.get('width').isdigit():
+                if is_ascii_digits(element.get('width')):
                     style_attribute += 'px'
                 yield specificity, check_style_attribute(element, style_attribute)
         elif element.tag == 'hr':
@@ -504,7 +505,7 @@ def find_style_attributes(tree, presentational_hints=False, base_url=None):
                     element, f'height:{size - 2}px')
             if element.get('width'):
                 style_attribute = f'width:{element.get("width")}'
-                if element.get('width').isdigit():
+                if is_ascii_digits(element.get('width')):
                     style_attribute += 'px'
                 yield specificity, check_style_attribute(element, style_attribute)
             if element.get('color'):
@@ -522,13 +523,13 @@ def find_style_attributes(tree, presentational_hints=False, base_url=None):
                         element, 'vertical-align:middle')
                 if element.get('hspace'):
                     hspace = element.get('hspace')
-                    if hspace.isdigit():
+                    if is_ascii_digits(hspace):
                         hspace += 'px'
                     yield specificity, check_style_attribute(
                         element, f'margin-left:{hspace};margin-right:{hspace}')
                 if element.get('vspace'):
                     vspace = element.get('vspace')
-                    if vspace.isdigit():
+                    if is_ascii_digits(vspace):
                         vspace += 'px'
                     yield specificity, check_style_attribute(
                         element, f'margin-top:{vspace};margin-bottom:{vspace}')
@@ -536,12 +537,12 @@ def find_style_attributes(tree, presentational_hints=False, base_url=None):
                 # lot of W3C tests rely on this attribute being applied to img
                 if element.get('width'):
                     style_attribute = f'width:{element.get("width")}'
-                    if element.get('width').isdigit():
+                    if is_ascii_digits(element.get('width')):
                         style_attribute += 'px'
                     yield specificity, check_style_attribute(element, style_attribute)
                 if element.get('height'):
                     style_attribute = f'height:{element.get("height")}'
-                    if element.get('height').isdigit():
+                    if is_ascii_digits(element.get('height')):
                         style_attribute += 'px'
                     yield specificity, check_style_attribute(element, style_attribute)
                 if element.tag in ('img', 'object', 'input'):

--- a/weasyprint/html_utils.py
+++ b/weasyprint/html_utils.py
@@ -1,0 +1,14 @@
+"""Utility functions for HTML microsyntax parsing."""
+
+ASCII_DIGITS = frozenset('0123456789')
+
+
+def is_ascii_digits(string):
+    """Return whether string is non-empty and contains only ASCII digits.
+
+    Unlike Python's str.isdigit(), this rejects non-ASCII digit characters
+    (e.g. Arabic-Indic digits) per the HTML specification:
+    https://infra.spec.whatwg.org/#ascii-digit
+
+    """
+    return bool(string) and all(c in ASCII_DIGITS for c in string)

--- a/weasyprint/pdf/anchors.py
+++ b/weasyprint/pdf/anchors.py
@@ -9,6 +9,7 @@ from urllib.parse import unquote, urlsplit
 import pydyf
 
 from .. import Attachment
+from ..html_utils import is_ascii_digits
 from ..logger import LOGGER
 from ..text.ffi import ffi, gobject, pango
 from ..text.fonts import get_font_description
@@ -268,7 +269,7 @@ def add_forms(forms, matrix, pdf, page, resources, stream, font_map):
                 field['Ff'] = 1 << (14 - 1)
             elif input_type == 'file':
                 field['Ff'] = 1 << (21 - 1)
-            if (max_length := element.get('maxlength', '')).isdigit():
+            if is_ascii_digits(max_length := element.get('maxlength', '')):
                 field['MaxLen'] = max_length
             pdf.add_object(field)
 


### PR DESCRIPTION
## Summary

- Add `is_ascii_digits()` utility that only matches ASCII digits (`0-9`), unlike Python's `str.isdigit()` which also matches non-ASCII digit characters (e.g. Arabic-Indic `٠١٢٣`)
- Replace all `.isdigit()` calls in presentational hint parsing (`css/__init__.py`) and PDF form field handling (`pdf/anchors.py`) with the new function
- Affected attributes: `cellpadding`, `hspace`, `vspace`, `width`, `height`, `maxlength`

## Context

Python's `str.isdigit()` returns `True` for non-ASCII digit characters, but the [HTML spec](https://infra.spec.whatwg.org/#ascii-digit) defines digits as ASCII digits only (`0-9`). This could cause incorrect unit appending (e.g. treating Arabic-Indic digits as a bare number and appending `px`).

Note: the two `.isdigit()` calls in `svg/bounding_box.py` are intentionally left unchanged — they check individual characters in SVG path data, a different context.

Related to #2636.

## Test plan

- [x] Unit tests for `is_ascii_digits`: basic values, empty string, non-digits, non-ASCII digits
- [x] All existing tests pass (3985 passed, 0 regressions)
- [x] `ruff check` passes

Fixes #2721