### PR TITLE
Fix: honor break-before and break-after on floated elements

### DIFF
--- a/tests/layout/test_float.py
+++ b/tests/layout/test_float.py
@@ -840,3 +840,46 @@ def test_first_letter_float():
     assert first_letter.position_x == 0
     # TODO: fix problem described in #1859.
     # assert text.position_x == 20
+
+
+@assert_no_logs
+def test_float_break_after_page():
+    # https://github.com/Kozea/WeasyPrint/issues/2277
+    # break-after: page on a floated element should force a page break.
+    pages = render_pages('''
+      <style>
+        @page { size: 100px; margin: 10px }
+      </style>
+      <div style="break-after: page; float: left">float</div>
+      <div>end</div>
+    ''')
+    assert len(pages) == 2
+    html1, = pages[0].children
+    body1, = html1.children
+    float_div, = body1.children
+    assert float_div.position_y == 10
+    html2, = pages[1].children
+    body2, = html2.children
+    end_div, = body2.children
+    assert end_div.position_y == 10
+
+
+@assert_no_logs
+def test_float_break_before_page():
+    # break-before: page on a floated element should force a page break.
+    pages = render_pages('''
+      <style>
+        @page { size: 100px; margin: 10px }
+      </style>
+      <div>start</div>
+      <div style="break-before: page; float: left">float</div>
+    ''')
+    assert len(pages) == 2
+    html1, = pages[0].children
+    body1, = html1.children
+    start_div, = body1.children
+    assert start_div.position_y == 10
+    html2, = pages[1].children
+    body2, = html2.children
+    float_div, = body2.children
+    assert float_div.position_y == 10

--- a/tests/layout/test_float.py
+++ b/tests/layout/test_float.py
@@ -844,42 +844,103 @@ def test_first_letter_float():
 
 @assert_no_logs
 def test_float_break_after_page():
-    # https://github.com/Kozea/WeasyPrint/issues/2277
-    # break-after: page on a floated element should force a page break.
-    pages = render_pages('''
-      <style>
-        @page { size: 100px; margin: 10px }
-      </style>
+    page1, page2 = render_pages('''
       <div style="break-after: page; float: left">float</div>
       <div>end</div>
     ''')
-    assert len(pages) == 2
-    html1, = pages[0].children
-    body1, = html1.children
-    float_div, = body1.children
-    assert float_div.position_y == 10
-    html2, = pages[1].children
-    body2, = html2.children
-    end_div, = body2.children
-    assert end_div.position_y == 10
+    html, = page1.children
+    body, = html.children
+    div, = body.children
+    assert div.position_y == 0
+    assert div.children[0].children[0].text == 'float'
+    html, = page2.children
+    body, = html.children
+    div, = body.children
+    assert div.position_y == 0
+    assert div.children[0].children[0].text == 'end'
+
+
+@assert_no_logs
+def test_float_in_block_break_after_page():
+    page1, page2 = render_pages('''
+      <div>
+        <div style="break-after: page; float: left">float</div>
+      </div>
+      <div>end</div>
+    ''')
+    html, = page1.children
+    body, = html.children
+    div, = body.children
+    assert div.position_y == 0
+    assert div.children[0].children[0].children[0].text == 'float'
+    html, = page2.children
+    body, = html.children
+    div, = body.children
+    assert div.position_y == 0
+    assert div.children[0].children[0].text == 'end'
 
 
 @assert_no_logs
 def test_float_break_before_page():
-    # break-before: page on a floated element should force a page break.
-    pages = render_pages('''
-      <style>
-        @page { size: 100px; margin: 10px }
-      </style>
+    page1, page2 = render_pages('''
       <div>start</div>
       <div style="break-before: page; float: left">float</div>
     ''')
-    assert len(pages) == 2
-    html1, = pages[0].children
-    body1, = html1.children
-    start_div, = body1.children
-    assert start_div.position_y == 10
-    html2, = pages[1].children
-    body2, = html2.children
-    float_div, = body2.children
-    assert float_div.position_y == 10
+    html, = page1.children
+    body, = html.children
+    div, = body.children
+    assert div.position_y == 0
+    assert div.children[0].children[0].text == 'start'
+    html, = page2.children
+    body, = html.children
+    div, = body.children
+    assert div.position_y == 0
+    assert div.children[0].children[0].text == 'float'
+
+
+@assert_no_logs
+def test_float_in_div_break_before_page():
+    page1, page2 = render_pages('''
+      <div>start</div>
+      <div>
+        <div style="break-before: page; float: left">float</div>
+      </div>
+    ''')
+    html, = page1.children
+    body, = html.children
+    div, = body.children
+    assert div.position_y == 0
+    assert div.children[0].children[0].text == 'start'
+    html, = page2.children
+    body, = html.children
+    div, = body.children
+    assert div.position_y == 0
+    assert div.children[0].children[0].children[0].text == 'float'
+
+
+@assert_no_logs
+def test_float_break_after_page_no_fit():
+    page1, page2, page3 = render_pages('''
+      <style>
+        @page { size: 100px }
+        html { line-height: 20px }
+      </style>
+      <div style="height: 90px">start</div>
+      <div style="break-after: right; float: left">float</div>
+      <div>end</div>
+    ''')
+    html, = page1.children
+    body, = html.children
+    div, = body.children
+    assert div.position_y == 0
+    assert div.children[0].children[0].text == 'start'
+    html, = page2.children
+    body, = html.children
+    div, = body.children
+    assert div.position_y == 0
+    assert div.children[0].children[0].text == 'float'
+    html, = page3.children
+    body, = html.children
+    div, = body.children
+    assert div.position_y == 0
+    assert div.children[0].children[0].text == 'end'

--- a/weasyprint/formatting_structure/boxes.py
+++ b/weasyprint/formatting_structure/boxes.py
@@ -407,12 +407,13 @@ class ParentBox(Box):
             raise ValueError('Table wrapper without a table')
 
     def page_values(self):
+        # See https://www.w3.org/TR/css-break-4/#break-propagation.
+        # The specification only includes in-flow boxes, but as page breaks can appear
+        # between floats, it makes sense to include them here too.
         start_value, end_value = super().page_values()
-        # TODO: We should find Class A possible page breaks according to
-        # https://drafts.csswg.org/css-page-3/#propdef-page
-        # Keep only children in normal flow for now.
         children = [
-            child for child in self.children if child.is_in_normal_flow()]
+            child for child in self.children
+            if child.is_in_normal_flow() or child.is_floated()]
         if children:
             if len(children) == 1:
                 page_values = children[0].page_values()

--- a/weasyprint/layout/block.py
+++ b/weasyprint/layout/block.py
@@ -237,7 +237,7 @@ def relative_positioning(box, containing_block):
 
 def _out_of_flow_layout(context, box, index, child, new_children,
                         page_is_empty, absolute_boxes, fixed_boxes,
-                        adjoining_margins, bottom_space):
+                        adjoining_margins, bottom_space, next_page):
     stop = False  # whether we should stop parent rendering after this layout
     resume_at = None  # where to resume in-flow rendering
     new_child = None  # child rendered by this layout
@@ -260,9 +260,35 @@ def _out_of_flow_layout(context, box, index, child, new_children,
 
     # Float child layout.
     elif child.is_floated():
+        # Check for forced break-before on the float.
+        # https://drafts.csswg.org/css-break/#break-between
+        last_in_flow_child = find_last_in_flow_child(new_children)
+        if last_in_flow_child is not None:
+            page_break = block_level_page_break(last_in_flow_child, child)
+            if force_page_break(page_break, context):
+                page_name = child.page_values()[0]
+                next_page = {'break': page_break, 'page': page_name}
+                resume_at = {index: None}
+                stop = True
+                return (
+                    stop, resume_at, new_child, out_of_flow_resume_at,
+                    next_page)
+
         new_child, out_of_flow_resume_at = float_layout(
             context, child, box, absolute_boxes, fixed_boxes, bottom_space,
             skip_stack=None)
+
+        # Check for forced break-after on the float.
+        page_break = child.style['break_after']
+        if force_page_break(page_break, context):
+            new_child.index = index
+            new_children.append(new_child)
+            page_name = child.page_values()[1]
+            next_page = {'break': page_break, 'page': page_name}
+            resume_at = {index + 1: None}
+            stop = True
+            return (
+                stop, resume_at, new_child, out_of_flow_resume_at, next_page)
 
         # Check that child doesn’t overflow page.
         page_overflow = context.overflows_page(
@@ -298,7 +324,7 @@ def _out_of_flow_layout(context, box, index, child, new_children,
         page = context.current_page
         context.running_elements[running_name][page].append(child)
 
-    return stop, resume_at, new_child, out_of_flow_resume_at
+    return stop, resume_at, new_child, out_of_flow_resume_at, next_page
 
 
 def _break_line(context, box, line, new_children, needed, page_is_empty, index,
@@ -734,10 +760,11 @@ def block_container_layout(context, box, bottom_space, skip_stack, page_is_empty
         if not child.is_in_normal_flow():
             # Layout out-of-flow child.
             abort = False
-            stop, resume_at, new_child, out_of_flow_resume_at = (
+            stop, resume_at, new_child, out_of_flow_resume_at, next_page = (
                 _out_of_flow_layout(
                     context, box, index, child, new_children, page_is_empty,
-                    absolute_boxes, fixed_boxes, adjoining_margins, bottom_space))
+                    absolute_boxes, fixed_boxes, adjoining_margins,
+                    bottom_space, next_page))
             if out_of_flow_resume_at:
                 context.add_broken_out_of_flow(
                     new_child, child, box, out_of_flow_resume_at)

--- a/weasyprint/layout/block.py
+++ b/weasyprint/layout/block.py
@@ -237,7 +237,7 @@ def relative_positioning(box, containing_block):
 
 def _out_of_flow_layout(context, box, index, child, new_children,
                         page_is_empty, absolute_boxes, fixed_boxes,
-                        adjoining_margins, bottom_space, next_page):
+                        adjoining_margins, bottom_space):
     stop = False  # whether we should stop parent rendering after this layout
     resume_at = None  # where to resume in-flow rendering
     new_child = None  # child rendered by this layout
@@ -300,7 +300,7 @@ def _out_of_flow_layout(context, box, index, child, new_children,
         page = context.current_page
         context.running_elements[running_name][page].append(child)
 
-    return stop, resume_at, new_child, out_of_flow_resume_at, next_page
+    return stop, resume_at, new_child, out_of_flow_resume_at
 
 
 def _break_line(context, box, line, new_children, needed, page_is_empty, index,
@@ -736,11 +736,9 @@ def block_container_layout(context, box, bottom_space, skip_stack, page_is_empty
 
         if not stop and not child.is_in_normal_flow():
             # Layout out-of-flow child.
-            stop, resume_at, new_child, out_of_flow_resume_at, next_page = (
-                _out_of_flow_layout(
-                    context, box, index, child, new_children, page_is_empty,
-                    absolute_boxes, fixed_boxes, adjoining_margins,
-                    bottom_space, next_page))
+            stop, resume_at, new_child, out_of_flow_resume_at = _out_of_flow_layout(
+                context, box, index, child, new_children, page_is_empty, absolute_boxes,
+                fixed_boxes, adjoining_margins, bottom_space)
             if out_of_flow_resume_at:
                 context.add_broken_out_of_flow(
                     new_child, child, box, out_of_flow_resume_at)

--- a/weasyprint/layout/block.py
+++ b/weasyprint/layout/block.py
@@ -262,33 +262,9 @@ def _out_of_flow_layout(context, box, index, child, new_children,
     elif child.is_floated():
         # Check for forced break-before on the float.
         # https://drafts.csswg.org/css-break/#break-between
-        last_in_flow_child = find_last_in_flow_child(new_children)
-        if last_in_flow_child is not None:
-            page_break = block_level_page_break(last_in_flow_child, child)
-            if force_page_break(page_break, context):
-                page_name = child.page_values()[0]
-                next_page = {'break': page_break, 'page': page_name}
-                resume_at = {index: None}
-                stop = True
-                return (
-                    stop, resume_at, new_child, out_of_flow_resume_at,
-                    next_page)
-
         new_child, out_of_flow_resume_at = float_layout(
             context, child, box, absolute_boxes, fixed_boxes, bottom_space,
             skip_stack=None)
-
-        # Check for forced break-after on the float.
-        page_break = child.style['break_after']
-        if force_page_break(page_break, context):
-            new_child.index = index
-            new_children.append(new_child)
-            page_name = child.page_values()[1]
-            next_page = {'break': page_break, 'page': page_name}
-            resume_at = {index + 1: None}
-            stop = True
-            return (
-                stop, resume_at, new_child, out_of_flow_resume_at, next_page)
 
         # Check that child doesn’t overflow page.
         page_overflow = context.overflows_page(
@@ -304,8 +280,8 @@ def _out_of_flow_layout(context, box, index, child, new_children,
         else:
             # Child doesn’t fit and we can break, find where to break and stop
             # parent rendering.
-            last_in_flow_child = find_last_in_flow_child(new_children)
-            page_break = block_level_page_break(last_in_flow_child, child)
+            last_child = find_last_class_a_break_point_child(new_children)
+            page_break = block_level_page_break(last_child, child)
             resume_at = {index: None}
             out_of_flow_resume_at = None
             stop = True
@@ -505,25 +481,10 @@ def _in_flow_layout(context, box, index, child, new_children, page_is_empty,
                     discard, next_page, max_lines):
     abort = stop = False
 
-    # Find possible page break between in-flow siblings.
-    last_in_flow_child = find_last_in_flow_child(new_children)
-    if last_in_flow_child is not None:
-        page_break = block_level_page_break(last_in_flow_child, child)
-        page_name = block_level_page_name(last_in_flow_child, child)
-        if page_name or force_page_break(page_break, context):
-            page_name = child.page_values()[0]
-            next_page = {'break': page_break, 'page': page_name}
-            resume_at = {index: None}
-            stop = True
-            return (
-                abort, stop, resume_at, position_y, adjoining_margins,
-                next_page, new_children, max_lines)
-    else:
-        page_break = 'auto'
-
     # Resolve percentages and collapsing top margins.
     if not box.is_table_wrapper:
         resolve_percentages(child, box)
+        last_in_flow_child = find_last_in_flow_child(new_children)
         if last_in_flow_child is None and box.top_margin_collapses():
             # TODO: add the adjoining descendants' margin top to
             # [child.margin_top].
@@ -632,6 +593,10 @@ def _in_flow_layout(context, box, index, child, new_children, page_is_empty,
 
     if new_child is None:
         # Nothing fits in the remaining space of this page: break.
+        page_break = 'auto'
+        last_child = find_last_class_a_break_point_child(new_children)
+        if last_child is not None:
+            page_break = block_level_page_break(last_child, child)
         if avoid_page_break(page_break, context):
             # TODO: fill the blank space at the bottom of the page.
             result = find_earlier_page_break(
@@ -755,11 +720,22 @@ def block_container_layout(context, box, bottom_space, skip_stack, page_is_empty
     for index, child in enumerate(box.children[skip:], start=(skip or 0)):
         child.position_x = position_x
         child.position_y = position_y  # doesn’t count adjoining_margins
+        abort = stop = False
         new_footnotes = []
 
-        if not child.is_in_normal_flow():
+        if child.is_in_normal_flow() or child.is_floated():
+            # Find possible page break between siblings.
+            last_child = find_last_class_a_break_point_child(new_children)
+            if last_child is not None:
+                page_break = block_level_page_break(last_child, child)
+                page_name = block_level_page_name(last_child, child)
+                if page_name or force_page_break(page_break, context):
+                    next_page = {'break': page_break, 'page': page_name}
+                    resume_at = {index: None}
+                    stop = True
+
+        if not stop and not child.is_in_normal_flow():
             # Layout out-of-flow child.
-            abort = False
             stop, resume_at, new_child, out_of_flow_resume_at, next_page = (
                 _out_of_flow_layout(
                     context, box, index, child, new_children, page_is_empty,
@@ -773,7 +749,7 @@ def block_container_layout(context, box, bottom_space, skip_stack, page_is_empty
                 if child.style['direction'] == 'rtl':
                     new_child.position_x += box.width + box.padding_right
 
-        elif isinstance(child, boxes.LineBox):
+        elif not stop and isinstance(child, boxes.LineBox):
             # Layout line child.
             (abort, stop, resume_at, position_y,
              new_footnotes, max_lines) = _linebox_layout(
@@ -785,7 +761,7 @@ def block_container_layout(context, box, bottom_space, skip_stack, page_is_empty
             adjoining_margins = []
             first_letter_style = first_line_style = None
 
-        else:
+        elif not stop:
             # Layout in-flow child.
             (abort, stop, resume_at, position_y, adjoining_margins,
              next_page, new_children, new_max_lines) = _in_flow_layout(
@@ -959,6 +935,21 @@ def collapse_margin(adjoining_margins):
     return max(positives) + min(negatives)
 
 
+def _add_break_values(box, side):
+    block_parallel_box_types = (
+        boxes.BlockLevelBox, boxes.TableRowGroupBox, boxes.TableRowBox)
+    values = []
+    while isinstance(box, block_parallel_box_types) and (
+            box.is_in_normal_flow() or box.is_floated()):
+        values.append(box.style[f'break_{side}'])
+        if not box.children:
+            break
+        box = box.children[-1 if side == 'after' else 0]
+    if side == 'after':
+        values.reverse()
+    return values
+
+
 def block_level_page_break(sibling_before, sibling_after):
     """Get the correct page break value between siblings.
 
@@ -973,30 +964,12 @@ def block_level_page_break(sibling_before, sibling_after):
     * 'left' or 'right' take priority over 'always', 'avoid' or 'auto'
     * Among 'left' and 'right', later values in the tree take priority.
 
-    See https://drafts.csswg.org/css-page-3/#allowed-pg-brk
-
     """
-    values = []
     # https://drafts.csswg.org/css-break-3/#possible-breaks
-    block_parallel_box_types = (
-        boxes.BlockLevelBox, boxes.TableRowGroupBox, boxes.TableRowBox)
-
-    box = sibling_before
-    while isinstance(box, block_parallel_box_types):
-        values.append(box.style['break_after'])
-        if not box.children:
-            break
-        box = box.children[-1]
-    values.reverse()  # Have them in tree order
-
-    box = sibling_after
-    while isinstance(box, block_parallel_box_types):
-        values.append(box.style['break_before'])
-        if not box.children:
-            break
-        box = box.children[0]
-
     result = 'auto'
+    values = [
+        *_add_break_values(sibling_before, 'after'),
+        *_add_break_values(sibling_after, 'before')]
     for value in values:
         if value in ('left', 'right', 'recto', 'verso') or (value, result) in (
                 ('page', 'auto'),
@@ -1102,9 +1075,17 @@ def find_earlier_page_break(context, children, absolute_boxes, fixed_boxes):
 
 
 def find_last_in_flow_child(children):
-    """Find and return the last in-flow child of given ``children``."""
+    """Return the last in-flow child of given ``children``."""
     for child in reversed(children):
         if child.is_in_normal_flow():
+            return child
+
+
+def find_last_class_a_break_point_child(children):
+    """Return the last child of given ``children`` for Class-A break points."""
+    # See https://www.w3.org/TR/css-break-4/#btw-blocks.
+    for child in reversed(children):
+        if child.is_in_normal_flow() or child.is_floated():
             return child
 
 


### PR DESCRIPTION
## Summary
- Floated elements bypassed break property handling because they are routed through `_out_of_flow_layout` instead of `_in_flow_layout`
- Added forced page break detection for floats following the CSS Fragmentation spec: *"User agents should also apply these properties to floated boxes whose containing block is in the normal flow of the root fragmented element."*
- Handles both `break-before` and `break-after` on floated elements

## Test plan
- [x] Added `test_float_break_after_page` — verifies `break-after: page` on a float forces a page break
- [x] Added `test_float_break_before_page` — verifies `break-before: page` on a float forces a page break

Fixes #2277