### PR TITLE
Support SVG transform angle units

### DIFF
--- a/tests/draw/svg/test_transform.py
+++ b/tests/draw/svg/test_transform.py
@@ -1,5 +1,7 @@
 """Test how SVG shapes are transformed."""
 
+import pytest
+
 from ...testing_utils import assert_no_logs
 
 
@@ -147,8 +149,10 @@ def test_transform_rotate_cx_cy(assert_pixels):
     ''')
 
 
+@pytest.mark.parametrize(
+    'angle', ['90deg', '100grad', '1.5707963267948966rad', '.25turn'])
 @assert_no_logs
-def test_transform_rotate_degrees(assert_same_renderings):
+def test_transform_rotate_angle_units(assert_same_renderings, angle):
     assert_same_renderings('''
       <style>
         @page { size: 9px }
@@ -158,57 +162,14 @@ def test_transform_rotate_degrees(assert_same_renderings):
         <rect x="2" y="-7" width="4" height="5" transform="rotate(90)"
               stroke-width="2" stroke="red" fill="none" />
       </svg>
-    ''', '''
+    ''', f'''
       <style>
-        @page { size: 9px }
-        svg { display: block }
+        @page {{ size: 9px }}
+        svg {{ display: block }}
       </style>
       <svg width="9px" height="9px" xmlns="http://www.w3.org/2000/svg">
-        <rect x="2" y="-7" width="4" height="5" transform="rotate(90deg)"
+        <rect x="2" y="-7" width="4" height="5" transform="rotate({angle})"
               stroke-width="2" stroke="red" fill="none" />
-      </svg>
-    ''')
-
-
-@assert_no_logs
-def test_transform_mermaid_gantt_css(assert_same_renderings):
-    assert_same_renderings('''
-      <style>
-        @page { size: 40px 40px }
-        svg { display: block }
-      </style>
-      <svg width="40px" height="40px" xmlns="http://www.w3.org/2000/svg">
-        <rect x="14" y="4" width="10" height="10" transform-origin="19px 9px"
-              transform="rotate(45) scale(.7 .7)"
-              stroke="green" fill="green" />
-        <g transform="translate(12, 18)">
-          <text y="3" transform="translate(3 1) rotate(90)"
-                font-family="weasyprint" font-size="3" fill="blue">
-            2026-04-01
-          </text>
-        </g>
-      </svg>
-    ''', '''
-      <style>
-        @page { size: 40px 40px }
-        svg { display: block }
-      </style>
-      <svg width="40px" height="40px" xmlns="http://www.w3.org/2000/svg">
-        <style>
-          .milestone {
-            transform: rotate(45deg) scale(.7, .7);
-          }
-          .tick text {
-            transform: translate(3px, 1px) rotate(90deg);
-          }
-        </style>
-        <rect class="milestone" x="14" y="4" width="10" height="10"
-              transform-origin="19px 9px" stroke="green" fill="green" />
-        <g class="tick" transform="translate(12, 18)">
-          <text y="3" font-family="weasyprint" font-size="3" fill="blue">
-            2026-04-01
-          </text>
-        </g>
       </svg>
     ''')
 

--- a/tests/draw/svg/test_transform.py
+++ b/tests/draw/svg/test_transform.py
@@ -148,6 +148,72 @@ def test_transform_rotate_cx_cy(assert_pixels):
 
 
 @assert_no_logs
+def test_transform_rotate_degrees(assert_same_renderings):
+    assert_same_renderings('''
+      <style>
+        @page { size: 9px }
+        svg { display: block }
+      </style>
+      <svg width="9px" height="9px" xmlns="http://www.w3.org/2000/svg">
+        <rect x="2" y="-7" width="4" height="5" transform="rotate(90)"
+              stroke-width="2" stroke="red" fill="none" />
+      </svg>
+    ''', '''
+      <style>
+        @page { size: 9px }
+        svg { display: block }
+      </style>
+      <svg width="9px" height="9px" xmlns="http://www.w3.org/2000/svg">
+        <rect x="2" y="-7" width="4" height="5" transform="rotate(90deg)"
+              stroke-width="2" stroke="red" fill="none" />
+      </svg>
+    ''')
+
+
+@assert_no_logs
+def test_transform_mermaid_gantt_css(assert_same_renderings):
+    assert_same_renderings('''
+      <style>
+        @page { size: 40px 40px }
+        svg { display: block }
+      </style>
+      <svg width="40px" height="40px" xmlns="http://www.w3.org/2000/svg">
+        <rect x="14" y="4" width="10" height="10" transform-origin="19px 9px"
+              transform="rotate(45) scale(.7 .7)"
+              stroke="green" fill="green" />
+        <g transform="translate(12, 18)">
+          <text y="3" transform="translate(3 1) rotate(90)"
+                font-family="weasyprint" font-size="3" fill="blue">
+            2026-04-01
+          </text>
+        </g>
+      </svg>
+    ''', '''
+      <style>
+        @page { size: 40px 40px }
+        svg { display: block }
+      </style>
+      <svg width="40px" height="40px" xmlns="http://www.w3.org/2000/svg">
+        <style>
+          .milestone {
+            transform: rotate(45deg) scale(.7, .7);
+          }
+          .tick text {
+            transform: translate(3px, 1px) rotate(90deg);
+          }
+        </style>
+        <rect class="milestone" x="14" y="4" width="10" height="10"
+              transform-origin="19px 9px" stroke="green" fill="green" />
+        <g class="tick" transform="translate(12, 18)">
+          <text y="3" font-family="weasyprint" font-size="3" fill="blue">
+            2026-04-01
+          </text>
+        </g>
+      </svg>
+    ''')
+
+
+@assert_no_logs
 def test_transform_skew(assert_pixels):
     assert_pixels('''
         _________

--- a/weasyprint/svg/utils.py
+++ b/weasyprint/svg/utils.py
@@ -2,7 +2,7 @@
 
 import re
 from contextlib import suppress
-from math import cos, radians, sin, tan
+from math import cos, pi, radians, sin, tan
 from urllib.parse import urlparse
 
 from tinycss2.color5 import parse_color
@@ -55,6 +55,20 @@ def size(string, font_size=None, percentage_reference=None):
 
     # Unknown size
     return 0
+
+
+def angle(string):
+    """Compute an angle in degrees from an SVG transform value."""
+    string = normalize(string).split(' ', 1)[0]
+    if string.endswith('deg'):
+        return float(string[:-3])
+    if string.endswith('grad'):
+        return float(string[:-4]) * 0.9
+    if string.endswith('rad'):
+        return float(string[:-3]) * 180 / pi
+    if string.endswith('turn'):
+        return float(string[:-4]) * 360
+    return float(string)
 
 
 def alpha_value(value):
@@ -164,31 +178,38 @@ def transform(transform_string, transform_origin, font_size, normalized_diagonal
 
     transformations = re.findall(r'(\w+) ?\( ?(.*?) ?\)', normalize(transform_string))
     for transformation_type, transformation in transformations:
-        values = [
-            size(value, font_size, normalized_diagonal)
-            for value in transformation.split(' ')]
+        values = [value for value in transformation.split(' ') if value]
         if transformation_type == 'matrix':
+            values = [
+                size(value, font_size, normalized_diagonal)
+                for value in values]
             matrix = Matrix(*values) @ matrix
         elif transformation_type == 'rotate':
             if len(values) == 3:
-                matrix = Matrix(e=values[1], f=values[2]) @ matrix
+                rotate_x = size(values[1], font_size, normalized_diagonal)
+                rotate_y = size(values[2], font_size, normalized_diagonal)
+                matrix = Matrix(e=rotate_x, f=rotate_y) @ matrix
+            rotation = angle(values[0])
             matrix = Matrix(
-                cos(radians(float(values[0]))),
-                sin(radians(float(values[0]))),
-                -sin(radians(float(values[0]))),
-                cos(radians(float(values[0])))) @ matrix
+                cos(radians(rotation)),
+                sin(radians(rotation)),
+                -sin(radians(rotation)),
+                cos(radians(rotation))) @ matrix
             if len(values) == 3:
-                matrix = Matrix(e=-values[1], f=-values[2]) @ matrix
+                matrix = Matrix(e=-rotate_x, f=-rotate_y) @ matrix
         elif transformation_type.startswith('skew'):
             if len(values) == 1:
-                values.append(0)
+                values.append('0')
             if transformation_type in ('skewX', 'skew'):
                 matrix = Matrix(
-                    c=tan(radians(float(values.pop(0))))) @ matrix
+                    c=tan(radians(angle(values.pop(0))))) @ matrix
             if transformation_type in ('skewY', 'skew'):
                 matrix = Matrix(
-                    b=tan(radians(float(values.pop(0))))) @ matrix
+                    b=tan(radians(angle(values.pop(0))))) @ matrix
         elif transformation_type.startswith('translate'):
+            values = [
+                size(value, font_size, normalized_diagonal)
+                for value in values]
             if len(values) == 1:
                 values.append(0)
             if transformation_type in ('translateX', 'translate'):
@@ -196,6 +217,9 @@ def transform(transform_string, transform_origin, font_size, normalized_diagonal
             if transformation_type in ('translateY', 'translate'):
                 matrix = Matrix(f=values.pop(0)) @ matrix
         elif transformation_type.startswith('scale'):
+            values = [
+                size(value, font_size, normalized_diagonal)
+                for value in values]
             if len(values) == 1:
                 values.append(values[0])
             if transformation_type in ('scaleX', 'scale'):

--- a/weasyprint/svg/utils.py
+++ b/weasyprint/svg/utils.py
@@ -2,11 +2,12 @@
 
 import re
 from contextlib import suppress
-from math import cos, pi, radians, sin, tan
+from math import cos, sin, tan
 from urllib.parse import urlparse
 
 from tinycss2.color5 import parse_color
 
+from ..css.units import ANGLE_TO_RADIANS
 from ..matrix import Matrix
 
 
@@ -58,17 +59,13 @@ def size(string, font_size=None, percentage_reference=None):
 
 
 def angle(string):
-    """Compute an angle in degrees from an SVG transform value."""
+    """Compute an angle in radians from an SVG transform value."""
     string = normalize(string).split(' ', 1)[0]
-    if string.endswith('deg'):
-        return float(string[:-3])
-    if string.endswith('grad'):
-        return float(string[:-4]) * 0.9
-    if string.endswith('rad'):
-        return float(string[:-3]) * 180 / pi
-    if string.endswith('turn'):
-        return float(string[:-4]) * 360
-    return float(string)
+    for unit, coefficient in sorted(
+            ANGLE_TO_RADIANS.items(), key=lambda item: -len(item[0])):
+        if string.endswith(unit):
+            return float(string[:-len(unit)]) * coefficient
+    return float(string) * ANGLE_TO_RADIANS['deg']
 
 
 def alpha_value(value):
@@ -191,10 +188,10 @@ def transform(transform_string, transform_origin, font_size, normalized_diagonal
                 matrix = Matrix(e=rotate_x, f=rotate_y) @ matrix
             rotation = angle(values[0])
             matrix = Matrix(
-                cos(radians(rotation)),
-                sin(radians(rotation)),
-                -sin(radians(rotation)),
-                cos(radians(rotation))) @ matrix
+                cos(rotation),
+                sin(rotation),
+                -sin(rotation),
+                cos(rotation)) @ matrix
             if len(values) == 3:
                 matrix = Matrix(e=-rotate_x, f=-rotate_y) @ matrix
         elif transformation_type.startswith('skew'):
@@ -202,10 +199,10 @@ def transform(transform_string, transform_origin, font_size, normalized_diagonal
                 values.append('0')
             if transformation_type in ('skewX', 'skew'):
                 matrix = Matrix(
-                    c=tan(radians(angle(values.pop(0))))) @ matrix
+                    c=tan(angle(values.pop(0)))) @ matrix
             if transformation_type in ('skewY', 'skew'):
                 matrix = Matrix(
-                    b=tan(radians(angle(values.pop(0))))) @ matrix
+                    b=tan(angle(values.pop(0)))) @ matrix
         elif transformation_type.startswith('translate'):
             values = [
                 size(value, font_size, normalized_diagonal)

--- a/weasyprint/svg/utils.py
+++ b/weasyprint/svg/utils.py
@@ -61,10 +61,10 @@ def size(string, font_size=None, percentage_reference=None):
 def angle(string):
     """Compute an angle in radians from an SVG transform value."""
     string = normalize(string).split(' ', 1)[0]
-    for unit, coefficient in sorted(
-            ANGLE_TO_RADIANS.items(), key=lambda item: -len(item[0])):
+    # Sort units by length to match grad between rad.
+    for unit in sorted(ANGLE_TO_RADIANS, key=len, reverse=True):
         if string.endswith(unit):
-            return float(string[:-len(unit)]) * coefficient
+            return float(string[:-len(unit)]) * ANGLE_TO_RADIANS[unit]
     return float(string) * ANGLE_TO_RADIANS['deg']
 
 
@@ -177,9 +177,7 @@ def transform(transform_string, transform_origin, font_size, normalized_diagonal
     for transformation_type, transformation in transformations:
         values = [value for value in transformation.split(' ') if value]
         if transformation_type == 'matrix':
-            values = [
-                size(value, font_size, normalized_diagonal)
-                for value in values]
+            values = [size(value, font_size, normalized_diagonal) for value in values]
             matrix = Matrix(*values) @ matrix
         elif transformation_type == 'rotate':
             if len(values) == 3:
@@ -187,26 +185,19 @@ def transform(transform_string, transform_origin, font_size, normalized_diagonal
                 rotate_y = size(values[2], font_size, normalized_diagonal)
                 matrix = Matrix(e=rotate_x, f=rotate_y) @ matrix
             rotation = angle(values[0])
-            matrix = Matrix(
-                cos(rotation),
-                sin(rotation),
-                -sin(rotation),
-                cos(rotation)) @ matrix
+            cos_r, sin_r = cos(rotation), sin(rotation)
+            matrix = Matrix(cos_r, sin_r, -sin_r, cos_r) @ matrix
             if len(values) == 3:
                 matrix = Matrix(e=-rotate_x, f=-rotate_y) @ matrix
         elif transformation_type.startswith('skew'):
             if len(values) == 1:
                 values.append('0')
             if transformation_type in ('skewX', 'skew'):
-                matrix = Matrix(
-                    c=tan(angle(values.pop(0)))) @ matrix
+                matrix = Matrix(c=tan(angle(values.pop(0)))) @ matrix
             if transformation_type in ('skewY', 'skew'):
-                matrix = Matrix(
-                    b=tan(angle(values.pop(0)))) @ matrix
+                matrix = Matrix(b=tan(angle(values.pop(0)))) @ matrix
         elif transformation_type.startswith('translate'):
-            values = [
-                size(value, font_size, normalized_diagonal)
-                for value in values]
+            values = [size(value, font_size, normalized_diagonal) for value in values]
             if len(values) == 1:
                 values.append(0)
             if transformation_type in ('translateX', 'translate'):
@@ -214,9 +205,7 @@ def transform(transform_string, transform_origin, font_size, normalized_diagonal
             if transformation_type in ('translateY', 'translate'):
                 matrix = Matrix(f=values.pop(0)) @ matrix
         elif transformation_type.startswith('scale'):
-            values = [
-                size(value, font_size, normalized_diagonal)
-                for value in values]
+            values = [size(value, font_size, normalized_diagonal) for value in values]
             if len(values) == 1:
                 values.append(values[0])
             if transformation_type in ('scaleX', 'scale'):


### PR DESCRIPTION
## What changed

Fixes #2735.

This adds SVG angle parsing for transform functions that take angles, so values such as `rotate(90deg)`, `rotate(.25turn)`, `rotate(1.5708rad)`, and `skew(20deg)` are treated as angles instead of lengths.

## Why

Generated SVGs commonly use explicit angle units in CSS transforms. Mermaid Gantt diagrams, for example, emit rules such as `transform: rotate(45deg) scale(...)` for milestones and `rotate(90deg)` for rotated tick labels. WeasyPrint previously parsed transform arguments as lengths before dispatching by transform function, which made angle units fail.

## Tests

- `python -m pytest tests/draw/svg/test_transform.py -q`
- `python -m pytest tests/draw/svg -q`
