### PR TITLE
Account for transformed SVG group bounds

### DIFF
--- a/tests/draw/svg/test_opacity.py
+++ b/tests/draw/svg/test_opacity.py
@@ -146,6 +146,22 @@ def test_translate_opacity(assert_same_renderings):
 
 
 @assert_no_logs
+def test_group_opacity_transformed_child(assert_same_renderings):
+    assert_same_renderings(
+        opacity_source % '''
+            <g opacity="0.5">
+              <rect x="0" y="0" width="4" height="4" fill="red"
+                    transform="translate(5 5)" />
+            </g>
+        ''',
+        opacity_source % '''
+            <rect x="0" y="0" width="4" height="4" fill="rgb(255, 127, 127)"
+                  transform="translate(5 5)" />
+        ''',
+    )
+
+
+@assert_no_logs
 def test_translate_use_opacity(assert_same_renderings):
     # Regression test for #1976.
     assert_same_renderings(

--- a/tests/draw/svg/test_opacity.py
+++ b/tests/draw/svg/test_opacity.py
@@ -155,6 +155,19 @@ def test_group_opacity_transformed_child(assert_same_renderings):
             </g>
         ''',
         opacity_source % '''
+            <g opacity="0.5"><g transform="translate(3 3)">
+              <rect x="0" y="0" width="4" height="4" fill="red"
+                    transform="translate(2 2)" />
+            </g></g>
+        ''',
+        opacity_source % '''
+            <defs>
+              <rect id="r" x="0" y="0" width="4" height="4" fill="red"
+                    transform="translate(5 5)" />
+            </defs>
+            <use href="#r" opacity="0.5" />
+        ''',
+        opacity_source % '''
             <rect x="0" y="0" width="4" height="4" fill="rgb(255, 127, 127)"
                   transform="translate(5 5)" />
         ''',

--- a/weasyprint/svg/__init__.py
+++ b/weasyprint/svg/__init__.py
@@ -818,16 +818,17 @@ class SVG:
             else:
                 self.stream.end()
 
-    def transform(self, node, font_size):
-        """Apply a transformation string to the node."""
-        transform_origin = node.get('transform-origin')
-        transform_string = node.get('transform')
-        if not transform_string:
-            return
+    def get_node_transform_matrix(self, node, font_size):
+        """Get the transformation matrix of a node."""
+        if transform_string := node.get('transform'):
+            origin = node.get('transform-origin')
+            matrix = transform(transform_string, origin, font_size, self.inner_diagonal)
+            if matrix.determinant:
+                return matrix
 
-        matrix = transform(
-            transform_string, transform_origin, font_size, self.inner_diagonal)
-        if matrix.determinant:
+    def transform(self, node, font_size):
+        """Apply the transformation string of a node to the stream."""
+        if matrix := self.get_node_transform_matrix(node, font_size):
             self.stream.transform(*matrix.values)
 
     def inherit_element(self, element, defs):

--- a/weasyprint/svg/bounding_box.py
+++ b/weasyprint/svg/bounding_box.py
@@ -3,7 +3,7 @@
 from math import atan, atan2, cos, inf, isinf, pi, radians, sin, sqrt, tan
 
 from .path import PATH_LETTERS
-from .utils import normalize, point
+from .utils import normalize, point, transform
 
 EMPTY_BOUNDING_BOX = inf, inf, 0, 0
 
@@ -215,7 +215,8 @@ def bounding_box_g(svg, node, font_size):
     for child in node:
         child_bounding_box = svg.calculate_bounding_box(child, font_size)
         if is_valid_bounding_box(child_bounding_box):
-            minx, miny, width, height = child_bounding_box
+            minx, miny, width, height = transform_bounding_box(
+                svg, child, font_size, child_bounding_box)
             maxx, maxy = minx + width, miny + height
             bounding_box = extend_bounding_box(
                 bounding_box, ((minx, miny), (maxx, maxy)))
@@ -345,6 +346,28 @@ def extend_bounding_box(bounding_box, points):
         min(minx, *x_list), min(miny, *y_list),
         max(maxx, *x_list), max(maxy, *y_list))
     return minx, miny, maxx - minx, maxy - miny
+
+
+def transform_bounding_box(svg, node, font_size, bounding_box):
+    """Apply node transform to a bounding box."""
+    transform_string = node.get('transform')
+    if not transform_string:
+        return bounding_box
+
+    matrix = transform(
+        transform_string, node.get('transform-origin'), font_size,
+        svg.inner_diagonal)
+    if not matrix.determinant:
+        return EMPTY_BOUNDING_BOX
+
+    minx, miny, width, height = bounding_box
+    maxx, maxy = minx + width, miny + height
+    points = (
+        matrix.transform_point(minx, miny),
+        matrix.transform_point(minx, maxy),
+        matrix.transform_point(maxx, miny),
+        matrix.transform_point(maxx, maxy))
+    return extend_bounding_box(EMPTY_BOUNDING_BOX, points)
 
 
 def is_valid_bounding_box(bounding_box):

--- a/weasyprint/svg/bounding_box.py
+++ b/weasyprint/svg/bounding_box.py
@@ -3,7 +3,7 @@
 from math import atan, atan2, cos, inf, isinf, pi, radians, sin, sqrt, tan
 
 from .path import PATH_LETTERS
-from .utils import normalize, point, transform
+from .utils import normalize, point
 
 EMPTY_BOUNDING_BOX = inf, inf, 0, 0
 
@@ -232,7 +232,8 @@ def bounding_box_use(svg, node, font_size):
     else:
         x, y = svg.point(node.get('x'), node.get('y'), font_size)
         box = bounding_box(svg, tree, font_size, True)
-        return box[0] + x, box[1] + y, box[2], box[3]
+        box = (box[0] + x, box[1] + y, box[2], box[3])
+        return transform_bounding_box(svg, tree, font_size, box)
 
 
 def _bounding_box_elliptical_arc(x1, y1, rx, ry, phi, large, sweep, x, y):
@@ -350,16 +351,9 @@ def extend_bounding_box(bounding_box, points):
 
 def transform_bounding_box(svg, node, font_size, bounding_box):
     """Apply node transform to a bounding box."""
-    transform_string = node.get('transform')
-    if not transform_string:
+    matrix = svg.get_node_transform_matrix(node, font_size)
+    if not matrix:
         return bounding_box
-
-    matrix = transform(
-        transform_string, node.get('transform-origin'), font_size,
-        svg.inner_diagonal)
-    if not matrix.determinant:
-        return EMPTY_BOUNDING_BOX
-
     minx, miny, width, height = bounding_box
     maxx, maxy = minx + width, miny + height
     points = (


### PR DESCRIPTION
## What changed

Fixes #2736.

This applies child transform matrices when extending an SVG group bounding box from child bounding boxes.

## Why

Opacity groups are rendered as Form XObjects whose BBox is computed from the SVG group bounds. If transformed children are measured in their original, untransformed positions, the Form XObject BBox can be too small and clip visible content. This shows up in generated SVGs such as Mermaid Gantt charts, where transformed tick labels sit inside opacity groups.

## Tests

- `python -m pytest tests/draw/svg/test_transform.py -q`
- `python -m pytest tests/draw/svg -q`
