### PR TITLE
Fix table break retry after padding overflow

### DIFF
--- a/tests/layout/test_table.py
+++ b/tests/layout/test_table.py
@@ -3175,6 +3175,46 @@ def test_table_break_children_margin():
     assert len(render_pages(html)) == 3
 
 
+def test_table_break_in_padded_block():
+    # Regression test for #2580.
+    page1, = render_pages('''
+      <style>
+        @page { size: 100px; margin: 0 }
+        body { margin: 0; font: 2px/1 weasyprint }
+        div.previous { height: 20px }
+        div.wrapper { padding-bottom: 6px }
+        table {
+          border-collapse: collapse;
+          border-spacing: 0;
+          margin: 20px 0;
+          table-layout: fixed;
+          width: 100%;
+        }
+        td { height: 10px; padding: 0 }
+        tr { break-inside: avoid }
+      </style>
+      <div class="previous">Before</div>
+      <div class="wrapper">
+        <table>
+          <thead><tr><td>Header</td></tr></thead>
+          <tbody><tr><td>Row</td></tr></tbody>
+          <tfoot><tr><td>Footer</td></tr></tfoot>
+        </table>
+      </div>
+    ''')
+    html, = page1.children
+    body, = html.children
+    previous, wrapper = body.children
+    table_wrapper, = wrapper.children
+    table, = table_wrapper.children
+    header, body_group, footer = table.children
+
+    assert previous.element_tag == 'div'
+    assert len(header.children) == 1
+    assert len(body_group.children) == 1
+    assert len(footer.children) == 1
+
+
 def test_table_td_break_inside_avoid():
     # Regression test for #1547.
     html = '''

--- a/weasyprint/layout/block.py
+++ b/weasyprint/layout/block.py
@@ -554,6 +554,8 @@ def _in_flow_layout(context, box, index, child, new_children, page_is_empty,
         child for child in new_children
         if not isinstance(child, AbsolutePlaceholder))
 
+    child_position_x = child.position_x
+    child_position_y = child.position_y
     (new_child, resume_at, next_page, next_adjoining_margins,
      collapsing_through, max_lines) = block_level_layout(
          context, child, bottom_space, skip_stack, box, page_is_empty_with_no_children,
@@ -585,11 +587,14 @@ def _in_flow_layout(context, box, index, child, new_children, page_is_empty,
                 # Child border/padding/margin overflows the page area, do the layout
                 # again with a bottom_space value that includes them.
                 remove_placeholders(context, [new_child], absolute_boxes, fixed_boxes)
+                child.position_x = child_position_x
+                child.position_y = child_position_y
                 (new_child, resume_at, next_page, next_adjoining_margins,
                  collapsing_through, max_lines) = block_level_layout(
                      context, child, bottom_space, skip_stack, box,
                      page_is_empty_with_no_children, absolute_boxes, fixed_boxes,
-                     adjoining_margins, discard, max_lines)
+                     adjoining_margins, first_letter_style, first_line_style,
+                     discard, max_lines)
                 if new_child:
                     position_y = new_child.border_box_y() + new_child.border_height()
             else:


### PR DESCRIPTION
## Summary

Fixes a block layout retry case that can push a table to the next page when the table is wrapped in a block with bottom padding. Adds a regression test based on the shape reported in #2580: previous content, a padded wrapper, and a table with `thead`, `tbody`, and `tfoot`.

## Root Cause

When a child's border, padding, or margin overflowed the current page, `_in_flow_layout` removed the laid-out child and retried layout with additional `bottom_space`. The first layout attempt can mutate the original child's coordinates, for example through table margin collapsing. The retry then started from the already-shifted position, effectively double-counting vertical offset and incorrectly deciding that the table no longer fit on the page.

The retry call also passed `discard` and `max_lines` into the `first_letter_style` / `first_line_style` argument slots, which meant the second layout attempt was not preserving the intended block layout parameters.

## Changes

- Save the child's original `position_x` and `position_y` before the first layout attempt.
- Restore those coordinates before retrying layout after bottom spacing overflow.
- Pass `first_letter_style`, `first_line_style`, `discard`, and `max_lines` to the retry in the correct order.
- Add a regression test proving that a table in a padded wrapper remains on the current page when its contents fit.

## Validation

- `pytest tests/layout/test_table.py -q`
- `pytest tests/layout/test_block.py -q`
- `ruff check weasyprint/layout/block.py tests/layout/test_table.py`