### PR TITLE
Fix flex row fragmentation

### DIFF
--- a/tests/layout/test_flex.py
+++ b/tests/layout/test_flex.py
@@ -840,6 +840,88 @@ def test_flex_row_fragmentation():
 
 
 @assert_no_logs
+def test_flex_row_fragmentation_wrapped_tables():
+    # Regression test for the larger structure reported in issue #2440.
+    page1, page2 = render_pages('''
+      <style>
+        @page { size: 20px 6px; margin: 0 }
+        body, table { font: 2px/1 weasyprint; margin: 0 }
+        .metric-page { page-break-before: always }
+        .tables { display: flex; flex-wrap: wrap; gap: 2px }
+        .table { box-sizing: border-box; page-break-inside: auto;
+                 width: 9px }
+        .table-bordered { border-spacing: 0; page-break-inside: auto;
+                          width: 100% }
+        .table-bordered tr { break-inside: auto; page-break-inside: auto }
+        td { height: 2px; padding: 0 }
+      </style>
+      <body>
+        <div class="metric-page page">
+          <div class="tables">
+            <div class="table">
+              <table class="table-bordered">
+                <tbody>
+                  <tr><td>A</td></tr><tr><td>B</td></tr>
+                  <tr><td>C</td></tr><tr><td>D</td></tr>
+                </tbody>
+              </table>
+            </div>
+            <div class="table">
+              <table class="table-bordered">
+                <tbody>
+                  <tr><td>a</td></tr><tr><td>b</td></tr>
+                  <tr><td>c</td></tr><tr><td>d</td></tr>
+                </tbody>
+              </table>
+            </div>
+            <div class="table">
+              <table class="table-bordered">
+                <tbody><tr><td>E</td></tr></tbody>
+              </table>
+            </div>
+            <div class="table">
+              <table class="table-bordered">
+                <tbody><tr><td>e</td></tr></tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+    ''')
+
+    def card_texts(card):
+        table_wrapper, = card.children
+        table, = table_wrapper.children
+        row_group, = table.children
+        return [
+            row.children[0].children[0].children[0].text
+            for row in row_group.children]
+
+    html, = page1.children
+    body, = html.children
+    page, = body.children
+    flex, = page.children
+    card1, card2 = flex.children
+    assert card1.position_x == 0
+    assert card2.position_x == 11
+    assert card_texts(card1) == ['A', 'B', 'C']
+    assert card_texts(card2) == ['a', 'b', 'c']
+
+    html, = page2.children
+    body, = html.children
+    page, = body.children
+    flex, = page.children
+    card1, card2, card3, card4 = flex.children
+    assert card1.position_x == card3.position_x == 0
+    assert card2.position_x == card4.position_x == 11
+    assert card1.position_y == card2.position_y == 0
+    assert card3.position_y == card4.position_y == 4
+    assert card_texts(card1) == ['D']
+    assert card_texts(card2) == ['d']
+    assert card_texts(card3) == ['E']
+    assert card_texts(card4) == ['e']
+
+
+@assert_no_logs
 def test_flex_row_fragmentation_completed_item():
     page1, page2 = render_pages('''
       <style>

--- a/tests/layout/test_flex.py
+++ b/tests/layout/test_flex.py
@@ -781,6 +781,93 @@ def test_flex_break_inside_avoid():
 
 
 @assert_no_logs
+def test_flex_row_fragmentation():
+    # Regression test for issue #2440.
+    page1, page2 = render_pages('''
+      <style>
+        @page { size: 12px 6px; margin: 0 }
+        body, table { font: 2px/1 weasyprint; margin: 0 }
+        article { display: flex; width: 12px }
+        section { width: 6px }
+        table { border-spacing: 0 }
+        td { height: 2px; padding: 0 }
+      </style>
+      <article>
+        <section>
+          <table>
+            <tr><td>A</td></tr>
+            <tr><td>B</td></tr>
+            <tr><td>C</td></tr>
+            <tr><td>D</td></tr>
+          </table>
+        </section>
+        <section>
+          <table>
+            <tr><td>a</td></tr>
+            <tr><td>b</td></tr>
+            <tr><td>c</td></tr>
+            <tr><td>d</td></tr>
+          </table>
+        </section>
+      </article>
+    ''')
+
+    def cell_texts(section):
+        table_wrapper, = section.children
+        table, = table_wrapper.children
+        row_group, = table.children
+        return [
+            row.children[0].children[0].children[0].text
+            for row in row_group.children]
+
+    html, = page1.children
+    body, = html.children
+    article, = body.children
+    section1, section2 = article.children
+    assert section1.position_x == 0
+    assert section2.position_x == 6
+    assert cell_texts(section1) == ['A', 'B', 'C']
+    assert cell_texts(section2) == ['a', 'b', 'c']
+
+    html, = page2.children
+    body, = html.children
+    article, = body.children
+    section1, section2 = article.children
+    assert section1.position_x == 0
+    assert section2.position_x == 6
+    assert cell_texts(section1) == ['D']
+    assert cell_texts(section2) == ['d']
+
+
+@assert_no_logs
+def test_flex_row_fragmentation_completed_item():
+    page1, page2 = render_pages('''
+      <style>
+        @page { size: 8px 6px; margin: 0 }
+        body { font: 2px/1 weasyprint; margin: 0 }
+        article { display: flex; width: 8px }
+        section { border: 1px solid; width: 2px }
+      </style>
+      <article>
+        <section>A<br>B<br>C<br>D</section>
+        <section>a</section>
+      </article>
+    ''')
+    html, = page1.children
+    body, = html.children
+    article, = body.children
+    section1, section2 = article.children
+    assert section1.children[0].children[0].text == 'A'
+    assert section2.children[0].children[0].text == 'a'
+
+    html, = page2.children
+    body, = html.children
+    article, = body.children
+    section, = article.children
+    assert section.children[0].children[0].text == 'C'
+
+
+@assert_no_logs
 def test_flex_absolute_content():
     # Regression test for issue #996.
     page, = render_pages('''

--- a/weasyprint/layout/flex.py
+++ b/weasyprint/layout/flex.py
@@ -89,15 +89,13 @@ def flex_layout(context, box, bottom_space, skip_stack, containing_block, page_i
     block.block_level_width(parent_box, containing_block)
     children = sorted(box.children, key=lambda item: item.style['order'])
     if skip_stack is not None:
-        (skip, skip_stack), = skip_stack.items()
+        skip = min(skip_stack)
         if box.style['flex_direction'].endswith('-reverse'):
             children = children[:skip + 1]
         else:
             children = children[skip:]
-        skip_stack = skip_stack
     else:
         skip, skip_stack = 0, None
-    child_skip_stack = skip_stack
 
     if row_gap == 'normal':
         row_gap = 0
@@ -131,6 +129,10 @@ def flex_layout(context, box, bottom_space, skip_stack, containing_block, page_i
     if parent_box.margin_top != 'auto':
         position_y += parent_box.margin_top
     for index, child in enumerate(children):
+        if skip_stack is not None:
+            child_skip_stack = skip_stack.get(index + skip)
+        else:
+            child_skip_stack = None
         if not child.is_flex_item:
             # Absolute child layout: create placeholder.
             if child.is_absolutely_positioned():
@@ -291,10 +293,6 @@ def flex_layout(context, box, bottom_space, skip_stack, containing_block, page_i
         max_size = getattr(child, f'max_{main}')
         child.hypothetical_main_size = max(
             min_size, min(child.flex_base_size, max_size))
-
-        # Skip stack is only for the first child.
-        child_skip_stack = None
-
     # 4 Determine the main size of the flex container using the rules of the formatting
     # context in which it participates.
     original_box_height = box.height
@@ -482,10 +480,13 @@ def flex_layout(context, box, bottom_space, skip_stack, containing_block, page_i
     # 7 Determine the hypothetical cross size of each item.
     # TODO: Handle breaks.
     new_flex_lines = []
-    child_skip_stack = skip_stack
     for line in flex_lines:
         new_flex_line = FlexLine()
         for index, child in line:
+            if skip_stack is not None:
+                child_skip_stack = skip_stack.get(index)
+            else:
+                child_skip_stack = None
             # TODO: Fix this value, see test_flex_item_auto_margin_cross.
             if child.margin_top == 'auto':
                 child.margin_top = 0
@@ -514,9 +515,6 @@ def flex_layout(context, box, bottom_space, skip_stack, containing_block, page_i
                     child.width = new_child.width
 
             new_flex_line.append((index, child))
-
-            # Skip stack is only for the first child.
-            child_skip_stack = None
 
         if new_flex_line:
             new_flex_lines.append(new_flex_line)
@@ -896,10 +894,15 @@ def flex_layout(context, box, bottom_space, skip_stack, containing_block, page_i
     # Now we are no longer in the flex algorithm.
     box = box.copy_with_children(
         [child for child in children if child.is_absolutely_positioned()])
-    child_skip_stack = skip_stack
     for line in flex_lines:
+        line_resume_at = {}
+        line_children = {}
         for index, child in line:
             if child.is_flex_item:
+                if skip_stack is not None:
+                    child_skip_stack = skip_stack.get(index)
+                else:
+                    child_skip_stack = None
                 # TODO: Don't use block_level_layout_switch.
                 new_child, child_resume_at, next_page = block.block_level_layout_switch(
                     context, child, bottom_space, child_skip_stack, box, page_is_empty,
@@ -907,28 +910,33 @@ def flex_layout(context, box, bottom_space, skip_stack, containing_block, page_i
                     first_letter_style=None, first_line_style=None, discard=discard,
                     max_lines=None)[:3]
                 if new_child is None:
-                    if resume_at:
-                        resume_index, = resume_at
-                        resume_index -= 1
-                    else:
-                        resume_index = 0
-                    resume_at = {resume_index + index: None}
+                    line_resume_at[index] = None
                 else:
-                    page_is_empty = False
-                    box.children.append(new_child)
+                    completed_child = (
+                        child_skip_stack and isinstance(child, boxes.ParentBox) and
+                        max(child_skip_stack) >= len(child.children) and
+                        not new_child.children and child_resume_at is None)
+                    if not completed_child:
+                        page_is_empty = False
+                        box.children.append(new_child)
+                        line_children[index] = new_child
                     position_y = new_child.position_y + new_child.border_height()
                     if child_resume_at is not None:
-                        first_level_skip = 0
-                        if resume_at:
-                            resume_index, = resume_at
-                            first_level_skip = resume_index
-                        resume_at = {first_level_skip + index: child_resume_at}
-                if resume_at:
+                        line_resume_at[index] = child_resume_at
+                if line_resume_at and main == 'height':
                     break
 
-            # Skip stack is only for the first child.
-            child_skip_stack = None
-        if resume_at:
+        if line_resume_at:
+            if main == 'width':
+                for index, child in line:
+                    if index in line_resume_at or index not in line_children:
+                        continue
+                    if isinstance(child, boxes.ParentBox):
+                        previous_skip = max(skip_stack.get(index, {0: None})) if (
+                            skip_stack and skip_stack.get(index)) else 0
+                        line_resume_at[index] = {
+                            previous_skip + len(line_children[index].children): None}
+            resume_at = line_resume_at
             break
 
     if original_box_height != 'auto':


### PR DESCRIPTION
## Summary

This PR adds basic row fragmentation support for flex containers. When one flex item in a row fragments across pages, sibling items in the same row are now also laid out on the current page and resumed independently on the next page when needed.

Fixes #2440.

## Root Cause

`flex_layout` stored a single child resume stack and stopped laying out the current flex line as soon as one item fragmented. In a row flex container, this serialized row items across pages: the first item consumed the page fragment, and the next item in the same visual row started only on the following page.

## Changes

- Keep per-item skip/resume state for flex items instead of treating the skip stack as applying only to the first child.
- Continue laying out remaining row items after one row item fragments, collecting a resume map for the whole flex line.
- Skip already-completed row siblings on continuation pages instead of drawing empty decorated fragments.
- Add regression coverage for table content in two side-by-side flex row items.
- Add an issue-shaped regression keeping the #2440 wrapped `.tables` / `.table` / `.table-bordered` structure, with a later wrapped row after a fragmented first row.
- Add coverage for a shorter row sibling that finishes before the fragmented sibling.

## Validation

- `venv/bin/python -m pytest tests/layout/test_flex.py` -> 178 passed
- `venv/bin/python -m pytest tests/layout`
- `venv/bin/python -m ruff check weasyprint/layout/flex.py tests/layout/test_flex.py`

