### PR TITLE
Fix flex cross size min/max

### DIFF
--- a/tests/layout/test_flex.py
+++ b/tests/layout/test_flex.py
@@ -53,6 +53,55 @@ def test_flex_direction_row_min_height():
 
 
 @assert_no_logs
+def test_flex_direction_row_wrap_min_height():
+    page, = render_pages('''
+      <article style="display: flex; flex-wrap: wrap; min-height: 100px; width: 4px">
+        <div style="height: 10px; width: 4px"></div>
+        <div style="height: 10px; width: 4px"></div>
+      </article>
+    ''')
+    html, = page.children
+    body, = html.children
+    article, = body.children
+    assert article.height == 100
+    div1, div2 = article.children
+    assert div1.position_y == 0
+    assert div2.position_y == 50
+
+
+@assert_no_logs
+def test_flex_direction_row_wrap_min_height_stretch():
+    page, = render_pages('''
+      <article style="display: flex; flex-wrap: wrap; min-height: 100px; width: 4px">
+        <div style="width: 4px"></div>
+        <div style="width: 4px"></div>
+      </article>
+    ''')
+    html, = page.children
+    body, = html.children
+    article, = body.children
+    assert article.height == 100
+    div1, div2 = article.children
+    assert div1.height == div2.height == 50
+    assert div1.position_y == 0
+    assert div2.position_y == 50
+
+
+@assert_no_logs
+def test_flex_direction_row_wrap_max_height():
+    page, = render_pages('''
+      <article style="display: flex; flex-wrap: wrap; max-height: 10px; width: 4px">
+        <div style="height: 10px; width: 4px"></div>
+        <div style="height: 10px; width: 4px"></div>
+      </article>
+    ''')
+    html, = page.children
+    body, = html.children
+    article, = body.children
+    assert article.height == 10
+
+
+@assert_no_logs
 def test_flex_direction_row_rtl():
     page, = render_pages('''
       <article style="display: flex; direction: rtl">

--- a/weasyprint/layout/flex.py
+++ b/weasyprint/layout/flex.py
@@ -569,16 +569,27 @@ def flex_layout(context, box, bottom_space, skip_stack, containing_block, page_i
             # 8.3 Set the used cross-size of the flex line.
             line.cross_size = max(collected_cross_size, non_collected_cross_size)
 
-    # 8.3 If the flex container is single-line…
-    if len(flex_lines) == 1:
-        line, = flex_lines
+    def min_max_cross_size(cross_size):
         min_cross_size = getattr(box, f'min_{cross}')
         if min_cross_size == 'auto':
             min_cross_size = -inf
         max_cross_size = getattr(box, f'max_{cross}')
         if max_cross_size == 'auto':
             max_cross_size = inf
-        line.cross_size = max(min_cross_size, min(line.cross_size, max_cross_size))
+        return max(min_cross_size, min(cross_size, max_cross_size))
+
+    # 8.3 If the flex container is single-line…
+    if len(flex_lines) == 1:
+        line, = flex_lines
+        line.cross_size = min_max_cross_size(line.cross_size)
+
+    # 15 Determine the flex container’s used cross size.
+    # TODO: Use the updated algorithm.
+    if cross == 'height' and getattr(box, cross) == 'auto':
+        # Otherwise, use the sum of the flex lines' cross sizes…
+        cross_size = sum(line.cross_size for line in flex_lines)
+        cross_size += (len(flex_lines) - 1) * cross_gap
+        setattr(box, cross, min_max_cross_size(cross_size))
 
     # 9 Handle 'align-content: stretch'.
     align_content = box.style['align_content']
@@ -850,11 +861,10 @@ def flex_layout(context, box, bottom_space, skip_stack, containing_block, page_i
     # TODO: Use the updated algorithm.
     if getattr(box, cross) == 'auto':
         # Otherwise, use the sum of the flex lines' cross sizes…
-        # TODO: Handle min-max.
         # TODO: What about align-content here?
         cross_size = sum(line.cross_size for line in flex_lines)
         cross_size += (len(flex_lines) - 1) * cross_gap
-        setattr(box, cross, cross_size)
+        setattr(box, cross, min_max_cross_size(cross_size))
 
     if len(flex_lines) > 1:
         # 15 If the cross size property is a definite size, use that…


### PR DESCRIPTION
## Summary

This PR makes auto-height row flex containers respect cross-size `min-height` and `max-height` constraints when their height is computed from wrapped flex lines.

It also makes the clamped auto height available before `align-content: stretch`, so wrapped row flex lines can stretch into a `min-height`-expanded container.

Part of #2400.

## Root Cause

For multi-line flex containers, the final auto cross size was computed as the sum of flex line cross sizes plus gaps, but it was not clamped by the flex container's cross-axis min/max properties. In row flex containers, this meant wrapped containers ignored `min-height` and `max-height` during final height computation.

The computed auto height was also set after the `align-content: stretch` step, so stretch could not distribute extra height introduced by `min-height`.

## Changes

- Add a small helper for clamping computed cross sizes with the container's `min-*` and `max-*` cross-axis properties.
- Reuse it for the existing single-line cross-size clamp.
- Clamp multi-line auto cross sizes before final assignment.
- For auto-height row flex containers, set the clamped height before `align-content: stretch` runs.
- Add tests for wrapped row flex containers with `min-height`, `max-height`, and stretch into a `min-height` container.

## Known Remaining Scope

This intentionally covers a small, reviewable slice of the larger flex min/max topic. Remaining gaps include:

- Column flex cross size (`min-width` / `max-width`) in all auto-width and wrapped-column cases.
- Inline flex cross-size clamping and baseline interactions.
- Definite cross-size cases with conflicting min/max constraints.
- Pagination interactions when min/max cross-size changes available page height.
- Broader intrinsic keyword support such as `min-content`, `max-content`, and `fit-content()`.

## Validation

- `venv/bin/python -m pytest tests/layout/test_flex.py`
- `venv/bin/python -m pytest tests/layout`
- `venv/bin/python -m ruff check weasyprint/layout/flex.py tests/layout/test_flex.py`
