### PR TITLE
Fix forced breaks in flex rows

### DIFF
--- a/tests/layout/test_flex.py
+++ b/tests/layout/test_flex.py
@@ -1762,6 +1762,103 @@ def test_flex_auto_break_before():
 
 
 @assert_no_logs
+def test_flex_direction_row_break_before_page():
+    page1, page2 = render_pages('''
+      <style>
+        @page { size: 20px; margin: 0 }
+        body { font: 2px/1 weasyprint; margin: 0 }
+        article { display: flex; width: 20px }
+        div { width: 4px }
+      </style>
+      <article>
+        <div>A</div>
+        <div style="break-before: page">B</div>
+        <div>C</div>
+      </article>
+    ''')
+    html, = page1.children
+    body, = html.children
+    article, = body.children
+    div, = article.children
+    assert div.children[0].children[0].text == 'A'
+
+    html, = page2.children
+    body, = html.children
+    article, = body.children
+    div1, div2 = article.children
+    assert div1.children[0].children[0].text == 'B'
+    assert div2.children[0].children[0].text == 'C'
+    assert div1.position_x == 0
+    assert div2.position_x == 4
+
+
+@assert_no_logs
+def test_flex_direction_row_break_after_page():
+    page1, page2 = render_pages('''
+      <style>
+        @page { size: 20px; margin: 0 }
+        body { font: 2px/1 weasyprint; margin: 0 }
+        article { display: flex; width: 20px }
+        div { width: 4px }
+      </style>
+      <article>
+        <div style="break-after: page">A</div>
+        <div>B</div>
+        <div>C</div>
+      </article>
+    ''')
+    html, = page1.children
+    body, = html.children
+    article, = body.children
+    div, = article.children
+    assert div.children[0].children[0].text == 'A'
+
+    html, = page2.children
+    body, = html.children
+    article, = body.children
+    div1, div2 = article.children
+    assert div1.children[0].children[0].text == 'B'
+    assert div2.children[0].children[0].text == 'C'
+    assert div1.position_x == 0
+    assert div2.position_x == 4
+
+
+@assert_no_logs
+def test_flex_direction_row_wrap_break_after_page():
+    page1, page2 = render_pages('''
+      <style>
+        @page { size: 20px; margin: 0 }
+        body { font: 2px/1 weasyprint; margin: 0 }
+        article { display: flex; flex-wrap: wrap; width: 8px }
+        div { width: 4px }
+      </style>
+      <article>
+        <div>A</div>
+        <div style="break-after: page">B</div>
+        <div>C</div>
+        <div>D</div>
+      </article>
+    ''')
+    html, = page1.children
+    body, = html.children
+    article, = body.children
+    div1, div2 = article.children
+    assert div1.children[0].children[0].text == 'A'
+    assert div2.children[0].children[0].text == 'B'
+    assert div1.position_y == div2.position_y == 0
+
+    html, = page2.children
+    body, = html.children
+    article, = body.children
+    div1, div2 = article.children
+    assert div1.children[0].children[0].text == 'C'
+    assert div2.children[0].children[0].text == 'D'
+    assert div1.position_x == 0
+    assert div2.position_x == 4
+    assert div1.position_y == div2.position_y == 0
+
+
+@assert_no_logs
 def test_flex_grow_in_flex_column():
     page, = render_pages('''
       <html style="width: 14px">

--- a/weasyprint/layout/flex.py
+++ b/weasyprint/layout/flex.py
@@ -479,6 +479,37 @@ def flex_layout(context, box, bottom_space, skip_stack, containing_block, page_i
             else:
                 child.height = child.target_main_size
 
+    forced_resume_at = None
+    forced_next_page = None
+    if main == 'width':
+        new_flex_lines = []
+        forced_resume_index = None
+        for line in flex_lines:
+            if new_flex_lines and line:
+                page_break = block.block_level_page_break(
+                    new_flex_lines[-1][-1][1], line[0][1])
+                if block.force_page_break(page_break, context):
+                    forced_resume_index = line[0][0]
+                    forced_next_page = {'break': page_break, 'page': None}
+                    break
+            for i, (index, child) in enumerate(line):
+                if not i:
+                    continue
+                page_break = block.block_level_page_break(line[i - 1][1], child)
+                if block.force_page_break(page_break, context):
+                    if i:
+                        new_flex_lines.append(FlexLine(line[:i]))
+                    forced_resume_index = index
+                    forced_next_page = {'break': page_break, 'page': None}
+                    break
+            else:
+                new_flex_lines.append(line)
+                continue
+            break
+        if forced_resume_index is not None:
+            flex_lines = new_flex_lines
+            forced_resume_at = {forced_resume_index: None}
+
     # 7 Determine the hypothetical cross size of each item.
     # TODO: Handle breaks.
     new_flex_lines = []
@@ -930,6 +961,10 @@ def flex_layout(context, box, bottom_space, skip_stack, containing_block, page_i
             child_skip_stack = None
         if resume_at:
             break
+
+    if resume_at is None and forced_resume_at is not None:
+        resume_at = forced_resume_at
+        next_page = forced_next_page
 
     if original_box_height != 'auto':
         # Don’t resume if flex items overflow flex container bottom.


### PR DESCRIPTION
## Summary

This PR adds a narrow forced-break path for row flex containers. When a row flex item requests a forced page break before or after another item, the flex line is split at that item boundary and the remaining items resume on the next page.

Part of #2400.

## Root Cause

Flex layout already delegates final child layout to the normal block layout machinery, but it did not inspect break opportunities between flex items. As a result, `break-before: page` and `break-after: page` on row flex items were ignored, even though block and table layout already honor the same break values between sibling boxes.

## Changes

- Reuse `block_level_page_break` and `force_page_break` to detect forced page breaks between row flex items.
- Split the current flex line at the forced break boundary.
- Resume layout from the first item after the forced break on the next page.
- Add coverage for `break-before: page`, `break-after: page`, and a wrapped-row boundary.

## Known Remaining Scope

This intentionally handles a small, reviewable slice of flex breaks. Remaining work includes:

- `break-before` on the first flex item, which needs parent/container-level coordination to avoid pointless blank pages.
- Full `left` / `right` / `recto` / `verso` behavior and page-name selection tests.
- `avoid` values, which require finding earlier/later legal flex-line break opportunities.
- Column flex direction interactions without regressing existing column fragmentation behavior.
- `break-inside: avoid` for row flex items, especially when one item fragments and another should remain unbroken.
- Interactions between forced sibling breaks and already-fragmented flex items.
- Nested table/grid/flex children whose own break signals need to compose with flex-line breaks.

## Validation

- `venv/bin/python -m pytest tests/layout/test_flex.py`
- `venv/bin/python -m pytest tests/layout`
- `venv/bin/python -m ruff check weasyprint/layout/flex.py tests/layout/test_flex.py`
