### PR TITLE
Support context paint in SVG markers

### DIFF
--- a/tests/draw/svg/test_defs.py
+++ b/tests/draw/svg/test_defs.py
@@ -56,3 +56,26 @@ def test_use_symbol_color(assert_pixels):
     svg = SVG.replace('fill="blue"', '')
     svg = svg.replace('href="#square"', 'href="#square" fill="blue"')
     assert_pixels(RESULT, STYLE + svg)
+
+
+@assert_no_logs
+def test_use_context_paint(assert_pixels):
+    assert_pixels('''
+        RRBB__GGMM
+        RRBB__GGMM
+    ''', '''
+      <style>
+        @page { size: 10px 2px }
+        svg { display: block }
+      </style>
+      <svg width="10px" height="2px" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <g id="rectangle" stroke="none">
+            <rect width="2" height="2" fill="context-fill" />
+            <rect x="2" width="2" height="2" fill="context-stroke" />
+          </g>
+        </defs>
+        <use href="#rectangle" fill="red" stroke="blue" />
+        <use href="#rectangle" x="6" fill="lime" stroke="magenta" />
+      </svg>
+    ''')

--- a/tests/draw/svg/test_markers.py
+++ b/tests/draw/svg/test_markers.py
@@ -40,6 +40,98 @@ def test_markers(assert_pixels):
 
 
 @assert_no_logs
+def test_markers_context_paint(assert_pixels):
+    assert_pixels('''
+        ___________
+        ___________
+        _____BRR___
+        _____RRR___
+        _____RRR___
+        ___________
+        _____BRR___
+        _____RRR___
+        _____RRR___
+        ___________
+        _____BRR___
+        _____RRR___
+        _____RRR___
+    ''', '''
+      <style>
+        @page { size: 11px 13px }
+        svg { display: block }
+      </style>
+      <svg width="11px" height="13px" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <marker id="rectangle" markerUnits="userSpaceOnUse">
+            <rect width="3" height="3" fill="context-stroke" />
+            <rect width="1" height="1" fill="context-fill" />
+          </marker>
+        </defs>
+        <path
+          d="M 5 2 v 4 v 4"
+          fill="blue" stroke="red" stroke-width="0"
+          marker-start="url(#rectangle)"
+          marker-mid="url(#rectangle)"
+          marker-end="url(#rectangle)" />
+      </svg>
+    ''')
+
+
+@assert_no_logs
+def test_markers_no_dash(assert_pixels):
+    assert_pixels('''
+        ___________
+        __RRRRRR___
+        __RRRRRR___
+    ''', '''
+      <style>
+        @page { size: 11px 3px }
+        svg { display: block }
+      </style>
+      <svg width="11px" height="3px" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <marker id="line" markerWidth="6" markerHeight="2"
+                  markerUnits="userSpaceOnUse">
+            <line x1="0" y1="1" x2="6" y2="1"
+                  stroke="red" stroke-width="2" />
+          </marker>
+        </defs>
+        <path
+          d="M 2 1 h 6"
+          stroke="red" stroke-width="0" stroke-dasharray="1"
+          marker-start="url(#line)" />
+      </svg>
+    ''')
+
+
+@assert_no_logs
+def test_markers_context_stroke_no_dash(assert_pixels):
+    assert_pixels('''
+        ___________
+        __RRRRRR___
+        __RRRRRR___
+    ''', '''
+      <style>
+        @page { size: 11px 3px }
+        svg { display: block }
+      </style>
+      <svg width="11px" height="3px" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <marker id="line" markerWidth="6" markerHeight="2"
+                  markerUnits="userSpaceOnUse">
+            <line x1="0" y1="1" x2="6" y2="1"
+                  stroke="context-stroke" stroke-width="2" />
+          </marker>
+        </defs>
+        <path
+          d="M 2 1 h 6"
+          stroke="red" stroke-width="0" stroke-dasharray="1"
+          marker-start="url(#line)" />
+      </svg>
+    ''')
+
+
+@assert_no_logs
 def test_markers_viewbox(assert_pixels):
     assert_pixels('''
         ___________

--- a/weasyprint/svg/__init__.py
+++ b/weasyprint/svg/__init__.py
@@ -332,6 +332,29 @@ class Node:
             svg.inner_width, svg.inner_height = svg.concrete_width, svg.concrete_height
         svg.inner_diagonal = hypot(svg.inner_width, svg.inner_height) / sqrt(2)
 
+    def get_paint(self, attribute, context=None):
+        """Get paint fill or stroke attribute with a color or a URL."""
+        assert attribute in ('fill', 'stroke')
+
+        value = self.get(attribute, 'black' if attribute == 'fill' else '').strip()
+
+        if not value or value == 'none':
+            return None, None
+
+        if value in ('context-fill', 'context-stroke'):
+            if context is None:
+                return None, None
+            return context.get_paint(value.removeprefix('context-'))
+
+        if match := re.compile(r'(url\(.+\)) *(.*)').search(value):
+            source = parse_url(match.group(1)).fragment
+            color = match.group(2) or None
+        else:
+            source = None
+            color = value or None
+
+        return source, color
+
 
 class LazyDefs:
     def __init__(self, name, svg):
@@ -385,7 +408,6 @@ class SVG:
         self.cursor_position = [0, 0]
         self.cursor_d_position = [0, 0]
         self.text_path_width = 0
-        self.context_paint_node = None
 
         self.tree.cascade(self.tree)
 
@@ -430,7 +452,7 @@ class SVG:
 
         self.draw_node(self.tree, size('12pt'))
 
-    def draw_node(self, node, font_size, fill_stroke=True):
+    def draw_node(self, node, font_size, fill_stroke=True, context=None):
         """Draw a node."""
         if node.tag == 'defs':
             return
@@ -462,7 +484,7 @@ class SVG:
 
         # Set graphical state
         if call_fill_stroke:
-            fill, stroke = self.set_graphical_state(node, font_size)
+            fill, stroke = self.set_graphical_state(node, font_size, context=context)
 
         # Clip
         clip_path = parse_url(node.get('clip-path')).fragment
@@ -693,50 +715,15 @@ class SVG:
                     self.stream.clip()
                     self.stream.end()
 
-                previous_context_paint_node = self.context_paint_node
-                self.context_paint_node = node
-                try:
-                    self.draw_node(child, font_size, fill_stroke)
-                finally:
-                    self.context_paint_node = previous_context_paint_node
+                self.draw_node(child, font_size, fill_stroke, context=node)
                 self.stream.pop_state()
 
             position = 'mid' if angles else 'start'
 
-    def get_paint(self, value):
-        """Get paint fill or stroke attribute with a color or a URL."""
-        return self._get_paint(value, ())
-
-    def _get_paint(self, value, context_values):
-        """Get paint fill or stroke, resolving context paint values."""
-        if not value or value == 'none':
-            return None, None
-
-        value = value.strip()
-        if value in ('context-fill', 'context-stroke'):
-            context_attribute = value.removeprefix('context-')
-            context_node = self.context_paint_node
-            if context_node is None or value in context_values:
-                return None, None
-            context_value = context_node.get(
-                context_attribute,
-                'black' if context_attribute == 'fill' else None)
-            return self._get_paint(context_value, (*context_values, value))
-
-        match = re.compile(r'(url\(.+\)) *(.*)').search(value)
-        if match:
-            source = parse_url(match.group(1)).fragment
-            color = match.group(2) or None
-        else:
-            source = None
-            color = value or None
-
-        return source, color
-
-    def set_graphical_state(self, node, font_size):
+    def set_graphical_state(self, node, font_size, context=None):
         """Set stroke and fill colors, gradients, patterns, and line options."""
         # Get fill data
-        source, fill = self.get_paint(node.get('fill', 'black'))
+        source, fill = node.get_paint('fill', context)
         opacity = alpha_value(node.get('fill-opacity', 1))
         if gradient := self.gradients.get(source):
             fill = draw_gradient(self, node, gradient, font_size, opacity, stroke=False)
@@ -749,7 +736,7 @@ class SVG:
 
         # Get stroke data
         if stroke_width := self.length(node.get('stroke-width', '1px'), font_size):
-            source, stroke = self.get_paint(node.get('stroke'))
+            source, stroke = node.get_paint('stroke', context)
             opacity = alpha_value(node.get('stroke-opacity', 1))
             if gradient := self.gradients.get(source):
                 stroke = draw_gradient(
@@ -879,9 +866,9 @@ class Pattern(SVG):
         self.svg = svg
         self.tree = tree
 
-    def draw_node(self, node, font_size, fill_stroke=True):
+    def draw_node(self, node, font_size, fill_stroke=True, context=None):
         # Store the original tree in self.tree when calling draw(), so that we
         # can reach defs outside the pattern
         if node == self.tree:
             self.tree = self.svg.tree
-        super().draw_node(node, font_size, fill_stroke=True)
+        super().draw_node(node, font_size, fill_stroke, context)

--- a/weasyprint/svg/__init__.py
+++ b/weasyprint/svg/__init__.py
@@ -385,6 +385,7 @@ class SVG:
         self.cursor_position = [0, 0]
         self.cursor_d_position = [0, 0]
         self.text_path_width = 0
+        self.context_paint_node = None
 
         self.tree.cascade(self.tree)
 
@@ -692,18 +693,36 @@ class SVG:
                     self.stream.clip()
                     self.stream.end()
 
-                self.draw_node(child, font_size, fill_stroke)
+                previous_context_paint_node = self.context_paint_node
+                self.context_paint_node = node
+                try:
+                    self.draw_node(child, font_size, fill_stroke)
+                finally:
+                    self.context_paint_node = previous_context_paint_node
                 self.stream.pop_state()
 
             position = 'mid' if angles else 'start'
 
-    @staticmethod
-    def get_paint(value):
+    def get_paint(self, value):
         """Get paint fill or stroke attribute with a color or a URL."""
+        return self._get_paint(value, ())
+
+    def _get_paint(self, value, context_values):
+        """Get paint fill or stroke, resolving context paint values."""
         if not value or value == 'none':
             return None, None
 
         value = value.strip()
+        if value in ('context-fill', 'context-stroke'):
+            context_attribute = value.removeprefix('context-')
+            context_node = self.context_paint_node
+            if context_node is None or value in context_values:
+                return None, None
+            context_value = context_node.get(
+                context_attribute,
+                'black' if context_attribute == 'fill' else None)
+            return self._get_paint(context_value, (*context_values, value))
+
         match = re.compile(r'(url\(.+\)) *(.*)').search(value)
         if match:
             source = parse_url(match.group(1)).fragment
@@ -760,6 +779,8 @@ class SVG:
                 sum_dashes = sum(float(value) for value in dash_array)
                 offset = sum_dashes - abs(offset) % sum_dashes
             self.stream.set_dash(dash_array, offset)
+        else:
+            self.stream.set_dash((), 0)
 
         # Apply line cap
         line_cap = node.get('stroke-linecap', 'butt')

--- a/weasyprint/svg/__init__.py
+++ b/weasyprint/svg/__init__.py
@@ -537,7 +537,8 @@ class SVG:
                 if new_chunk:
                     new_stream = self.stream
                     self.stream = original_streams[-1]
-                self.draw_node(child, font_size, fill_stroke)
+                context = node if node.tag == 'use' else context
+                self.draw_node(child, font_size, fill_stroke, context)
                 if new_chunk:
                     self.stream = new_stream
                 visible_text_child = (

--- a/weasyprint/svg/bounding_box.py
+++ b/weasyprint/svg/bounding_box.py
@@ -15,7 +15,7 @@ def bounding_box(svg, node, font_size, stroke):
     box = BOUNDING_BOX_METHODS[node.tag](svg, node, font_size)
     if not is_valid_bounding_box(box):
         return EMPTY_BOUNDING_BOX
-    if stroke and node.tag != 'g' and any(svg.get_paint(node.get('stroke'))):
+    if stroke and node.tag != 'g' and any(node.get_paint('stroke')):
         stroke_width = svg.length(node.get('stroke-width', '1px'), font_size)
         box = (
             box[0] - stroke_width / 2, box[1] - stroke_width / 2,


### PR DESCRIPTION
Fixes #2667.

## Context

SVG 2 adds `context-fill` and `context-stroke` paint values so marker contents can use the fill or stroke paint of the element referencing the marker. The motivating issue uses a marker circle with `stroke="context-stroke"` and `fill="context-fill"` on a dashed red path. In browsers such as Firefox, the marker takes the path paint values, but WeasyPrint did not recognize these keywords.

While investigating this, there was also an older rendering problem exposed by the same example: the dashed PDF graphics state from the referencing path could leak into marker contents. That meant a marker stroke could become dashed even if the marker child itself had no `stroke-dasharray`. This was not specific to the new SVG 2 keywords; it could happen with a plain `stroke="red"` marker too.

## Changes

- Track the marker-referencing SVG node while marker children are rendered.
- Resolve `context-fill` and `context-stroke` paint values from that context node.
- Keep the implementation scoped to marker rendering, which is the context element defined by the reported issue and the SVG 2 paint spec.
- Reset the SVG dash state to a solid stroke when the current node has no valid `stroke-dasharray`, preventing marker strokes from inheriting a dashed graphics state from the referencing path.
- Add regression tests for both the SVG 2 context-paint behavior and the pre-existing dashed-marker state leak.

## Scope and follow-up

This is intentionally a first, narrow slice of SVG 2 context paint support. It does not try to implement every context-paint case from the spec. In particular, `use`-element context paint and paint-server coordinate-space continuity for contextual paint values remain follow-up work.

## Tests

- `venv/bin/python -m pytest tests/draw/svg/test_markers.py`
- `venv/bin/python -m pytest tests/draw/svg`
- `venv/bin/python -m ruff check weasyprint/svg/__init__.py tests/draw/svg/test_markers.py`
