### PR TITLE
Support context paint in SVG use elements

### DIFF
--- a/tests/draw/svg/test_defs.py
+++ b/tests/draw/svg/test_defs.py
@@ -56,3 +56,26 @@ def test_use_symbol_color(assert_pixels):
     svg = SVG.replace('fill="blue"', '')
     svg = svg.replace('href="#square"', 'href="#square" fill="blue"')
     assert_pixels(RESULT, STYLE + svg)
+
+
+@assert_no_logs
+def test_use_context_paint(assert_pixels):
+    assert_pixels('''
+        RRBB__GGMM
+        RRBB__GGMM
+    ''', '''
+      <style>
+        @page { size: 10px 2px }
+        svg { display: block }
+      </style>
+      <svg width="10px" height="2px" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <g id="rectangle" stroke="none">
+            <rect width="2" height="2" fill="context-fill" />
+            <rect x="2" width="2" height="2" fill="context-stroke" />
+          </g>
+        </defs>
+        <use href="#rectangle" fill="red" stroke="blue" />
+        <use href="#rectangle" x="6" fill="lime" stroke="magenta" />
+      </svg>
+    ''')

--- a/tests/draw/svg/test_markers.py
+++ b/tests/draw/svg/test_markers.py
@@ -40,6 +40,98 @@ def test_markers(assert_pixels):
 
 
 @assert_no_logs
+def test_markers_context_paint(assert_pixels):
+    assert_pixels('''
+        ___________
+        ___________
+        _____BRR___
+        _____RRR___
+        _____RRR___
+        ___________
+        _____BRR___
+        _____RRR___
+        _____RRR___
+        ___________
+        _____BRR___
+        _____RRR___
+        _____RRR___
+    ''', '''
+      <style>
+        @page { size: 11px 13px }
+        svg { display: block }
+      </style>
+      <svg width="11px" height="13px" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <marker id="rectangle" markerUnits="userSpaceOnUse">
+            <rect width="3" height="3" fill="context-stroke" />
+            <rect width="1" height="1" fill="context-fill" />
+          </marker>
+        </defs>
+        <path
+          d="M 5 2 v 4 v 4"
+          fill="blue" stroke="red" stroke-width="0"
+          marker-start="url(#rectangle)"
+          marker-mid="url(#rectangle)"
+          marker-end="url(#rectangle)" />
+      </svg>
+    ''')
+
+
+@assert_no_logs
+def test_markers_no_dash(assert_pixels):
+    assert_pixels('''
+        ___________
+        __RRRRRR___
+        __RRRRRR___
+    ''', '''
+      <style>
+        @page { size: 11px 3px }
+        svg { display: block }
+      </style>
+      <svg width="11px" height="3px" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <marker id="line" markerWidth="6" markerHeight="2"
+                  markerUnits="userSpaceOnUse">
+            <line x1="0" y1="1" x2="6" y2="1"
+                  stroke="red" stroke-width="2" />
+          </marker>
+        </defs>
+        <path
+          d="M 2 1 h 6"
+          stroke="red" stroke-width="0" stroke-dasharray="1"
+          marker-start="url(#line)" />
+      </svg>
+    ''')
+
+
+@assert_no_logs
+def test_markers_context_stroke_no_dash(assert_pixels):
+    assert_pixels('''
+        ___________
+        __RRRRRR___
+        __RRRRRR___
+    ''', '''
+      <style>
+        @page { size: 11px 3px }
+        svg { display: block }
+      </style>
+      <svg width="11px" height="3px" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <marker id="line" markerWidth="6" markerHeight="2"
+                  markerUnits="userSpaceOnUse">
+            <line x1="0" y1="1" x2="6" y2="1"
+                  stroke="context-stroke" stroke-width="2" />
+          </marker>
+        </defs>
+        <path
+          d="M 2 1 h 6"
+          stroke="red" stroke-width="0" stroke-dasharray="1"
+          marker-start="url(#line)" />
+      </svg>
+    ''')
+
+
+@assert_no_logs
 def test_markers_viewbox(assert_pixels):
     assert_pixels('''
         ___________

--- a/weasyprint/svg/__init__.py
+++ b/weasyprint/svg/__init__.py
@@ -1,7 +1,7 @@
 """Render SVG images."""
 
 import re
-from contextlib import suppress
+from contextlib import contextmanager, suppress
 from math import cos, hypot, pi, radians, sin, sqrt
 from xml.etree import ElementTree
 
@@ -509,27 +509,29 @@ class SVG:
 
         # Draw node children
         if node.display and node.tag not in DEF_TYPES:
-            for child in node:
-                new_chunk = text_anchor_shift and (
-                    child.tag == 'text' or 'x' in child.attrib or 'y' in child.attrib)
-                if new_chunk:
-                    new_stream = self.stream
-                    self.stream = original_streams[-1]
-                self.draw_node(child, font_size, fill_stroke)
-                if new_chunk:
-                    self.stream = new_stream
-                visible_text_child = (
-                    TAGS.get(node.tag) == text and
-                    TAGS.get(child.tag) == text and
-                    child.visible)
-                if visible_text_child:
-                    if not is_valid_bounding_box(child.text_bounding_box):
-                        continue
-                    x1, y1 = child.text_bounding_box[:2]
-                    x2 = x1 + child.text_bounding_box[2]
-                    y2 = y1 + child.text_bounding_box[3]
-                    node.text_bounding_box = extend_bounding_box(
-                        node.text_bounding_box, ((x1, y1), (x2, y2)))
+            with self.context_paint(node if node.tag == 'use' else None):
+                for child in node:
+                    new_chunk = text_anchor_shift and (
+                        child.tag == 'text' or
+                        'x' in child.attrib or 'y' in child.attrib)
+                    if new_chunk:
+                        new_stream = self.stream
+                        self.stream = original_streams[-1]
+                    self.draw_node(child, font_size, fill_stroke)
+                    if new_chunk:
+                        self.stream = new_stream
+                    visible_text_child = (
+                        TAGS.get(node.tag) == text and
+                        TAGS.get(child.tag) == text and
+                        child.visible)
+                    if visible_text_child:
+                        if not is_valid_bounding_box(child.text_bounding_box):
+                            continue
+                        x1, y1 = child.text_bounding_box[:2]
+                        x2 = x1 + child.text_bounding_box[2]
+                        y2 = y1 + child.text_bounding_box[3]
+                        node.text_bounding_box = extend_bounding_box(
+                            node.text_bounding_box, ((x1, y1), (x2, y2)))
 
         # Restore concrete and inner size of root svg tag
         if node.tag == 'svg':
@@ -692,15 +694,24 @@ class SVG:
                     self.stream.clip()
                     self.stream.end()
 
-                previous_context_paint_node = self.context_paint_node
-                self.context_paint_node = node
-                try:
+                with self.context_paint(node):
                     self.draw_node(child, font_size, fill_stroke)
-                finally:
-                    self.context_paint_node = previous_context_paint_node
                 self.stream.pop_state()
 
             position = 'mid' if angles else 'start'
+
+    @contextmanager
+    def context_paint(self, node):
+        """Set the context element used by context-fill and context-stroke."""
+        if node is None:
+            yield
+            return
+        previous_context_paint_node = self.context_paint_node
+        self.context_paint_node = node
+        try:
+            yield
+        finally:
+            self.context_paint_node = previous_context_paint_node
 
     def get_paint(self, value):
         """Get paint fill or stroke attribute with a color or a URL."""

--- a/weasyprint/svg/__init__.py
+++ b/weasyprint/svg/__init__.py
@@ -385,6 +385,7 @@ class SVG:
         self.cursor_position = [0, 0]
         self.cursor_d_position = [0, 0]
         self.text_path_width = 0
+        self.context_paint_node = None
 
         self.tree.cascade(self.tree)
 
@@ -691,18 +692,36 @@ class SVG:
                     self.stream.clip()
                     self.stream.end()
 
-                self.draw_node(child, font_size, fill_stroke)
+                previous_context_paint_node = self.context_paint_node
+                self.context_paint_node = node
+                try:
+                    self.draw_node(child, font_size, fill_stroke)
+                finally:
+                    self.context_paint_node = previous_context_paint_node
                 self.stream.pop_state()
 
             position = 'mid' if angles else 'start'
 
-    @staticmethod
-    def get_paint(value):
+    def get_paint(self, value):
         """Get paint fill or stroke attribute with a color or a URL."""
+        return self._get_paint(value, ())
+
+    def _get_paint(self, value, context_values):
+        """Get paint fill or stroke, resolving context paint values."""
         if not value or value == 'none':
             return None, None
 
         value = value.strip()
+        if value in ('context-fill', 'context-stroke'):
+            context_attribute = value.removeprefix('context-')
+            context_node = self.context_paint_node
+            if context_node is None or value in context_values:
+                return None, None
+            context_value = context_node.get(
+                context_attribute,
+                'black' if context_attribute == 'fill' else None)
+            return self._get_paint(context_value, (*context_values, value))
+
         match = re.compile(r'(url\(.+\)) *(.*)').search(value)
         if match:
             source = parse_url(match.group(1)).fragment
@@ -752,6 +771,8 @@ class SVG:
                 sum_dashes = sum(float(value) for value in dash_array)
                 offset = sum_dashes - abs(offset) % sum_dashes
             self.stream.set_dash(dash_array, offset)
+        else:
+            self.stream.set_dash((), 0)
 
         # Apply line cap
         line_cap = node.get('stroke-linecap', 'butt')


### PR DESCRIPTION
Stacked on #2744.

## Context

#2744 adds marker-scoped support for the SVG 2 `context-fill` and `context-stroke` paint values, fixing the concrete marker case from #2667. The SVG 2 paint definition also says that an element inside a subtree instantiated by a `use` element has that `use` element as its context element.

This draft PR adds that second small context-paint case on top of #2744, so maintainers can decide whether they want to include it as a follow-up feature.

## Changes

- Reuse the context-paint tracking introduced by #2744 when drawing children of a `use` element.
- Treat the `use` element as the context element while its referenced subtree is drawn.
- Add a pixel regression test proving that `context-fill` and `context-stroke` are resolved independently for multiple `use` instances with different solid paint values.

## Scope and limitations

This intentionally supports the simple solid-color case. It does not try to solve the harder paint-server geometry case for contextual `url(#gradient)` or `url(#pattern)` values. For those, SVG 2 requires the paint server coordinate space and bounding box to come from the context element, which needs additional gradient/pattern plumbing beyond this small follow-up.

Until #2744 lands, this PR’s diff includes the marker context-paint groundwork from #2744 plus one additional commit for `use` elements.

## Tests

- `venv/bin/python -m pytest tests/draw/svg/test_defs.py::test_use_context_paint tests/draw/svg/test_defs.py::test_use_symbol_color tests/draw/svg/test_markers.py::test_markers_context_paint`
- `venv/bin/python -m pytest tests/draw/svg`
- `venv/bin/python -m ruff check weasyprint/svg/__init__.py tests/draw/svg/test_defs.py tests/draw/svg/test_markers.py`
