### PR TITLE
Support basic display: contents

### DIFF
--- a/tests/layout/test_flex.py
+++ b/tests/layout/test_flex.py
@@ -1028,6 +1028,31 @@ def test_flex_direction_row_inline_block():
 
 
 @assert_no_logs
+def test_flex_display_contents():
+    # Regression test for issue #2210.
+    page, = render_pages('''
+      <article style="display: flex; flex-flow: column wrap">
+        <div style="display: contents">
+          <label style="order: 1">Tab 1</label>
+          <label style="order: 2">Tab 2</label>
+        </div>
+        <div style="display: contents">
+          <div style="order: 1">Content Block 1</div>
+          <div style="order: 2">Content Block 2</div>
+        </div>
+      </article>
+    ''')
+    html, = page.children
+    body, = html.children
+    article, = body.children
+    tab_1, content_1, tab_2, content_2 = article.children
+    assert tab_1.children[0].children[0].children[0].text == 'Tab 1'
+    assert content_1.children[0].children[0].text == 'Content Block 1'
+    assert tab_2.children[0].children[0].children[0].text == 'Tab 2'
+    assert content_2.children[0].children[0].text == 'Content Block 2'
+
+
+@assert_no_logs
 def test_flex_float():
     page, = render_pages('''
       <article style="display: flex">

--- a/weasyprint/css/computed_values.py
+++ b/weasyprint/css/computed_values.py
@@ -583,6 +583,8 @@ def display(style, name, value):
     # See https://www.w3.org/TR/CSS21/visuren.html#dis-pos-flo.
     float_ = style.specified['float']
     position = style.specified['position']
+    if style.is_root_element and value == ('contents',):
+        return ('block', 'flow')
     if position in ('absolute', 'fixed') or float_ != 'none' or style.is_root_element:
         if value == ('inline-table',):
             return ('block', 'table')

--- a/weasyprint/css/validation/properties.py
+++ b/weasyprint/css/validation/properties.py
@@ -718,7 +718,7 @@ def display(tokens):
         if value in (
                 'none', 'table-caption', 'table-row-group', 'table-cell',
                 'table-header-group', 'table-footer-group', 'table-row',
-                'table-column-group', 'table-column'):
+                'table-column-group', 'table-column', 'contents'):
             return (value,)
         elif value in ('inline-table', 'inline-flex', 'inline-grid'):
             return tuple(value.split('-'))

--- a/weasyprint/formatting_structure/build.py
+++ b/weasyprint/formatting_structure/build.py
@@ -143,7 +143,10 @@ def element_to_box(element, style_for, get_image_from_uri, base_url,
             # TODO: handle compact footnotes
             style['display'] = ('inline', 'flow')
 
-    box = make_box(element.tag, style, [], element)
+    if display == ('contents',):
+        box = boxes.BlockBox(element.tag, style, element, [])
+    else:
+        box = make_box(element.tag, style, [], element)
     box.first_letter_style = style_for(element, 'first-letter')
     box.first_line_style = style_for(element, 'first-line')
 
@@ -230,6 +233,9 @@ def element_to_box(element, style_for, get_image_from_uri, base_url,
     set_content_lists(
         element, box, style, counter_values, target_collector, counter_style)
 
+    if display == ('contents',):
+        return children
+
     if marker_boxes and len(box.children) == 1:
         # See https://www.w3.org/TR/css-lists-3/#list-style-position-outside
         #
@@ -277,7 +283,10 @@ def before_after_to_box(element, pseudo_type, state, style_for,
     content = style['content']
     if content in ('normal', 'inhibit', 'none'):
         return []
-    box = make_box(f'{element.tag}::{pseudo_type}', style, [], element)
+    if display == ('contents',):
+        box = boxes.InlineBox(f'{element.tag}::{pseudo_type}', style, element, [])
+    else:
+        box = make_box(f'{element.tag}::{pseudo_type}', style, [], element)
 
     quote_depth, counter_values, _counter_scopes, _page_groups = state
     update_counters(state, style)
@@ -302,7 +311,7 @@ def before_after_to_box(element, pseudo_type, state, style_for,
         compute_bookmark_label(
             element, box, style['bookmark_label'], counter_values,
             target_collector, counter_style)
-    return [box]
+    return children if display == ('contents',) else [box]
 
 
 def marker_to_box(element, state, parent_style, style_for, get_image_from_uri,
@@ -321,10 +330,10 @@ def marker_to_box(element, state, parent_style, style_for, get_image_from_uri,
     # `content` where 'normal' computes as 'inhibit' for pseudo elements.
     quote_depth, counter_values, _counter_scopes, _page_groups = state
 
-    box = make_box(f'{element.tag}::marker', style, children, element)
-
-    if style['display'] == ('none',):
+    if style['display'] in (('none',), ('contents',)):
         return
+
+    box = make_box(f'{element.tag}::marker', style, children, element)
 
     image_type, image = style['list_style_image']
 


### PR DESCRIPTION
Fixes #2210.

## Context

#2210 reports that tabbed content generated by Material for MkDocs / PyMdown Extensions is rendered in the wrong order when wrappers use `display: contents` inside a flex container. WeasyPrint currently rejects `display: contents` during CSS validation, so these wrappers generate real boxes instead of being flattened into their children.

The issue thread also mentioned that the same order problem could be reproduced without `display: contents` when inline `label` elements are direct flex children. On current `main`, that direct-inline case is already handled correctly by the existing flex item/blockification work related to #1652. The remaining missing part is the actual `display: contents` wrapper behavior.

## Changes

- Accept `display: contents` as a valid `display` value.
- Compute `display: contents` on the root element back to a normal block-flow root box, avoiding a missing root box.
- Flatten normal `display: contents` elements by returning their child boxes instead of a principal box.
- Handle pseudo-element and marker edge cases so the new display value does not fall through to box creation paths that have no `contents` box type.
- Add a regression test for the #2210 flex/tabbed-content structure, checking that the children are flex items in the expected order: Tab 1, Content Block 1, Tab 2, Content Block 2.

## Scope and limitations

This is intended as a first, narrow implementation of `display: contents`. It fixes the concrete wrapper/flex case from #2210 and keeps the change small enough to review.

It does not claim complete CSS Display conformance. In particular, this does not deeply address every possible interaction of `display: contents` with accessibility/tree semantics, unusual pseudo-element behavior, replaced elements, or every layout model. The goal is to provide a useful first fix and let maintainers decide whether this approach is acceptable as a base for broader support.

## Tests

- `venv/bin/python -m pytest tests/layout/test_flex.py tests/css/test_validation.py`
- `venv/bin/python -m pytest tests/layout`
- `venv/bin/python -m ruff check weasyprint/css/validation/properties.py weasyprint/css/computed_values.py weasyprint/formatting_structure/build.py tests/layout/test_flex.py`
- `git diff --check`
