### PR TITLE
Fix inline break opportunities across boxes

### DIFF
--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -20,6 +20,12 @@ def make_text(text, width=None, **style):
         justification_spacing=0)
 
 
+def box_text(box):
+    if hasattr(box, 'text'):
+        return box.text
+    return ''.join(box_text(child) for child in box.children)
+
+
 @assert_no_logs
 def test_line_content():
     for width, remaining in [(100, 'text for test'),
@@ -960,6 +966,83 @@ def test_wrap_overflow_word_break(span_css, expected_lines):
             line_text += span_box.children[0].text
         lines.append(line_text)
     assert lines == expected_lines
+
+
+@assert_no_logs
+def test_overflow_wrap_inline_box_boundary():
+    # Regression test for #1614.
+    page, = render_pages('''
+      <style>
+        body {font-family: weasyprint; font-size: 16px;
+              overflow-wrap: break-word}
+        div {width: 280px}
+      </style>
+      <div>aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa<span>bbbbbbbbbb</span></div>
+    ''')
+    html, = page.children
+    body, = html.children
+    div, = body.children
+
+    assert [box_text(line) for line in div.children] == [
+        'aaaaaaaaaaaaaaaaa',
+        'aaaaaaaaaaaaabbbb',
+        'bbbbbb',
+    ]
+    assert all(line.width <= div.width for line in div.children)
+
+
+@assert_no_logs
+def test_pre_wrap_inline_box_boundary():
+    # Regression test for #2308.
+    text = '00 00 00 00 00 00 00 00 00 00 '
+    span_text = '00 00 00 00 00 00 00 00 00 00 00 00 00 00 00'
+    after_text = ' 00 00 00 00 00'
+    page, = render_pages(f'''
+      <style>
+        code {{display: block; font-family: weasyprint; font-size: 16px;
+               white-space: pre-wrap; width: 300px}}
+      </style>
+      <code>{text}<span>{span_text}</span>{after_text}</code>
+    ''')
+    html, = page.children
+    body, = html.children
+    code, = body.children
+    _line1, line2, _line3, _line4, line5 = code.children
+
+    text, span = line2.children
+    span_text, = span.children
+    assert text.text == '00 00 00 00 '
+    assert span_text.text == '00 00 '
+    span, text = line5.children
+    span_text, = span.children
+    assert span_text.text == '00'
+    assert text.text == ' 00 00 00 00 00'
+
+
+@assert_no_logs
+def test_pre_wrap_space_before_after_inline_box():
+    # Regression test for #2025.
+    html = '''
+      <style>
+        pre {font-family: weasyprint; font-size: 16px;
+             white-space: pre-wrap; width: 250px}
+      </style>
+      <pre><b>1234567890 1234567890 </b>domicilié 1234567890</pre>
+      <pre><b>1234567890 1234567890</b> domicilié 1234567890</pre>
+    '''
+    page, = render_pages(html)
+    html, = page.children
+    body, = html.children
+    pre1, pre2 = body.children
+
+    assert [box_text(line) for line in pre1.children] == [
+        '1234567890 ',
+        '1234567890 ',
+        'domicilié ',
+        '1234567890',
+    ]
+    assert [box_text(line) for line in pre1.children] == [
+        box_text(line) for line in pre2.children]
 
 
 @assert_no_logs

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -992,6 +992,41 @@ def test_overflow_wrap_inline_box_boundary():
 
 
 @assert_no_logs
+def test_overflow_wrap_nested_inline_box_boundary():
+    # Regression test for #2102.
+    html = '''
+      <style>
+        body {font-family: weasyprint; font-size: 16px;
+              overflow-wrap: break-word}
+        div {width: 20em}
+      </style>
+      <div>
+        <em>
+          some text
+          <span>xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx yyyyyyyyy</span>
+          zzzz wwwwwwwwwwwww
+          aaaaaa
+        </em>
+      </div>
+      <div>
+        <em>
+          some text
+          xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx yyyyyyyyy
+          zzzz wwwwwwwwwwwww
+          aaaaaa
+        </em>
+      </div>
+    '''
+    page, = render_pages(html)
+    html, = page.children
+    body, = html.children
+    div1, div2 = body.children
+
+    assert [box_text(line) for line in div1.children] == [
+        box_text(line) for line in div2.children]
+
+
+@assert_no_logs
 def test_pre_wrap_inline_box_boundary():
     # Regression test for #2308.
     text = '00 00 00 00 00 00 00 00 00 00 '

--- a/weasyprint/layout/inline.py
+++ b/weasyprint/layout/inline.py
@@ -487,7 +487,9 @@ def split_inline_level(context, box, position_x, max_x, bottom_space,
             skip = skip or 0
             assert skip_stack is None
 
-        is_line_start = len(line_children) == 0
+        text = box.text.encode()[skip:].decode()
+        first_letter = text[0] if text else None
+        is_line_start = not line_has_break(line_children, first_letter, box.style)
         new_box, skip, preserved_line_break = split_text_box(
             context, box, max_x - position_x, skip,
             is_line_start=is_line_start)
@@ -808,21 +810,10 @@ def split_inline_box(context, box, position_x, max_x, bottom_space, skip_stack,
         if preserved:
             preserved_line_break = True
 
-        can_break = None
-        if last_letter is True:
-            last_letter = ' '
-        elif last_letter is False:
-            last_letter = ' '  # no-break space
-        elif box.style['white_space'] in ('pre', 'nowrap'):
+        if box.style['white_space'] in ('pre', 'nowrap'):
             can_break = False
-        if can_break is None:
-            if None in (last_letter, first):
-                can_break = False
-            elif first in (True, False):
-                can_break = first
-            else:
-                can_break = can_break_text(
-                    last_letter + first, child.style['lang'])
+        else:
+            can_break = can_break_between(last_letter, first, child.style)
 
         if can_break:
             children.extend(waiting_children)
@@ -1253,3 +1244,53 @@ def can_break_inside(box):
     elif text_wrap and isinstance(box, boxes.ParentBox):
         return any(can_break_inside(child) for child in box.children)
     return False
+
+
+def can_break_between(last_letter, first_letter, style):
+    if last_letter is True:
+        last_letter = ' '
+    elif last_letter is False:
+        last_letter = ' '  # no-break space
+    if None in (last_letter, first_letter):
+        return False
+    if first_letter in (True, False):
+        return first_letter
+    return can_break_text(last_letter + first_letter, style['lang'])
+
+
+def first_last_letters(box):
+    if isinstance(box, boxes.TextBox):
+        if not box.text:
+            return None, None
+        if box.trailing_collapsible_space:
+            return box.text[0], True
+        return box.text[0], box.text[-1]
+    elif isinstance(box, boxes.AtomicInlineLevelBox):
+        # See https://www.w3.org/TR/css-text-3/#line-breaking
+        # Atomic inlines behave like ideographic characters.
+        return '\u2e80', '\u2e80'
+    elif isinstance(box, boxes.ParentBox):
+        first_letter = last_letter = None
+        for child in box.children:
+            if not child.is_in_normal_flow():
+                continue
+            child_first, child_last = first_last_letters(child)
+            if first_letter is None:
+                first_letter = child_first
+            if child_last is not None:
+                last_letter = child_last
+        return first_letter, last_letter
+    return None, None
+
+
+def line_has_break(line_children, first_letter, style):
+    last_letter = None
+    for _, child in line_children:
+        child_first, child_last = first_last_letters(child)
+        if can_break_between(last_letter, child_first, style):
+            return True
+        if can_break_inside(child):
+            return True
+        if child_last is not None:
+            last_letter = child_last
+    return can_break_between(last_letter, first_letter, style)

--- a/weasyprint/layout/inline.py
+++ b/weasyprint/layout/inline.py
@@ -458,7 +458,8 @@ def inline_block_width(box, context, containing_block):
 def split_inline_level(context, box, position_x, max_x, bottom_space,
                        skip_stack, containing_block, absolute_boxes,
                        fixed_boxes, line_placeholders, waiting_floats,
-                       line_children, first_letter_style, first_line_style):
+                       line_children, first_letter_style, first_line_style,
+                       previous_letter=None):
     """Fit as much content as possible from an inline-level box in a width.
 
     Return ``(new_box, resume_at, preserved_line_break, first_letter, last_letter)``.
@@ -489,7 +490,9 @@ def split_inline_level(context, box, position_x, max_x, bottom_space,
 
         text = box.text.encode()[skip:].decode()
         first_letter = text[0] if text else None
-        is_line_start = not line_has_break(line_children, first_letter, box.style)
+        is_line_start = not (
+            line_has_break(line_children, first_letter, box.style) or
+            can_break_between(previous_letter, first_letter, box.style))
         new_box, skip, preserved_line_break = split_text_box(
             context, box, max_x - position_x, skip,
             is_line_start=is_line_start)
@@ -515,7 +518,8 @@ def split_inline_level(context, box, position_x, max_x, bottom_space,
          last_letter, float_widths) = split_inline_box(
              context, box, position_x, max_x, bottom_space, skip_stack,
              containing_block, absolute_boxes, fixed_boxes, line_placeholders,
-             waiting_floats, line_children, first_letter_style, first_line_style)
+             waiting_floats, line_children, first_letter_style, first_line_style,
+             previous_letter)
     elif isinstance(box, boxes.AtomicInlineLevelBox):
         new_box = atomic_box(
             context, box, position_x, skip_stack, containing_block,
@@ -711,7 +715,7 @@ def _adjust_line_height(box):
 def split_inline_box(context, box, position_x, max_x, bottom_space, skip_stack,
                      containing_block, absolute_boxes, fixed_boxes, line_placeholders,
                      waiting_floats, line_children, first_letter_style,
-                     first_line_style):
+                     first_line_style, previous_letter=None):
     """Fit as much content as possible from an inline box in a width.
 
     Return ``(new_box, resume_at, preserved_line_break, first_letter, last_letter)``.
@@ -780,12 +784,15 @@ def split_inline_box(context, box, position_x, max_x, bottom_space, skip_stack,
         is_last_child = (index == len(box.children) - 1)
         available_width = max_x
         child_waiting_floats = []
+        child_previous_letter = (
+            previous_letter if last_letter is None else last_letter)
         new_child, resume_at, preserved, first, last, new_float_widths = (
             split_inline_level(
                 context, child, position_x, available_width, bottom_space,
                 skip_stack, containing_block, absolute_boxes, fixed_boxes,
                 line_placeholders, child_waiting_floats, line_children,
-                first_letter_style, first_line_style))
+                first_letter_style, first_line_style,
+                previous_letter=child_previous_letter))
         if box.style['direction'] == 'rtl':
             end_spacing = left_spacing
             max_x -= new_float_widths['left']
@@ -801,7 +808,8 @@ def split_inline_box(context, box, position_x, max_x, bottom_space, skip_stack,
                     context, child, position_x, available_width, bottom_space,
                     skip_stack, containing_block, absolute_boxes, fixed_boxes,
                     line_placeholders, child_waiting_floats, line_children,
-                    first_letter_style, first_line_style))
+                    first_letter_style, first_line_style,
+                    previous_letter=child_previous_letter))
 
         float_widths['left'] = max(float_widths['left'], new_float_widths['left'])
         float_widths['right'] = max(float_widths['right'], new_float_widths['right'])


### PR DESCRIPTION
## What changed

This updates inline line breaking so `overflow-wrap: break-word` decides whether a text fragment is at the start of an otherwise unbreakable sequence by checking for real break opportunities already present on the line, instead of only checking whether this is the first box on the line. The state is also carried into nested inline boxes so a previous break opportunity outside a span is still visible when laying out text inside that span.

That fixes the linked case from #1614 where a single long word is split across a text node and an inline box, for example `aaaaaaaa...<span>bbbb...</span>`. The text can now wrap inside the continued word instead of overflowing because the span boundary was treated too much like a word boundary.

The PR also adds regression coverage for related inline-boundary reports from #2102, #2025, and #2308. Current `main` already appears to handle the concrete #2308 example, but the test pins the behavior so it does not regress.

## Historical context

The issue chain is:

- #2308 reports that highlighted spans with `white-space: pre-wrap` can wrap as whole spans.
- #2025 reports different `pre-wrap` behavior depending on whether a preserved space is inside or outside an inline tag.
- #2102 reports that wrapping a long word in an extra span changes `word-wrap: break-word` rendering.
- #1614 identifies the broader line-breaking problem: WeasyPrint can treat inline boxes almost as separate words, and the existing `is_line_start` heuristic is based on box position rather than whether the current line already has an acceptable break opportunity.

There is also the older draft #1840, which explores a much broader line-breaking rewrite using Harfbuzz data. Daniel Fitzpatrick also has a fork commit for the same root problem: https://github.com/danfitz36/WeasyPrint/commit/f9e68e2afdda1e62076008482643cf01bd5f7df3. This PR is intentionally much smaller than #1840, and now also carries the previous fragment state into nested inlines as Daniel’s commit does.

## What this does not claim

This is not full CSS Text line-breaking compliance. It does not implement the complete CSS Text Level 3 model, nor does it solve every interaction between inline boundaries, shaping, bidi, CJK line-breaking rules, hyphenation, `word-break`, `line-break`, and all `overflow-wrap` cases.

The goal here is narrower: fix the immediate inline-boundary triggers reported in #1614 and #2102, and keep the related #2025/#2308 examples covered by tests, while leaving the broader line-breaking universe for a larger implementation.

## Tests

- `venv/bin/python -m ruff check weasyprint/layout/inline.py tests/test_text.py`
- `venv/bin/python -m pytest tests/test_text.py`
- `venv/bin/python -m pytest tests/layout/test_inline.py`
- `venv/bin/python -m pytest` -> 4029 passed, 40 xfailed

Addresses #1614 and #2102.
Related to #2025 and #2308.