### PR TITLE
Fix simple grid content widths

### DIFF
--- a/tests/layout/test_grid.py
+++ b/tests/layout/test_grid.py
@@ -104,6 +104,46 @@ def test_grid_container_max_content_width():
 
 
 @assert_no_logs
+def test_grid_container_in_flex_column():
+    # Reference test for the #2354 flex/grid example.
+    page, = render_pages('''
+      <style>
+        body {font-family: weasyprint; font-size: 2px}
+      </style>
+      <div style="padding: 10px; display: flex; flex-direction: column;
+                  background: red">
+        <div style="display: grid; grid-template-columns: 1fr 1fr;
+                    align-items: center; background: pink">
+          <span style="background: lime">a</span>
+          <span style="background: cyan">ab cd ef gh</span>
+        </div>
+      </div>
+    ''')
+    html, = page.children
+    body, = html.children
+    flex, = body.children
+    grid, = flex.children
+    span1, span2 = grid.children
+    line1, = span1.children
+    line2, = span2.children
+    inline1, = line1.children
+    inline2, = line2.children
+    text1, = inline1.children
+    text2, = inline2.children
+
+    assert flex.width == body.width - 20
+    assert grid.position_x == flex.position_x + 10
+    assert grid.width == flex.width
+    assert span1.position_x == grid.position_x
+    assert span2.position_x == span1.position_x + span1.width
+    assert isclose(span1.width, grid.width / 2)
+    assert span1.width == span2.width
+    assert span1.position_y == span2.position_y
+    assert text1.text == 'a'
+    assert text2.text == 'ab cd ef gh'
+
+
+@assert_no_logs
 def test_grid_rows():
     page, = render_pages('''
       <article style="display: grid">

--- a/tests/layout/test_grid.py
+++ b/tests/layout/test_grid.py
@@ -73,6 +73,37 @@ def test_grid_single_percentage_width():
 
 
 @assert_no_logs
+def test_grid_container_max_content_width():
+    # Regression test for #2354.
+    page, = render_pages('''
+      <style>
+        body {font-family: weasyprint; font-size: 2px}
+      </style>
+      <div style="float: left">
+        <div style="display: grid; grid: 1fr / 1fr 1fr;
+                    border: 1px solid">
+          <div>abc def</div>
+          <div>abc def</div>
+        </div>
+      </div>
+    ''')
+    html, = page.children
+    body, = html.children
+    float_box, = body.children
+    grid, = float_box.children
+    div1, div2 = grid.children
+    line1, = div1.children
+    line2, = div2.children
+    text1, = line1.children
+    text2, = line2.children
+
+    assert float_box.width == 30
+    assert grid.width == 28
+    assert div1.width == div2.width == 14
+    assert text1.text == text2.text == 'abc def'
+
+
+@assert_no_logs
 def test_grid_rows():
     page, = render_pages('''
       <article style="display: grid">

--- a/weasyprint/layout/grid.py
+++ b/weasyprint/layout/grid.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from itertools import count, cycle
 from math import inf
 
+from ..css.functions import check_math
 from ..css.properties import Dimension
 from ..formatting_structure import boxes
 from ..logger import LOGGER
@@ -226,6 +227,55 @@ def _get_template_tracks(tracks):
             else:
                 tracks_list.append(list(track))
     return tracks_list
+
+
+def grid_content_width(context, box, outer=True, function='max-content'):
+    """Return a simple intrinsic width for grid containers.
+
+    This does not implement the whole grid intrinsic sizing algorithm, but it
+    handles common non-spanning row-flow grids by summing track contributions
+    instead of treating the grid as a regular block.
+
+    """
+    assert function in ('min-content', 'max-content')
+
+    width = box.style['width']
+    if width != 'auto' and not check_math(width) and width.unit != '%':
+        from .preferred import block_max_content_width, block_min_content_width
+        if function == 'min-content':
+            return block_min_content_width(context, box, outer)
+        else:
+            return block_max_content_width(context, box, outer)
+
+    columns = _get_template_tracks(box.style['grid_template_columns'])
+    columns_sizing = [_get_sizing_functions(column) for column in columns[1::2]]
+    columns_number = len(columns_sizing) or 1
+    tracks_widths = [0] * columns_number
+
+    column_gap = box.style['column_gap']
+    if column_gap == 'normal' or check_math(column_gap) or column_gap.unit == '%':
+        column_gap = 0
+    else:
+        column_gap = column_gap.value
+
+    content_width = (
+        min_content_width if function == 'min-content' else max_content_width)
+    for index, child in enumerate(
+            child for child in box.children if not child.is_absolutely_positioned()):
+        column = index % columns_number
+        tracks_widths[column] = max(
+            tracks_widths[column], content_width(context, child))
+
+    for i, sizing in enumerate(columns_sizing):
+        min_function, max_function = sizing
+        for track_function in (min_function, max_function):
+            if _is_length(track_function) and not check_math(track_function):
+                tracks_widths[i] = max(tracks_widths[i], track_function.value)
+
+    width = sum(tracks_widths) + max(0, columns_number - 1) * column_gap
+
+    from .preferred import adjust
+    return adjust(box, outer, width)
 
 
 def _distribute_extra_space(affected_sizes, affected_tracks_types, size_contribution,

--- a/weasyprint/layout/preferred.py
+++ b/weasyprint/layout/preferred.py
@@ -57,8 +57,8 @@ def min_content_width(context, box, outer=True):
     elif isinstance(box, boxes.FlexContainerBox):
         return flex_min_content_width(context, box, outer)
     elif isinstance(box, boxes.GridContainerBox):
-        # TODO: Get real grid size.
-        return block_min_content_width(context, box, outer)
+        from .grid import grid_content_width
+        return grid_content_width(context, box, outer, function='min-content')
     else:
         raise TypeError(f'min-content width for {type(box).__name__} not handled yet')
 
@@ -84,8 +84,8 @@ def max_content_width(context, box, outer=True):
     elif isinstance(box, boxes.FlexContainerBox):
         return flex_max_content_width(context, box, outer)
     elif isinstance(box, boxes.GridContainerBox):
-        # TODO: Get real grid size.
-        return block_max_content_width(context, box, outer)
+        from .grid import grid_content_width
+        return grid_content_width(context, box, outer, function='max-content')
     else:
         raise TypeError(f'max-content width for {type(box).__name__} not handled yet')
 


### PR DESCRIPTION
## What changed

This adds a small intrinsic-width helper for grid containers used by preferred width calculations.

Before this change, `min_content_width()` and `max_content_width()` treated `GridContainerBox` like a regular block container. That means shrink-to-fit contexts, such as floats and flex/grid items using intrinsic size contributions, could see a multi-column grid as if its intrinsic width were just the width of one child block. In the minimal example discussed in #2354/#2145, a two-column grid containing `abc def` twice reported a width close to one `abc def`, causing each grid item to wrap to `abc`/`def`.

The new helper handles simple, non-spanning row-flow grid containers by summing per-track intrinsic contributions and gutters. It is deliberately conservative: it improves common grid content width cases without attempting to implement the complete CSS Grid intrinsic sizing algorithm.

## Investigation summary

I followed the #2354 link chain and related work before making this patch:

- #2354 was opened as a follow-up to #2342, replacing the earlier flex/grid mixed example with a grid-only example using nested grids and auto-height rows.
- #2342 links these separate limitations:
  - #1891: `aspect-ratio` is unsupported.
  - #1665: flex `gap` support, later handled by the flex rewrite.
  - #1652 and #1563: flex item sizing/margin issues, later handled by the flex rewrite.
  - #2145: the grid support tracking issue.
  - #2362 / #2387: the flex rewrite, now merged.
- #2145 explicitly tracks #2354 as “auto content size for grid containers”. It also tracks nearby grid gaps including #2644 (“grid items with intrinsic size”, eg images), #2647 (grid + float), #2397/#2564 (grid row fragmentation, merged), #2628/#2643 (`box-sizing: border-box` in grid layout, merged), and #2142/#2162 (`grid-auto-flow: column`, merged).
- I searched for open and closed upstream PRs around #2354/#2342 and the relevant grid terms. I did not find an existing open PR or submitted patch specifically for #2354.

## What this fixes

The PR fixes the maintainer’s minimal intrinsic-size example from #2354/#2145:

```html
<div style="float: left">
  <div style="display: grid; grid: 1fr / 1fr 1fr; border: 1px solid red">
    <div>abc def</div>
    <div>abc def</div>
  </div>
</div>
```

With this patch, the float’s max-content width includes both grid tracks, and the two `abc def` items no longer wrap as if the grid were one child block wide.

The PR now also includes the exact flex-column/grid sample from the #2354 issue comment as `test_grid_container_in_flex_column`. On current main, that standalone sample already lays out as a stretched flex item, so this test is included as related reference coverage; the behavior-changing regression remains the shrink-to-fit grid content width case above.

## What this does not fix

This is not full CSS Grid intrinsic sizing support. In particular, this PR does **not** claim to solve:

- the complete original image/object-fit layout in #2354;
- grid items with intrinsic image sizes (#2644);
- `aspect-ratio` support (#1891);
- absolutely positioned or floating grid items (#2647);
- spanning items in intrinsic sizing;
- complex `min-content` / `max-content` cases;
- `auto-fit` / `auto-fill`;
- `auto` margins for grid items;
- `min-*` / `max-*` constraints on grid items;
- the complete CSS Grid track sizing algorithm for intrinsic contributions.

The intent is to provide a small reviewable base for one narrow part of #2354: simple grid containers contributing a sensible min/max-content width in shrink-to-fit contexts.

## Tests

- `venv/bin/python -m ruff check weasyprint/layout/grid.py weasyprint/layout/preferred.py tests/layout/test_grid.py`
- `venv/bin/python -m pytest tests/layout/test_grid.py`
- `venv/bin/python -m pytest tests/layout/test_preferred.py tests/layout/test_flex.py`
- `venv/bin/python -m pytest` -> 4027 passed, 40 xfailed

Addresses part of #2354.
Related to #2145, #2644, #2342, #1891, #1665, #1652, #2362, #2628, #2647.


