### PR TITLE
Fix right alignment with pre-wrap trailing spaces

### DIFF
--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -210,6 +210,38 @@ def test_text_align_right():
 
 
 @assert_no_logs
+def test_text_align_right_pre_wrap_trailing_space():
+    # Regression test for #2384.
+    page, = render_pages('''
+      <style>
+        @page { size: 100px 200px; margin: 0 }
+        body { margin: 0; width: 35px; font: 10px/1 weasyprint }
+        div { text-align: right; white-space: pre-wrap }
+      </style>
+      <body><div>abc def ghi jkl mno</div>
+    ''')
+    html, = page.children
+    body, = html.children
+    div, = body.children
+    line1, line2, line3, line4, line5 = div.children
+    text1, = line1.children
+    text2, = line2.children
+    text3, = line3.children
+    text4, = line4.children
+    text5, = line5.children
+
+    assert text1.text == 'abc '
+    assert text2.text == 'def '
+    assert text3.text == 'ghi '
+    assert text4.text == 'jkl '
+    assert text5.text == 'mno'
+    assert line1.width > div.width
+    assert line1.position_x == line2.position_x == 5
+    assert line2.position_x == line3.position_x == line4.position_x
+    assert line5.position_x == 5
+
+
+@assert_no_logs
 def test_text_align_center():
     # <-------------------->  page, body
     #           +-----+

--- a/weasyprint/layout/inline.py
+++ b/weasyprint/layout/inline.py
@@ -1147,7 +1147,11 @@ def text_align(context, line, available_width, last):
     # "When the total width of the inline-level boxes on a line is less than
     # the width of the line box containing them, their horizontal distribution
     # within the line box is determined by the 'text-align' property."
-    if line.width >= available_width:
+    line_width = line.width
+    if line.style['white_space'] == 'pre-wrap':
+        line_width = max(0, line_width - trailing_whitespace_size(
+            context, line, white_space=('pre-wrap',)))
+    if line_width >= available_width:
         return 0
 
     align = line.style['text_align_all']
@@ -1163,7 +1167,7 @@ def text_align(context, line, available_width, last):
             align = 'end'
     if align == 'start':
         return 0
-    offset = available_width - line.width
+    offset = available_width - line_width
     if align == 'justify':
         if space_collapse:
             # Justification of texts where white space is not collapsing is

--- a/weasyprint/layout/preferred.py
+++ b/weasyprint/layout/preferred.py
@@ -802,7 +802,8 @@ def flex_max_content_width(context, box, outer=True):
         return adjust(box, outer, max(max_contents))
 
 
-def trailing_whitespace_size(context, box):
+def trailing_whitespace_size(
+        context, box, white_space=('normal', 'nowrap', 'pre-line')):
     """Return the size of the trailing whitespace of ``box``."""
     from .inline import split_first_line, split_text_box
 
@@ -817,8 +818,8 @@ def trailing_whitespace_size(context, box):
     if not isinstance(box, boxes.TextBox) or not box.text:
         # There’s no text in last child.
         return 0
-    elif box.style['white_space'] not in ('normal', 'nowrap', 'pre-line'):
-        # Spaces don’t collapse.
+    elif box.style['white_space'] not in white_space:
+        # Spaces aren’t handled by this caller.
         return 0
     elif box.style['font_size'] == 0:
         # Trailing spaces take no space.


### PR DESCRIPTION
## What changed

This adjusts line alignment so that trailing spaces preserved by `white-space: pre-wrap` hang for alignment purposes. The spaces remain in the line box, but `text-align: right`/`end`/`center` computes the alignment offset from the non-hanging content width.

This matches the CSS Text phase 2 rule linked from #2384: end-of-line preserved spaces with `pre-wrap` should hang rather than contribute to the visible right-alignment inset.

## Why

In #2384, right-aligned `white-space: pre-wrap` text gets an unwanted right-side gap. The line content includes the preserved break-triggering trailing spaces, and WeasyPrint was using that full line width to calculate the alignment offset. As a result, the visible words were shifted too far left.

## Scope

This is a small targeted fix, not full CSS Text Level 4 whitespace support. Existing collapsing-space callers keep their current behavior because `trailing_whitespace_size` still defaults to `normal`, `nowrap`, and `pre-line`; the new `pre-wrap` path is requested explicitly by text alignment.

## Related investigation

I followed the #2384 comments and related links before making this patch:

- #2384 points at the CSS Text white-space phase 2 hanging-space rule.
- #2384 may be related to #751, but #751 is a separate case involving inline `dl`/`dt`/`dd` content and anonymous block construction around `dt::before`. This PR does not claim to fix #751.
- #751 is also mentioned from #2504 / PR #2496 in the context of PDF/UA sample invoice testing. Those links did not include an existing whitespace alignment patch.
- I searched open and closed PRs for #2384, #751, #2504, `pre-wrap`, `white-space`, `hang spaces`, and trailing-space terms, and did not find an existing upstream PR for this specific fix.

## Tests

Added `test_text_align_right_pre_wrap_trailing_space`.

Validation run locally:

- `venv/bin/python -m ruff check weasyprint/layout/inline.py weasyprint/layout/preferred.py tests/test_text.py`
- `venv/bin/python -m pytest tests/test_text.py tests/layout/test_inline.py tests/layout/test_preferred.py -q` -> 294 passed, 3 xfailed
- `venv/bin/python -m pytest tests/draw/test_text.py -q` -> 42 passed, 5 xfailed
- `venv/bin/python -m pytest` -> 4026 passed, 40 xfailed

Fixes #2384.
Related to #751 and #2504.
