### PR TITLE
Fix floated first-letter line positioning

### DIFF
--- a/tests/layout/test_float.py
+++ b/tests/layout/test_float.py
@@ -838,5 +838,4 @@ def test_first_letter_float():
     line1, = p.children
     first_letter, text = line1.children
     assert first_letter.position_x == 0
-    # TODO: fix problem described in #1859.
-    # assert text.position_x == 20
+    assert text.position_x == 20

--- a/weasyprint/layout/inline.py
+++ b/weasyprint/layout/inline.py
@@ -640,6 +640,8 @@ def _out_of_flow_layout(context, box, containing_block, index, child,
         page = context.current_page
         context.running_elements[running_name][page].append(child)
 
+    return position_x, max_x
+
 
 def _break_waiting_children(context, box, max_x, bottom_space, initial_skip_stack,
                             absolute_boxes, fixed_boxes, line_placeholders,
@@ -764,14 +766,16 @@ def split_inline_box(context, box, position_x, max_x, bottom_space, skip_stack,
         child.position_y = box.position_y
 
         if not child.is_in_normal_flow():
-            _out_of_flow_layout(
+            new_position_x, new_max_x = _out_of_flow_layout(
                 context, box, containing_block, index, child, children,
                 line_children, waiting_children, waiting_floats,
                 absolute_boxes, fixed_boxes, line_placeholders, float_widths,
                 max_x, position_x, bottom_space)
+            if isinstance(box, boxes.LineBox):
+                position_x, max_x = new_position_x, new_max_x
             if child.is_floated():
                 float_resume_index = index + 1
-                if child not in waiting_floats:
+                if child not in waiting_floats and not isinstance(box, boxes.LineBox):
                     max_x -= child.margin_width()
             continue
 


### PR DESCRIPTION
Fixes #1859.
Refs #2486.

## What changed

This keeps the updated inline position and maximum line width calculated while laying out out-of-flow children on root line boxes. For floated `::first-letter` boxes, this means the text that follows the generated first-letter box starts after the float instead of being laid out underneath it.

The existing regression test for #1859 already documented the missing assertion; this PR enables that assertion.

## Root cause

`_out_of_flow_layout` updated `position_x` and `max_x` when it laid out a float, but these values were local to the helper. `split_inline_box` kept using the old values for the following text, so a generated floated `::first-letter` could occupy the left side of the line while the remaining text still started at the original line position.

The returned state is only applied for root `LineBox` layout. Nested inline float accounting keeps the previous behavior, which avoids changing existing inline-float wrapping cases.

## Scope

This does not implement the `initial-letter` property requested in #2486. WeasyPrint still treats declarations such as `initial-letter: 3` as unknown. This PR fixes the smaller drop-cap workaround that #2486 points to through #1859: `::first-letter` with `float: left`.

A fuller `initial-letter` implementation would still need parsing for the property values and dedicated size/sink/drop/raise layout behavior.

## Tests

- `venv/bin/python -m pytest tests/layout/test_float.py -q`
- `venv/bin/python -m pytest tests/test_text.py -q`
- `venv/bin/python -m ruff check weasyprint/layout/inline.py tests/layout/test_float.py`