### PR TITLE
Add initial-letter support

### DIFF
--- a/tests/css/test_validation.py
+++ b/tests/css/test_validation.py
@@ -321,6 +321,40 @@ def test_line_height_invalid(rule):
 
 
 @assert_no_logs
+@pytest.mark.parametrize(('rule', 'value'), [
+    ('normal', 'normal'),
+    ('1', (1, 1)),
+    ('1.5', (1.5, 2)),
+    ('3', (3, 3)),
+    ('3 1', (3, 1)),
+    ('3 2', (3, 2)),
+    ('3 calc(1 + 1)', (3, 2)),
+    ('2.5 3', (2.5, 3)),
+    ('3 drop', (3, 3)),
+    ('drop 3', (3, 3)),
+    ('3 raise', (3, 1)),
+    ('raise 3', (3, 1)),
+])
+def test_initial_letter(rule, value):
+    assert get_value(f'initial-letter: {rule}') == value
+
+
+@pytest.mark.parametrize('rule', [
+    'auto',
+    '0',
+    '-1',
+    '3 0',
+    '3 2.5',
+    '3 2 1',
+    'drop',
+    'raise',
+    'drop raise 3',
+])
+def test_initial_letter_invalid(rule):
+    assert_invalid(f'initial-letter: {rule}')
+
+
+@assert_no_logs
 @pytest.mark.parametrize('rule', [
     'symbols()',
     'symbols(cyclic)',

--- a/tests/layout/test_float.py
+++ b/tests/layout/test_float.py
@@ -839,3 +839,175 @@ def test_first_letter_float():
     first_letter, text = line1.children
     assert first_letter.position_x == 0
     assert text.position_x == 20
+
+
+@assert_no_logs
+def test_initial_letter():
+    page, = render_pages('''
+      <style>
+        body { width: 100px; font: 20px/1 weasyprint; margin: 0 }
+        p { margin: 0 }
+        p::first-letter { initial-letter: 3 }
+      </style>
+      <p>Lor em in up ax by</p>''')
+    html, = page.children
+    body, = html.children
+    p, = body.children
+    line1, line2, line3, line4, line5 = p.children
+    first_letter, text = line1.children
+    first_letter_line, = first_letter.children
+    first_letter_text, = first_letter_line.children
+    assert first_letter_text.text == 'L'
+    assert first_letter_text.style['font_size'] == 60
+    assert first_letter.height == 60
+    assert text.text == 'or'
+    assert text.position_x == 60
+    assert line2.position_x == 60
+    assert line3.position_x == 60
+    assert line4.position_x == 0
+    assert line5.position_x == 0
+
+
+@assert_no_logs
+def test_initial_letter_sink():
+    page, = render_pages('''
+      <style>
+        body { width: 100px; font: 20px/1 weasyprint; margin: 0 }
+        p { margin: 0 }
+        p::first-letter { initial-letter: 3 2 }
+      </style>
+      <p>Lor em in up ax by</p>''')
+    html, = page.children
+    body, = html.children
+    p, = body.children
+    line1, line2, line3, line4 = p.children
+    first_letter, text = line1.children
+    assert first_letter.height == 60
+    assert first_letter.children[0].children[0].style['font_size'] == 60
+    assert line1.height == 40
+    assert text.position_x == 60
+    assert text.position_y == 20
+    assert line2.position_x == 60
+    assert line3.position_x == 0
+    assert line4.position_x == 0
+
+
+@assert_no_logs
+def test_initial_letter_raise():
+    page, = render_pages('''
+      <style>
+        body { width: 100px; font: 20px/1 weasyprint; margin: 0 }
+        p { margin: 40px 0 0 }
+        p::first-letter { initial-letter: 3 raise }
+      </style>
+      <p>Lor em in up ax by</p>''')
+    html, = page.children
+    body, = html.children
+    p, = body.children
+    line1, line2, line3, line4 = p.children
+    first_letter, text = line1.children
+    assert first_letter.height == 60
+    assert line1.height == 60
+    assert text.position_x == 60
+    assert text.position_y == 80
+    assert line2.position_x == 0
+    assert line3.position_x == 0
+    assert line4.position_x == 0
+
+
+@assert_no_logs
+def test_initial_letter_fractional_size():
+    page, = render_pages('''
+      <style>
+        body { width: 100px; font: 20px/1 weasyprint; margin: 0 }
+        p { margin: 0 }
+        p::first-letter { initial-letter: 2.5 3 }
+      </style>
+      <p>Lor em in up ax by</p>''')
+    html, = page.children
+    body, = html.children
+    p, = body.children
+    line1, line2, line3, line4, line5 = p.children
+    first_letter, text = line1.children
+    assert first_letter.width == 50
+    assert first_letter.height == 50
+    assert first_letter.children[0].children[0].style['font_size'] == 50
+    assert text.position_x == 50
+    assert line2.position_x == 50
+    assert line3.position_x == 50
+    assert line4.position_x == 0
+    assert line5.position_x == 0
+
+
+@assert_no_logs
+def test_initial_letter_punctuation():
+    page, = render_pages('''
+      <style>
+        body { width: 140px; font: 20px/1 weasyprint; margin: 0 }
+        p { margin: 0 }
+        p::first-letter { initial-letter: 3 }
+      </style>
+      <p>“Lor” em ipsum dolor</p>''')
+    html, = page.children
+    body, = html.children
+    p, = body.children
+    line1, line2, line3, line4 = p.children
+    first_letter, text = line1.children
+    first_letter_line, = first_letter.children
+    first_letter_text, = first_letter_line.children
+    assert first_letter_text.text == '“L'
+    assert text.text == 'or”'
+    assert text.position_x == 120
+    assert line2.position_x == 0
+    assert line3.position_x == 0
+    assert line4.position_x == 0
+
+
+@assert_no_logs
+def test_initial_letter_styled_box():
+    page, = render_pages('''
+      <style>
+        body { width: 140px; font: 20px/1 weasyprint; margin: 0 }
+        p { margin: 0 }
+        p::first-letter {
+          initial-letter: 3;
+          border: 2px solid;
+          padding: 2px;
+          margin-right: 5px;
+        }
+      </style>
+      <p>Lor em ipsum dolor sit amet</p>''')
+    html, = page.children
+    body, = html.children
+    p, = body.children
+    line1, line2, line3, line4, line5, line6 = p.children
+    first_letter, text = line1.children
+    first_letter_text, = first_letter.children[0].children
+    assert first_letter.width == 60
+    assert first_letter.margin_width() == 73
+    assert first_letter_text.position_x == 4
+    assert text.position_x == 73
+    assert line2.position_x == 73
+    assert line3.position_x == 0
+    assert line4.position_x == 0
+    assert line5.position_x == 0
+    assert line6.position_x == 0
+
+
+@assert_no_logs
+def test_initial_letter_short_paragraph():
+    page, = render_pages('''
+      <style>
+        body { width: 140px; font: 20px/1 weasyprint; margin: 0 }
+        p { margin: 0 }
+        p::first-letter { initial-letter: 3 }
+      </style>
+      <p>Lor</p>''')
+    html, = page.children
+    body, = html.children
+    p, = body.children
+    line, = p.children
+    first_letter, text = line.children
+    assert first_letter.height == 60
+    assert text.text == 'or'
+    assert text.position_x == 60

--- a/tests/layout/test_float.py
+++ b/tests/layout/test_float.py
@@ -838,5 +838,4 @@ def test_first_letter_float():
     line1, = p.children
     first_letter, text = line1.children
     assert first_letter.position_x == 0
-    # TODO: fix problem described in #1859.
-    # assert text.position_x == 20
+    assert text.position_x == 20

--- a/weasyprint/css/properties.py
+++ b/weasyprint/css/properties.py
@@ -151,6 +151,9 @@ INITIAL_VALUES = {
     'object_position': (('left', Dimension(50, '%'),
                          'top', Dimension(50, '%')),),
 
+    # CSS Inline Layout 3 (WD): https://www.w3.org/TR/css-inline-3/
+    'initial_letter': 'normal',
+
     # Paged Media 3 (WD): https://www.w3.org/TR/css-page-3/
     'size': None,  # set to A4 in computed_values
     'page': 'auto',

--- a/weasyprint/css/validation/properties.py
+++ b/weasyprint/css/validation/properties.py
@@ -4,7 +4,7 @@ See https://www.w3.org/TR/CSS21/propidx.html and various CSS3 modules.
 
 """
 
-from math import inf
+from math import ceil, inf
 
 from tinycss2 import parse_component_value_list
 from tinycss2.color5 import parse_color
@@ -1022,6 +1022,43 @@ def outline_offset(token):
     """Validation for ``outline-offset``."""
     if length := get_length(token):
         return length
+
+
+@property(unstable=True)
+def initial_letter(tokens):
+    """Validation for ``initial-letter``."""
+    if len(tokens) == 1 and get_keyword(tokens[0]) == 'normal':
+        return 'normal'
+    if len(tokens) not in (1, 2):
+        return
+
+    size = sink = mode = None
+    for token in tokens:
+        keyword = get_keyword(token)
+        if keyword in ('drop', 'raise'):
+            if mode is not None or sink is not None:
+                return
+            mode = keyword
+            continue
+
+        if number := get_number(token):
+            if number.value < 1:
+                return
+            if size is None:
+                size = number.value
+                continue
+            if sink is not None or mode is not None:
+                return
+            integer = get_number(token, integer=True)
+            if integer and integer.value >= 1:
+                sink = integer.value
+                continue
+        return
+
+    if size is not None:
+        if sink is None:
+            sink = 1 if mode == 'raise' else ceil(size)
+        return size, sink
 
 
 @property()

--- a/weasyprint/layout/inline.py
+++ b/weasyprint/layout/inline.py
@@ -640,6 +640,8 @@ def _out_of_flow_layout(context, box, containing_block, index, child,
         page = context.current_page
         context.running_elements[running_name][page].append(child)
 
+    return position_x, max_x
+
 
 def _break_waiting_children(context, box, max_x, bottom_space, initial_skip_stack,
                             absolute_boxes, fixed_boxes, line_placeholders,
@@ -764,14 +766,16 @@ def split_inline_box(context, box, position_x, max_x, bottom_space, skip_stack,
         child.position_y = box.position_y
 
         if not child.is_in_normal_flow():
-            _out_of_flow_layout(
+            new_position_x, new_max_x = _out_of_flow_layout(
                 context, box, containing_block, index, child, children,
                 line_children, waiting_children, waiting_floats,
                 absolute_boxes, fixed_boxes, line_placeholders, float_widths,
                 max_x, position_x, bottom_space)
+            if isinstance(box, boxes.LineBox):
+                position_x, max_x = new_position_x, new_max_x
             if child.is_floated():
                 float_resume_index = index + 1
-                if child not in waiting_floats:
+                if child not in waiting_floats and not isinstance(box, boxes.LineBox):
                     max_x -= child.margin_width()
             continue
 

--- a/weasyprint/layout/inline.py
+++ b/weasyprint/layout/inline.py
@@ -139,6 +139,12 @@ def get_next_linebox(context, linebox, position_y, bottom_space, skip_stack,
         # Removing this line breaks the position == linebox.position test below
         # See issue #583.
         line.position_y = position_y
+        if clear_gap := initial_letter_clear_gap(line):
+            line.height += clear_gap
+            line.baseline += clear_gap
+            for child in line.children:
+                if child.is_in_normal_flow():
+                    child.translate(dy=clear_gap)
 
         if line.height <= candidate_height:
             break
@@ -291,6 +297,36 @@ def remove_last_whitespace(context, line):
     # 'white-space' set to 'pre-wrap', UAs may visually collapse them.
 
 
+def apply_initial_letter(box, letter_style):
+    """Apply simple dropped-initial sizing to a ``::first-letter`` style."""
+    initial_letter = letter_style['initial_letter']
+    if initial_letter == 'normal':
+        return
+
+    size, sink = initial_letter
+    line_height, _ = strut(box.style)
+    parent_cap_height = box.style['font_size'] * character_ratio(box.style, 'cap')
+    letter_cap_ratio = character_ratio(letter_style, 'cap')
+    letter_font_size = (
+        ((size - 1) * line_height + parent_cap_height) / letter_cap_ratio)
+    letter_style['font_size'] = letter_font_size
+    letter_style['line_height'] = ('PIXELS', letter_font_size)
+    letter_style['__initial_letter_clear_gap'] = (
+        max(size - sink, 0) * line_height)
+    if letter_style['float'] == 'none':
+        letter_style['float'] = (
+            'right' if box.style['direction'] == 'rtl' else 'left')
+
+
+def initial_letter_clear_gap(line):
+    """Return the gap before first-line contents for raised initial letters."""
+    return max(
+        (
+            child.style.get('__initial_letter_clear_gap', 0)
+            for child in line.children if child.is_floated()),
+        default=0)
+
+
 def first_letter_to_box(box, skip_stack, first_letter_style):
     """Create a box for the ::first-letter selector."""
     if first_letter_style and box.children:
@@ -305,6 +341,7 @@ def first_letter_to_box(box, skip_stack, first_letter_style):
             letter_style = box.style.copy()
             for key, value in first_letter_style.items():
                 letter_style[key] = value
+            apply_initial_letter(box, letter_style)
             if child.element_tag.endswith('::first-letter'):
                 letter_box = boxes.InlineBox(
                     f'{box.element_tag}::first-letter', letter_style,


### PR DESCRIPTION
Draft PR stacked on #2751.

Refs #2486.

This starts support for the CSS Inline Layout `initial-letter` property for `::first-letter`.

Because this branch depends on #2751, the diff includes the floated `::first-letter` positioning fix until that PR lands. The additional initial-letter implementation is commit 08ec75278bb435e83f2b3d17eb7689f3fe25b938.

## What changed

- Parse unprefixed `initial-letter`, including `normal`, numeric sizes, explicit sink values, `drop`, `raise`, fractional sizes, and integer `calc()` sink values.
- Apply `initial-letter` to `::first-letter` by reusing the floated first-letter layout path.
- Size the initial letter from the requested line span using the parent line height and cap-height ratios.
- Add first-line clearance for raised/sunken initials so following text keeps the expected visual gap.
- Add focused tests for validation, default drop behavior, explicit sink values, raised initials, fractional sizes, punctuation, styled first-letter boxes, and short paragraphs.

## Scope and known gaps

This is intentionally a first, reviewable step rather than a full implementation of CSS Inline Layout Level 3.

Known gaps include:

- RTL rendering is not good enough yet; the branch includes visual proof showing this as an explicit gap.
- `initial-letter-align` and `initial-letter-wrap` are not implemented.
- Vertical writing modes, ruby interactions, and text-box trimming are not covered.
- Fragmentation/page/column interactions are not handled specially.
- Interactions with other floats and exclusion geometry may need more work for complex documents.
- The prefixed `-webkit-initial-letter` alias is intentionally not added here; this PR focuses on the unprefixed CSS property.

## Visual proof

The locally generated PNG/PDF proof artifacts were uploaded to GitHub attachments. The contact sheet is cropped to the visible content for easier review.

<img width="850" height="2297" alt="compact initial-letter visual proof" src="https://github.com/user-attachments/assets/1f948fea-cc18-4a2b-8b4f-1766c822141b" />

Individual proof artifacts:

- initial-letter: 3: [PNG](https://github.com/user-attachments/assets/6715e7e0-138a-40ac-a005-a40d26352b48), [PDF](https://github.com/user-attachments/files/26980671/initial-letter-3.pdf)
- initial-letter: 3 2: [PNG](https://github.com/user-attachments/assets/b8419f69-ef64-40f4-8088-f71db0ed4912), [PDF](https://github.com/user-attachments/files/26980672/initial-letter-3-2.pdf)
- initial-letter: 3 raise: [PNG](https://github.com/user-attachments/assets/6a3c57d2-725d-4315-b859-318d13643360), [PDF](https://github.com/user-attachments/files/26980673/initial-letter-3-raise.pdf)
- initial-letter: 2.5 3: [PNG](https://github.com/user-attachments/assets/7087abe3-6437-4f4e-b9e9-2a2cb76d5196), [PDF](https://github.com/user-attachments/files/26980675/initial-letter-2-5-3.pdf)
- initial-letter: 4: [PNG](https://github.com/user-attachments/assets/b2e14c24-da3b-4997-9fa2-1099a61bb508), [PDF](https://github.com/user-attachments/files/26980676/initial-letter-4.pdf)
- initial-letter: 4 2: [PNG](https://github.com/user-attachments/assets/a2fff86a-3724-427d-bbd1-be5355f9450f), [PDF](https://github.com/user-attachments/files/26980678/initial-letter-4-2.pdf)
- initial-letter: 1.5: [PNG](https://github.com/user-attachments/assets/66e72423-0fb0-42fb-9764-4c04ee1fc0fa), [PDF](https://github.com/user-attachments/files/26980679/initial-letter-1-5.pdf)
- punctuation: [PNG](https://github.com/user-attachments/assets/7ad8a7c8-277f-4505-9cbf-74466a456afb), [PDF](https://github.com/user-attachments/files/26980680/initial-letter-punctuation.pdf)
- short paragraph: [PNG](https://github.com/user-attachments/assets/7d92a7b3-e768-4a3b-bb1f-22d48cd959c0), [PDF](https://github.com/user-attachments/files/26980681/initial-letter-short-paragraph.pdf)
- RTL gap case: [PNG](https://github.com/user-attachments/assets/e0370442-695c-43d9-a319-0a4794a56414), [PDF](https://github.com/user-attachments/files/26980682/initial-letter-rtl.pdf)
- styled border/padding: [PNG](https://github.com/user-attachments/assets/a7b9ee0e-e21b-4152-91e8-593843912758), [PDF](https://github.com/user-attachments/files/26980683/initial-letter-colored-border.pdf)
- manual first-letter float comparison: [PNG](https://github.com/user-attachments/assets/60a64eda-4289-40dc-a983-d9b9bb0cc49d), [PDF](https://github.com/user-attachments/files/26980684/manual-first-letter-float.pdf)

## Checks

- `venv/bin/python -m pytest tests/css/test_validation.py tests/layout/test_float.py tests/test_text.py -q`
- `venv/bin/python -m ruff check weasyprint/css/properties.py weasyprint/css/validation/properties.py weasyprint/layout/inline.py tests/css/test_validation.py tests/layout/test_float.py`
