### PR TITLE
Handle larger initial-letter sink values

### DIFF
--- a/tests/css/test_validation.py
+++ b/tests/css/test_validation.py
@@ -321,6 +321,40 @@ def test_line_height_invalid(rule):
 
 
 @assert_no_logs
+@pytest.mark.parametrize(('rule', 'value'), [
+    ('normal', 'normal'),
+    ('1', (1, 1)),
+    ('1.5', (1.5, 2)),
+    ('3', (3, 3)),
+    ('3 1', (3, 1)),
+    ('3 2', (3, 2)),
+    ('3 calc(1 + 1)', (3, 2)),
+    ('2.5 3', (2.5, 3)),
+    ('3 drop', (3, 3)),
+    ('drop 3', (3, 3)),
+    ('3 raise', (3, 1)),
+    ('raise 3', (3, 1)),
+])
+def test_initial_letter(rule, value):
+    assert get_value(f'initial-letter: {rule}') == value
+
+
+@pytest.mark.parametrize('rule', [
+    'auto',
+    '0',
+    '-1',
+    '3 0',
+    '3 2.5',
+    '3 2 1',
+    'drop',
+    'raise',
+    'drop raise 3',
+])
+def test_initial_letter_invalid(rule):
+    assert_invalid(f'initial-letter: {rule}')
+
+
+@assert_no_logs
 @pytest.mark.parametrize('rule', [
     'symbols()',
     'symbols(cyclic)',

--- a/tests/layout/test_float.py
+++ b/tests/layout/test_float.py
@@ -839,3 +839,175 @@ def test_first_letter_float():
     first_letter, text = line1.children
     assert first_letter.position_x == 0
     assert text.position_x == 20
+
+
+@assert_no_logs
+def test_initial_letter():
+    page, = render_pages('''
+      <style>
+        body { width: 100px; font: 20px/1 weasyprint; margin: 0 }
+        p { margin: 0 }
+        p::first-letter { initial-letter: 3 }
+      </style>
+      <p>Lor em in up ax by</p>''')
+    html, = page.children
+    body, = html.children
+    p, = body.children
+    line1, line2, line3, line4, line5 = p.children
+    first_letter, text = line1.children
+    first_letter_line, = first_letter.children
+    first_letter_text, = first_letter_line.children
+    assert first_letter_text.text == 'L'
+    assert first_letter_text.style['font_size'] == 60
+    assert first_letter.height == 60
+    assert text.text == 'or'
+    assert text.position_x == 60
+    assert line2.position_x == 60
+    assert line3.position_x == 60
+    assert line4.position_x == 0
+    assert line5.position_x == 0
+
+
+@assert_no_logs
+def test_initial_letter_sink():
+    page, = render_pages('''
+      <style>
+        body { width: 100px; font: 20px/1 weasyprint; margin: 0 }
+        p { margin: 0 }
+        p::first-letter { initial-letter: 3 2 }
+      </style>
+      <p>Lor em in up ax by</p>''')
+    html, = page.children
+    body, = html.children
+    p, = body.children
+    line1, line2, line3, line4 = p.children
+    first_letter, text = line1.children
+    assert first_letter.height == 60
+    assert first_letter.children[0].children[0].style['font_size'] == 60
+    assert line1.height == 40
+    assert text.position_x == 60
+    assert text.position_y == 20
+    assert line2.position_x == 60
+    assert line3.position_x == 0
+    assert line4.position_x == 0
+
+
+@assert_no_logs
+def test_initial_letter_raise():
+    page, = render_pages('''
+      <style>
+        body { width: 100px; font: 20px/1 weasyprint; margin: 0 }
+        p { margin: 40px 0 0 }
+        p::first-letter { initial-letter: 3 raise }
+      </style>
+      <p>Lor em in up ax by</p>''')
+    html, = page.children
+    body, = html.children
+    p, = body.children
+    line1, line2, line3, line4 = p.children
+    first_letter, text = line1.children
+    assert first_letter.height == 60
+    assert line1.height == 60
+    assert text.position_x == 60
+    assert text.position_y == 80
+    assert line2.position_x == 0
+    assert line3.position_x == 0
+    assert line4.position_x == 0
+
+
+@assert_no_logs
+def test_initial_letter_fractional_size():
+    page, = render_pages('''
+      <style>
+        body { width: 100px; font: 20px/1 weasyprint; margin: 0 }
+        p { margin: 0 }
+        p::first-letter { initial-letter: 2.5 3 }
+      </style>
+      <p>Lor em in up ax by</p>''')
+    html, = page.children
+    body, = html.children
+    p, = body.children
+    line1, line2, line3, line4, line5 = p.children
+    first_letter, text = line1.children
+    assert first_letter.width == 50
+    assert first_letter.height == 50
+    assert first_letter.children[0].children[0].style['font_size'] == 50
+    assert text.position_x == 50
+    assert line2.position_x == 50
+    assert line3.position_x == 50
+    assert line4.position_x == 0
+    assert line5.position_x == 0
+
+
+@assert_no_logs
+def test_initial_letter_punctuation():
+    page, = render_pages('''
+      <style>
+        body { width: 140px; font: 20px/1 weasyprint; margin: 0 }
+        p { margin: 0 }
+        p::first-letter { initial-letter: 3 }
+      </style>
+      <p>“Lor” em ipsum dolor</p>''')
+    html, = page.children
+    body, = html.children
+    p, = body.children
+    line1, line2, line3, line4 = p.children
+    first_letter, text = line1.children
+    first_letter_line, = first_letter.children
+    first_letter_text, = first_letter_line.children
+    assert first_letter_text.text == '“L'
+    assert text.text == 'or”'
+    assert text.position_x == 120
+    assert line2.position_x == 0
+    assert line3.position_x == 0
+    assert line4.position_x == 0
+
+
+@assert_no_logs
+def test_initial_letter_styled_box():
+    page, = render_pages('''
+      <style>
+        body { width: 140px; font: 20px/1 weasyprint; margin: 0 }
+        p { margin: 0 }
+        p::first-letter {
+          initial-letter: 3;
+          border: 2px solid;
+          padding: 2px;
+          margin-right: 5px;
+        }
+      </style>
+      <p>Lor em ipsum dolor sit amet</p>''')
+    html, = page.children
+    body, = html.children
+    p, = body.children
+    line1, line2, line3, line4, line5, line6 = p.children
+    first_letter, text = line1.children
+    first_letter_text, = first_letter.children[0].children
+    assert first_letter.width == 60
+    assert first_letter.margin_width() == 73
+    assert first_letter_text.position_x == 4
+    assert text.position_x == 73
+    assert line2.position_x == 73
+    assert line3.position_x == 0
+    assert line4.position_x == 0
+    assert line5.position_x == 0
+    assert line6.position_x == 0
+
+
+@assert_no_logs
+def test_initial_letter_short_paragraph():
+    page, = render_pages('''
+      <style>
+        body { width: 140px; font: 20px/1 weasyprint; margin: 0 }
+        p { margin: 0 }
+        p::first-letter { initial-letter: 3 }
+      </style>
+      <p>Lor</p>''')
+    html, = page.children
+    body, = html.children
+    p, = body.children
+    line, = p.children
+    first_letter, text = line.children
+    assert first_letter.height == 60
+    assert text.text == 'or'
+    assert text.position_x == 60

--- a/tests/layout/test_float.py
+++ b/tests/layout/test_float.py
@@ -838,5 +838,4 @@ def test_first_letter_float():
     line1, = p.children
     first_letter, text = line1.children
     assert first_letter.position_x == 0
-    # TODO: fix problem described in #1859.
-    # assert text.position_x == 20
+    assert text.position_x == 20

--- a/tests/layout/test_float.py
+++ b/tests/layout/test_float.py
@@ -893,6 +893,33 @@ def test_initial_letter_sink():
 
 
 @assert_no_logs
+def test_initial_letter_larger_sink():
+    page, = render_pages('''
+      <style>
+        body { width: 100px; font: 20px/1 weasyprint; margin: 0 }
+        p { margin: 0 }
+        p::first-letter { initial-letter: 3 4 }
+      </style>
+      <p>Lor em in up ax by</p>''')
+    html, = page.children
+    body, = html.children
+    p, = body.children
+    line1, line2, line3, line4, line5 = p.children
+    first_letter, text = line1.children
+    assert first_letter.height == 60
+    assert first_letter.margin_top == 20
+    assert first_letter.margin_height() == 80
+    assert first_letter.border_box_y() == 20
+    assert first_letter.children[0].children[0].style['font_size'] == 60
+    assert text.position_x == 60
+    assert text.position_y == 0
+    assert line2.position_x == 60
+    assert line3.position_x == 60
+    assert line4.position_x == 60
+    assert line5.position_x == 0
+
+
+@assert_no_logs
 def test_initial_letter_raise():
     page, = render_pages('''
       <style>

--- a/weasyprint/css/properties.py
+++ b/weasyprint/css/properties.py
@@ -151,6 +151,9 @@ INITIAL_VALUES = {
     'object_position': (('left', Dimension(50, '%'),
                          'top', Dimension(50, '%')),),
 
+    # CSS Inline Layout 3 (WD): https://www.w3.org/TR/css-inline-3/
+    'initial_letter': 'normal',
+
     # Paged Media 3 (WD): https://www.w3.org/TR/css-page-3/
     'size': None,  # set to A4 in computed_values
     'page': 'auto',

--- a/weasyprint/css/validation/properties.py
+++ b/weasyprint/css/validation/properties.py
@@ -4,7 +4,7 @@ See https://www.w3.org/TR/CSS21/propidx.html and various CSS3 modules.
 
 """
 
-from math import inf
+from math import ceil, inf
 
 from tinycss2 import parse_component_value_list
 from tinycss2.color5 import parse_color
@@ -1022,6 +1022,43 @@ def outline_offset(token):
     """Validation for ``outline-offset``."""
     if length := get_length(token):
         return length
+
+
+@property(unstable=True)
+def initial_letter(tokens):
+    """Validation for ``initial-letter``."""
+    if len(tokens) == 1 and get_keyword(tokens[0]) == 'normal':
+        return 'normal'
+    if len(tokens) not in (1, 2):
+        return
+
+    size = sink = mode = None
+    for token in tokens:
+        keyword = get_keyword(token)
+        if keyword in ('drop', 'raise'):
+            if mode is not None or sink is not None:
+                return
+            mode = keyword
+            continue
+
+        if number := get_number(token):
+            if number.value < 1:
+                return
+            if size is None:
+                size = number.value
+                continue
+            if sink is not None or mode is not None:
+                return
+            integer = get_number(token, integer=True)
+            if integer and integer.value >= 1:
+                sink = integer.value
+                continue
+        return
+
+    if size is not None:
+        if sink is None:
+            sink = 1 if mode == 'raise' else ceil(size)
+        return size, sink
 
 
 @property()

--- a/weasyprint/layout/float.py
+++ b/weasyprint/layout/float.py
@@ -43,6 +43,8 @@ def float_layout(context, box, containing_block, absolute_boxes, fixed_boxes,
         box.margin_top = 0
     if box.margin_bottom == 'auto':
         box.margin_bottom = 0
+    if initial_letter_sink_gap := box.style.get('__initial_letter_sink_gap', 0):
+        box.margin_top += initial_letter_sink_gap
 
     clearance = get_clearance(context, box, containing_block.style['direction'])
     if clearance is not None:

--- a/weasyprint/layout/inline.py
+++ b/weasyprint/layout/inline.py
@@ -640,6 +640,8 @@ def _out_of_flow_layout(context, box, containing_block, index, child,
         page = context.current_page
         context.running_elements[running_name][page].append(child)
 
+    return position_x, max_x
+
 
 def _break_waiting_children(context, box, max_x, bottom_space, initial_skip_stack,
                             absolute_boxes, fixed_boxes, line_placeholders,
@@ -764,14 +766,16 @@ def split_inline_box(context, box, position_x, max_x, bottom_space, skip_stack,
         child.position_y = box.position_y
 
         if not child.is_in_normal_flow():
-            _out_of_flow_layout(
+            new_position_x, new_max_x = _out_of_flow_layout(
                 context, box, containing_block, index, child, children,
                 line_children, waiting_children, waiting_floats,
                 absolute_boxes, fixed_boxes, line_placeholders, float_widths,
                 max_x, position_x, bottom_space)
+            if isinstance(box, boxes.LineBox):
+                position_x, max_x = new_position_x, new_max_x
             if child.is_floated():
                 float_resume_index = index + 1
-                if child not in waiting_floats:
+                if child not in waiting_floats and not isinstance(box, boxes.LineBox):
                     max_x -= child.margin_width()
             continue
 

--- a/weasyprint/layout/inline.py
+++ b/weasyprint/layout/inline.py
@@ -139,6 +139,12 @@ def get_next_linebox(context, linebox, position_y, bottom_space, skip_stack,
         # Removing this line breaks the position == linebox.position test below
         # See issue #583.
         line.position_y = position_y
+        if clear_gap := initial_letter_clear_gap(line):
+            line.height += clear_gap
+            line.baseline += clear_gap
+            for child in line.children:
+                if child.is_in_normal_flow():
+                    child.translate(dy=clear_gap)
 
         if line.height <= candidate_height:
             break
@@ -291,6 +297,36 @@ def remove_last_whitespace(context, line):
     # 'white-space' set to 'pre-wrap', UAs may visually collapse them.
 
 
+def apply_initial_letter(box, letter_style):
+    """Apply simple dropped-initial sizing to a ``::first-letter`` style."""
+    initial_letter = letter_style['initial_letter']
+    if initial_letter == 'normal':
+        return
+
+    size, sink = initial_letter
+    line_height, _ = strut(box.style)
+    parent_cap_height = box.style['font_size'] * character_ratio(box.style, 'cap')
+    letter_cap_ratio = character_ratio(letter_style, 'cap')
+    letter_font_size = (
+        ((size - 1) * line_height + parent_cap_height) / letter_cap_ratio)
+    letter_style['font_size'] = letter_font_size
+    letter_style['line_height'] = ('PIXELS', letter_font_size)
+    letter_style['__initial_letter_clear_gap'] = (
+        max(size - sink, 0) * line_height)
+    if letter_style['float'] == 'none':
+        letter_style['float'] = (
+            'right' if box.style['direction'] == 'rtl' else 'left')
+
+
+def initial_letter_clear_gap(line):
+    """Return the gap before first-line contents for raised initial letters."""
+    return max(
+        (
+            child.style.get('__initial_letter_clear_gap', 0)
+            for child in line.children if child.is_floated()),
+        default=0)
+
+
 def first_letter_to_box(box, skip_stack, first_letter_style):
     """Create a box for the ::first-letter selector."""
     if first_letter_style and box.children:
@@ -305,6 +341,7 @@ def first_letter_to_box(box, skip_stack, first_letter_style):
             letter_style = box.style.copy()
             for key, value in first_letter_style.items():
                 letter_style[key] = value
+            apply_initial_letter(box, letter_style)
             if child.element_tag.endswith('::first-letter'):
                 letter_box = boxes.InlineBox(
                     f'{box.element_tag}::first-letter', letter_style,

--- a/weasyprint/layout/inline.py
+++ b/weasyprint/layout/inline.py
@@ -313,6 +313,8 @@ def apply_initial_letter(box, letter_style):
     letter_style['line_height'] = ('PIXELS', letter_font_size)
     letter_style['__initial_letter_clear_gap'] = (
         max(size - sink, 0) * line_height)
+    letter_style['__initial_letter_sink_gap'] = (
+        max(sink - size, 0) * line_height)
     if letter_style['float'] == 'none':
         letter_style['float'] = (
             'right' if box.style['direction'] == 'rtl' else 'left')
@@ -609,6 +611,8 @@ def _out_of_flow_layout(context, box, containing_block, index, child,
             fixed_boxes.append(placeholder)
 
     elif child.is_floated():
+        if child.style.get('__initial_letter_sink_gap', 0):
+            child = child.copy()
         child.position_x = position_x
         float_width = shrink_to_fit(context, child, containing_block.width)
 


### PR DESCRIPTION
Draft PR stacked on #2752, which is itself stacked on #2751.

Refs #2486.

This extends the initial `initial-letter` implementation with support for sink values larger than the initial-letter size, such as the MDN example `initial-letter: 3 4`.

Because this branch depends on #2752, the diff includes the earlier `initial-letter` implementation until that PR lands. The additional change in this branch is commit 39811e171d30be7eb4e440099bd155940ed7fcd1.

## What changed

- Track an internal initial-letter sink gap when the sink value is larger than the visual size.
- Apply that gap as an internal top margin when laying out the generated first-letter float.
- Copy the float before applying the internal adjustment so the original inline child is not mutated across layout retries.
- Keep the exclusion area starting at the first line while the glyph itself is shifted downward, matching the behavior used by browser implementations for `size < sink`.
- Add a regression test for `initial-letter: 3 4`.

## Prior art / source behavior

The implementation follows the same broad behavior as Blink’s `ComputeInitialLetterBoxBlockOffset` / `CreateExclusionSpaceForInitialLetterBox` logic: when `size < sink`, the initial-letter box is positioned lower, but the exclusion space still starts at the original line block offset and extends down to the sink depth.

Relevant sources:

- Blink initial-letter layout: https://chromium.googlesource.com/chromium/src/+/main/third_party/blink/renderer/core/layout/inline/initial_letter_utils.cc
- CSS Inline Layout block positioning: https://drafts.csswg.org/css-inline/#initial-letter-block-position
- MDN sink-value example range: https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/initial-letter

## Visual proof

Generated from this branch and uploaded as local PNG/PDF artifacts:

<img width="839" height="1191" alt="initial-letter-3-4" src="https://github.com/user-attachments/assets/0124e77d-34b2-411a-8176-2d0e78a2253b" />

- [`initial-letter: 3 4` PDF](https://github.com/user-attachments/files/26981175/initial-letter-3-4.pdf)

## Scope and known gaps

This only handles the `sink > size` case for the existing `::first-letter`-based implementation. It does not add support for first inline-level child applicability, `initial-letter-align`, `initial-letter-wrap`, vertical writing modes, RTL improvements, or fragmentation behavior.

## Checks

- `venv/bin/python -m pytest tests/css/test_validation.py tests/layout/test_float.py tests/test_text.py -q`
- `venv/bin/python -m ruff check weasyprint/layout/inline.py weasyprint/layout/float.py tests/layout/test_float.py`
