### PR TITLE
Fix SVG text chunk shaping

### DIFF
--- a/tests/draw/svg/test_text.py
+++ b/tests/draw/svg/test_text.py
@@ -22,6 +22,49 @@ def test_text_fill(assert_pixels):
 
 
 @assert_no_logs
+def test_text_combining_character(assert_same_renderings):
+    assert_same_renderings('''
+      <style>
+        @page { size: 20px 20px }
+        svg { display: block }
+      </style>
+      <svg width="20px" height="20px" xmlns="http://www.w3.org/2000/svg">
+        <text x="0" y="15" font-family="weasyprint" font-size="16" fill="blue">
+          é
+        </text>
+      </svg>
+    ''', '''
+      <style>
+        @page { size: 20px 20px }
+        svg { display: block }
+      </style>
+      <svg width="20px" height="20px" xmlns="http://www.w3.org/2000/svg">
+        <text x="0" y="15" font-family="weasyprint" font-size="16" fill="blue">
+          é
+        </text>
+      </svg>
+    ''')
+
+
+@assert_no_logs
+def test_text_ligature(assert_pixels):
+    assert_pixels('''
+        BBB_________________
+        BBB_________________
+    ''', '''
+      <style>
+        @page { size: 20px 2px }
+        svg { display: block }
+      </style>
+      <svg width="20px" height="2px" xmlns="http://www.w3.org/2000/svg">
+        <text x="0" y="1.5" font-family="weasyprint" font-size="2" fill="blue">
+          liga
+        </text>
+      </svg>
+    ''')
+
+
+@assert_no_logs
 def test_text_stroke(assert_pixels):
     assert_pixels('''
         _BBBBBBBBBBBB_______

--- a/weasyprint/svg/text.py
+++ b/weasyprint/svg/text.py
@@ -22,6 +22,11 @@ class Style(dict):
     """Dummy class to store dict."""
 
 
+def is_positioned(positions):
+    """Return whether a list of positions includes per-character values."""
+    return any(len(position) > 1 for position in positions)
+
+
 def text(svg, node, font_size):
     """Draw text node."""
     from ..css.properties import INITIAL_VALUES
@@ -48,7 +53,7 @@ def text(svg, node, font_size):
         except ValueError:
             style['font_weight'] = 400
 
-    layout, _, _, width, height, _ = split_first_line(
+    layout, _, _, width, height, baseline = split_first_line(
         node.text, style, svg.context, inf, 0)
 
     # Get rotations and translations
@@ -69,9 +74,6 @@ def text(svg, node, font_size):
         rotate = [radians(float(i)) if i else 0
                   for i in normalize(node.attrib['rotate']).strip().split(' ')]
     last_r = rotate[-1]
-    letters_positions = [
-        ([pl.pop(0) if pl else None for pl in (x, y, dx, dy, rotate)], char)
-        for char in node.text]
 
     letter_spacing = svg.length(node.get('letter-spacing'), font_size)
     text_length = svg.length(node.get('textLength'), font_size)
@@ -133,20 +135,18 @@ def text(svg, node, font_size):
     svg.stream.begin_text()
     emoji_lines = []
 
-    # Draw letters
-    for i, ((x, y, dx, dy, r), letter) in enumerate(letters_positions):
-        if x:
+    def draw_text(layout, width, height, baseline, position, spacing=False):
+        x, y, dx, dy, r = position
+        if x is not None:
             svg.cursor_d_position[0] = 0
-        if y:
+        if y is not None:
             svg.cursor_d_position[1] = 0
         svg.cursor_d_position[0] += dx or 0
         svg.cursor_d_position[1] += dy or 0
-        layout, _, _, width, height, baseline = split_first_line(
-            letter, style, svg.context, inf, 0)
         x = svg.cursor_position[0] if x is None else x
         y = svg.cursor_position[1] if y is None else y
         width *= scale_x
-        if i:
+        if spacing:
             x += letter_spacing
         svg.cursor_position = x + width, y
 
@@ -169,6 +169,23 @@ def text(svg, node, font_size):
         emojis = draw_first_line(
             svg.stream, TextBox(layout, style), 'none', 'none', matrix)
         emoji_lines.append((x, y, emojis))
+
+    if not (is_positioned((x, y, dx, dy, rotate)) or letter_spacing or text_length):
+        position = [
+            positions[0] if positions else None
+            for positions in (x, y, dx, dy, rotate)]
+        draw_text(layout, width, height, baseline, position)
+    else:
+        letters_positions = [
+            ([pl.pop(0) if pl else None for pl in (x, y, dx, dy, rotate)], char)
+            for char in node.text]
+
+        # Draw letters
+        for i, (position, letter) in enumerate(letters_positions):
+            layout, _, _, width, height, baseline = split_first_line(
+                letter, style, svg.context, inf, 0)
+            draw_text(
+                layout, width, height, baseline, position, spacing=bool(i))
 
     svg.stream.end_text()
     svg.stream.pop_state()


### PR DESCRIPTION
## What changed

SVG text nodes now keep simple text chunks shaped as a whole instead of drawing them code point by code point. This lets Pango keep combining marks and ligatures together in the common case where there are no per-character `x`, `y`, `dx`, `dy`, `rotate`, `letter-spacing`, or `textLength` adjustments.

The existing per-character path is still used when SVG positioning or spacing attributes require manual placement.

Fixes https://github.com/Kozea/WeasyPrint/issues/2249.

## Why

The old SVG text drawing path split text before shaping, so sequences such as `e` + U+0301 COMBINING ACUTE ACCENT and font ligatures could be separated before Pango got a chance to shape the text run. SVG 2 also describes special handling for cases where characters and glyphs are not one-to-one, including combining marks and ligatures:

https://svgwg.org/svg2-draft/text.html#TSpanNotes

This patch takes the small, conservative path suggested by the issue: shape and draw the whole text when there are no glyph-specific positioning attributes.

## Visual proof

SVG source proof:

![svg-text-shaping-proof-v3.svg](https://github.com/user-attachments/assets/376cd952-43da-46b4-8eb4-e89ae9f5ba61)

Rendered PNG:

![svg-text-shaping-proof-v3.png](https://github.com/user-attachments/assets/1b74418d-7acb-40bb-8d81-e19a40dd30d1)

## Scope

This does not implement the full SVG 2 mapping between addressable characters and shaped glyph clusters for positioned text. RTL and bidi support for positioned SVG text also remain separate work.

## Tests

```console
venv/bin/python -m pytest tests/draw/svg/test_text.py -q
venv/bin/python -m pytest tests/draw/svg -q
venv/bin/python -m ruff check weasyprint/svg/text.py tests/draw/svg/test_text.py
```
