### PR TITLE
Support simple SVG unicode-bidi text

### DIFF
--- a/tests/draw/svg/test_text.py
+++ b/tests/draw/svg/test_text.py
@@ -334,6 +334,27 @@ def test_text_direction_rtl_anchor_end(assert_pixels):
 
 
 @assert_no_logs
+def test_text_unicode_bidi_override(assert_pixels):
+    assert_pixels('''
+        BBBBBBBBBB__________
+        BBBBBBBBBB__________
+        BBBBBBBBBB__________
+        BBBBBBBBBB__________
+    ''', '''
+      <style>
+        @page { size: 20px 4px }
+        svg { display: block }
+      </style>
+      <svg width="20px" height="4px" xmlns="http://www.w3.org/2000/svg">
+        <text x="10" y="3" font-family="weasyprint" font-size="4"
+              fill="blue" direction="rtl" unicode-bidi="bidi-override">
+          liga
+        </text>
+      </svg>
+    ''')
+
+
+@assert_no_logs
 def test_text_tspan(assert_pixels):
     assert_pixels('''
         BBBBBB__BBBBBB______

--- a/tests/draw/svg/test_text.py
+++ b/tests/draw/svg/test_text.py
@@ -295,6 +295,45 @@ def test_text_anchor_end(assert_pixels):
 
 
 @assert_no_logs
+def test_text_direction_rtl_anchor_start(assert_pixels):
+    assert_pixels('''
+        ____________BBBBBB__
+        ____________BBBBBB__
+    ''', '''
+      <style>
+        @page { size: 20px 2px }
+        svg { display: block }
+      </style>
+      <svg width="20px" height="2px" direction="rtl"
+           xmlns="http://www.w3.org/2000/svg">
+        <text x="18" y="1.5" font-family="weasyprint" font-size="2"
+              fill="blue">
+          ABC
+        </text>
+      </svg>
+    ''')
+
+
+@assert_no_logs
+def test_text_direction_rtl_anchor_end(assert_pixels):
+    assert_pixels('''
+        __BBBBBB____________
+        __BBBBBB____________
+    ''', '''
+      <style>
+        @page { size: 20px 2px }
+        svg { display: block }
+      </style>
+      <svg width="20px" height="2px" xmlns="http://www.w3.org/2000/svg">
+        <text x="2" y="1.5" font-family="weasyprint" font-size="2"
+              fill="blue" direction="rtl" text-anchor="end">
+          ABC
+        </text>
+      </svg>
+    ''')
+
+
+@assert_no_logs
 def test_text_tspan(assert_pixels):
     assert_pixels('''
         BBBBBB__BBBBBB______

--- a/tests/draw/svg/test_text.py
+++ b/tests/draw/svg/test_text.py
@@ -22,6 +22,49 @@ def test_text_fill(assert_pixels):
 
 
 @assert_no_logs
+def test_text_combining_character(assert_same_renderings):
+    assert_same_renderings('''
+      <style>
+        @page { size: 20px 20px }
+        svg { display: block }
+      </style>
+      <svg width="20px" height="20px" xmlns="http://www.w3.org/2000/svg">
+        <text x="0" y="15" font-family="weasyprint" font-size="16" fill="blue">
+          é
+        </text>
+      </svg>
+    ''', '''
+      <style>
+        @page { size: 20px 20px }
+        svg { display: block }
+      </style>
+      <svg width="20px" height="20px" xmlns="http://www.w3.org/2000/svg">
+        <text x="0" y="15" font-family="weasyprint" font-size="16" fill="blue">
+          é
+        </text>
+      </svg>
+    ''')
+
+
+@assert_no_logs
+def test_text_ligature(assert_pixels):
+    assert_pixels('''
+        BBB_________________
+        BBB_________________
+    ''', '''
+      <style>
+        @page { size: 20px 2px }
+        svg { display: block }
+      </style>
+      <svg width="20px" height="2px" xmlns="http://www.w3.org/2000/svg">
+        <text x="0" y="1.5" font-family="weasyprint" font-size="2" fill="blue">
+          liga
+        </text>
+      </svg>
+    ''')
+
+
+@assert_no_logs
 def test_text_stroke(assert_pixels):
     assert_pixels('''
         _BBBBBBBBBBBB_______

--- a/weasyprint/svg/__init__.py
+++ b/weasyprint/svg/__init__.py
@@ -489,7 +489,11 @@ class SVG:
         # Handle text anchor and set text bounding box
         text_anchor_shift = False
         if node.display and TAGS.get(node.tag) == text:
-            if (text_anchor := node.get('text-anchor')) in ('middle', 'end'):
+            text_anchor = node.get('text-anchor')
+            direction = node.get('direction', 'ltr')
+            if (text_anchor == 'middle' or
+                    (text_anchor == 'end' and direction != 'rtl') or
+                    (text_anchor in (None, 'start') and direction == 'rtl')):
                 text_anchor_shift = True
                 group = self.stream.add_group(0, 0, 0, 0)  # BBox set after drawing
                 original_streams.append(self.stream)

--- a/weasyprint/svg/text.py
+++ b/weasyprint/svg/text.py
@@ -22,6 +22,11 @@ class Style(dict):
     """Dummy class to store dict."""
 
 
+def is_positioned(positions):
+    """Return whether a list of positions includes per-character values."""
+    return any(len(position) > 1 for position in positions)
+
+
 def text(svg, node, font_size):
     """Draw text node."""
     from ..css.properties import INITIAL_VALUES
@@ -48,7 +53,7 @@ def text(svg, node, font_size):
         except ValueError:
             style['font_weight'] = 400
 
-    layout, _, _, width, height, _ = split_first_line(
+    layout, _, _, width, height, baseline = split_first_line(
         node.text, style, svg.context, inf, 0)
 
     # Get rotations and translations
@@ -69,9 +74,6 @@ def text(svg, node, font_size):
         rotate = [radians(float(i)) if i else 0
                   for i in normalize(node.attrib['rotate']).strip().split(' ')]
     last_r = rotate[-1]
-    letters_positions = [
-        ([pl.pop(0) if pl else None for pl in (x, y, dx, dy, rotate)], char)
-        for char in node.text]
 
     letter_spacing = svg.length(node.get('letter-spacing'), font_size)
     text_length = svg.length(node.get('textLength'), font_size)
@@ -133,20 +135,18 @@ def text(svg, node, font_size):
     svg.stream.begin_text()
     emoji_lines = []
 
-    # Draw letters
-    for i, ((x, y, dx, dy, r), letter) in enumerate(letters_positions):
-        if x:
+    def draw_text(layout, width, height, baseline, position, spacing=False):
+        x, y, dx, dy, r = position
+        if x is not None:
             svg.cursor_d_position[0] = 0
-        if y:
+        if y is not None:
             svg.cursor_d_position[1] = 0
         svg.cursor_d_position[0] += dx or 0
         svg.cursor_d_position[1] += dy or 0
-        layout, _, _, width, height, baseline = split_first_line(
-            letter, style, svg.context, inf, 0)
         x = svg.cursor_position[0] if x is None else x
         y = svg.cursor_position[1] if y is None else y
         width *= scale_x
-        if i:
+        if spacing:
             x += letter_spacing
         svg.cursor_position = x + width, y
 
@@ -169,6 +169,23 @@ def text(svg, node, font_size):
         emojis = draw_first_line(
             svg.stream, TextBox(layout, style), 'none', 'none', matrix)
         emoji_lines.append((x, y, emojis))
+
+    if not (is_positioned((x, y, dx, dy, rotate)) or letter_spacing or text_length):
+        position = [
+            positions[0] if positions else None
+            for positions in (x, y, dx, dy, rotate)]
+        draw_text(layout, width, height, baseline, position)
+    else:
+        letters_positions = [
+            ([pl.pop(0) if pl else None for pl in (x, y, dx, dy, rotate)], char)
+            for char in node.text]
+
+        # Draw letters
+        for i, (position, letter) in enumerate(letters_positions):
+            layout, _, _, width, height, baseline = split_first_line(
+                letter, style, svg.context, inf, 0)
+            draw_text(
+                layout, width, height, baseline, position, spacing=bool(i))
 
     svg.stream.end_text()
     svg.stream.pop_state()

--- a/weasyprint/svg/text.py
+++ b/weasyprint/svg/text.py
@@ -27,6 +27,31 @@ def is_positioned(positions):
     return any(len(position) > 1 for position in positions)
 
 
+def apply_unicode_bidi(text, direction, unicode_bidi):
+    """Add Unicode bidi controls matching CSS unicode-bidi."""
+    if not text:
+        return text
+    direction = 'rtl' if direction == 'rtl' else 'ltr'
+    unicode_bidi = (unicode_bidi or 'normal').strip()
+    if unicode_bidi == 'normal':
+        return text
+
+    controls = {
+        ('embed', 'ltr'): ('\u202a', '\u202c'),
+        ('embed', 'rtl'): ('\u202b', '\u202c'),
+        ('isolate', 'ltr'): ('\u2066', '\u2069'),
+        ('isolate', 'rtl'): ('\u2067', '\u2069'),
+        ('bidi-override', 'ltr'): ('\u202d', '\u202c'),
+        ('bidi-override', 'rtl'): ('\u202e', '\u202c'),
+        ('isolate-override', 'ltr'): ('\u2068\u202d', '\u202c\u2069'),
+        ('isolate-override', 'rtl'): ('\u2068\u202e', '\u202c\u2069'),
+        ('plaintext', 'ltr'): ('\u2068', '\u2069'),
+        ('plaintext', 'rtl'): ('\u2068', '\u2069'),
+    }
+    start, end = controls.get((unicode_bidi, direction), ('', ''))
+    return f'{start}{text}{end}'
+
+
 def text(svg, node, font_size):
     """Draw text node."""
     from ..css.properties import INITIAL_VALUES
@@ -55,9 +80,6 @@ def text(svg, node, font_size):
         except ValueError:
             style['font_weight'] = 400
 
-    layout, _, _, width, height, baseline = split_first_line(
-        node.text, style, svg.context, inf, 0)
-
     # Get rotations and translations
     x, y, dx, dy, rotate = [], [], [], [], [0]
     if 'x' in node.attrib:
@@ -77,8 +99,25 @@ def text(svg, node, font_size):
                   for i in normalize(node.attrib['rotate']).strip().split(' ')]
     last_r = rotate[-1]
 
+    # Return early when there’s no text
+    if not node.text:
+        x = x[0] if x else svg.cursor_position[0]
+        y = y[0] if y else svg.cursor_position[1]
+        dx = dx[0] if dx else 0
+        dy = dy[0] if dy else 0
+        svg.cursor_position = (x + dx, y + dy)
+        return
+
     letter_spacing = svg.length(node.get('letter-spacing'), font_size)
     text_length = svg.length(node.get('textLength'), font_size)
+    use_unicode_bidi = not (
+        is_positioned((x, y, dx, dy, rotate)) or letter_spacing or text_length)
+    text = (
+        apply_unicode_bidi(node.text, style['direction'], node.get('unicode-bidi'))
+        if use_unicode_bidi else node.text)
+    layout, _, _, width, height, baseline = split_first_line(
+        text, style, svg.context, inf, 0)
+
     scale_x = 1
     if text_length and node.text:
         # calculate the number of spaces to be considered for the text
@@ -122,15 +161,6 @@ def text(svg, node, font_size):
     elif alignment_baseline in (
             'text-after-edge', 'after_edge', 'bottom', 'text-bottom'):
         y_align = -descent
-
-    # Return early when there’s no text
-    if not node.text:
-        x = x[0] if x else svg.cursor_position[0]
-        y = y[0] if y else svg.cursor_position[1]
-        dx = dx[0] if dx else 0
-        dy = dy[0] if dy else 0
-        svg.cursor_position = (x + dx, y + dy)
-        return
 
     svg.stream.push_state()
     svg.set_graphical_state(node, font_size, text=True)

--- a/weasyprint/svg/text.py
+++ b/weasyprint/svg/text.py
@@ -43,6 +43,8 @@ def text(svg, node, font_size):
     style['font_style'] = node.get('font-style', 'normal')
     style['font_weight'] = node.get('font-weight', 400)
     style['font_size'] = font_size
+    if node.get('direction') in ('ltr', 'rtl'):
+        style['direction'] = node.get('direction')
     if style['font_weight'] == 'normal':
         style['font_weight'] = 400
     elif style['font_weight'] == 'bold':


### PR DESCRIPTION
## What changed

SVG text now applies simple `unicode-bidi` values by translating them to the Unicode bidi controls Pango already understands before shaping whole text chunks.

Supported values in this simple path are `embed`, `isolate`, `bidi-override`, `isolate-override`, and `plaintext`.

This is stacked on #2755, and only the last commit is new here.

## Why

CSS Writing Modes defines `unicode-bidi` values as effectively inserting matching Unicode bidi control codes into the text stream before bidi reordering:

https://drafts.csswg.org/css-writing-modes-3/#unicode-bidi

Before this patch, SVG `unicode-bidi="bidi-override"` was cascaded as an attribute but ignored when WeasyPrint built the SVG text layout.

## Visual proof

Source SVG:

![svg-unicode-bidi-proof.svg](https://github.com/user-attachments/assets/ca2c070d-258f-4912-ad19-faf4906d92fe)

Rendered PNG:

![svg-unicode-bidi-proof.png](https://github.com/user-attachments/assets/8670e14f-9797-4755-8a39-ebf6e5ab6343)

The HTML wrapper used to render the proof is:

```html
<!doctype html>
<meta charset="utf-8">
<style>
  @page {
    size: 1160px 620px;
    margin: 0;
  }
  html,
  body {
    margin: 0;
  }
  img {
    display: block;
    width: 1160px;
    height: 620px;
  }
</style>
<img src="svg-unicode-bidi-proof.svg" alt="">
```

## Scope

This deliberately applies only to simple whole-text chunks. It does not implement full SVG 2 mapping of per-character `x`, `y`, `dx`, `dy`, and `rotate` lists onto shaped visual glyph clusters after bidi reordering.

## Tests

```console
venv/bin/python -m pytest tests/draw/svg/test_text.py -q
venv/bin/python -m pytest tests/draw/svg -q
venv/bin/python -m ruff check weasyprint/svg/text.py tests/draw/svg/test_text.py
```
