### PR TITLE
Document bundled sRGB ICC profile attribution

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -27,3 +27,19 @@ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+Bundled ICC profile
+-------------------
+
+WeasyPrint includes the International Color Consortium sRGB2014.icc profile in
+weasyprint/pdf/sRGB2014.icc. Its original source is:
+
+https://www.color.org/srgbprofiles.xalter
+
+Copyright International Color Consortium, 2015
+
+This profile is made available by the International Color Consortium, and may be
+copied, distributed, embedded, made, used, and sold without restriction. Altered
+versions of this profile shall have the original identification and copyright
+information removed and shall not be misrepresented as the original profile.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -616,7 +616,12 @@ def test_partial_pdf_custom_metadata():
 @assert_no_logs
 def test_pdf_srgb():
     stdout = _run('--srgb --uncompressed-pdf - -', b'test')
-    assert b'sRGB' in stdout
+    assert b'/OutputIntents' in stdout
+    assert b'/S /GTS_PDFA1' in stdout
+    assert b'/OutputConditionIdentifier (sRGB IEC61966-2.1)' in stdout
+    assert b'/DestOutputProfile' in stdout
+    assert b'/N 3' in stdout
+    assert b'/Alternate /DeviceRGB' in stdout
 
 
 @assert_no_logs


### PR DESCRIPTION
Closes #2758.

## What changed

- Add source, copyright, and reuse terms for the bundled `sRGB2014.icc` profile to `LICENSE`.
- Strengthen `test_pdf_srgb` to check the generated PDF output intent dictionary fields instead of only looking for the `sRGB` string.

## Why

The bundled ICC profile is redistributable and appropriate for the existing sRGB/PDF-A output intent behavior, but its attribution and reuse terms should be visible in the repository license text.

## Checks

- `python -m pytest tests/test_api.py::test_pdf_srgb tests/test_api.py::test_pdf_no_srgb -q`
- `python -m ruff check tests/test_api.py`
