### PR TITLE
block: tolerate non-dict first_letter_style/first_line_style

### DIFF
--- a/weasyprint/layout/block.py
+++ b/weasyprint/layout/block.py
@@ -708,7 +708,7 @@ def block_container_layout(context, box, bottom_space, skip_stack, page_is_empty
     if box.first_line_style is not None:
         box_first_line_style = {
             key: box.first_line_style[key] for key in box.first_line_style.cascaded}
-        if first_line_style is None:
+        if not isinstance(first_line_style, dict):
             first_line_style = box_first_line_style
         else:
             first_line_style |= box_first_line_style
@@ -716,7 +716,7 @@ def block_container_layout(context, box, bottom_space, skip_stack, page_is_empty
     if box.first_letter_style is not None:
         box_first_letter_style = {
             key: box.first_letter_style[key] for key in box.first_letter_style.cascaded}
-        if first_letter_style is None:
+        if not isinstance(first_letter_style, dict):
             first_letter_style = box_first_letter_style
         else:
             first_letter_style |= box_first_letter_style


### PR DESCRIPTION
Closes #2717. `|=` raises `TypeError` if a caller passes a bool; treat anything non-dict as no inherited style.