### PR TITLE
Preserve replaced box height on relayout

### DIFF
--- a/tests/layout/test_image.py
+++ b/tests/layout/test_image.py
@@ -3,6 +3,7 @@
 import pytest
 
 from weasyprint.formatting_structure import boxes
+from weasyprint.layout.percent import resolve_percentages
 
 from ..testing_utils import assert_no_logs, capture_logs, render_pages
 
@@ -289,6 +290,25 @@ def test_images_16():
     assert img.element_tag == 'img'
     assert img.width == 300
     assert img.height == 200
+
+
+@assert_no_logs
+def test_images_auto_height_block_replaced_relayout():
+    page, = render_pages('''
+        <style>
+            @page { size: 100px }
+            img { display: block; width: 40px }
+        </style>
+        <body>
+            <img src="pattern.png">
+    ''')
+    html, = page.children
+    body, = html.children
+    img, = body.children
+    assert isinstance(img, boxes.BlockReplacedBox)
+    assert img.height == 40
+    resolve_percentages(img, (100, 'auto'))
+    assert img.margin_height() == 40
 
 
 @assert_no_logs

--- a/weasyprint/layout/percent.py
+++ b/weasyprint/layout/percent.py
@@ -79,7 +79,14 @@ def resolve_percentages(box, containing_block):
         # depends on its content.
         height = box.style['height']
         if height == 'auto' or check_math(height) or height.unit == '%':
-            box.height = 'auto'
+            computed_height = getattr(box, 'height', 'auto')
+            # Keep the height computed by replaced box layout when a block
+            # replaced box is laid out again.
+            if not (
+                    isinstance(box, boxes.BlockReplacedBox) and
+                    computed_height != 'auto' and
+                    not isinstance(computed_height, str)):
+                box.height = 'auto'
         else:
             assert height.unit.lower() == 'px'
             box.height = height.value


### PR DESCRIPTION
## What changed

`resolve_percentages` now preserves an already computed numeric height for block replaced boxes when the containing block height is `auto`.

This prevents a relayout pass from changing a floated replaced box, such as an image, back to `height = 'auto'` after replaced-box layout has computed its used height.

## Why

In documents with floated images and page remakes, a block replaced box can be laid out again after its height has already been resolved from its intrinsic ratio. Resetting that height to the string `auto` can leave the box in float exclusion data with a non-numeric height. Later calls to `margin_height()` then try to add that string to numeric padding or border values and raise a `TypeError`.

## Tests

- `python -m pytest tests/layout/test_image.py::test_images_auto_height_block_replaced_relayout -q`
- `python -m pytest tests/layout/test_image.py tests/layout/test_float.py -q`
- `python -m ruff check weasyprint/layout/percent.py tests/layout/test_image.py`

## Background

I hit this when trying to format a book I use Weasyprint with (hambook.org) for a kindle sized screen. Due to time constraints, the fix, repro case, and PR were all figured out by various AI tools, but as best I can tell it seems reasonable. Could be you know a better fix, but at least the test I think shows the failure; I can upload another repro case if needed.
