### PR TITLE
Never try to render SVG use tags with external sources

### DIFF
--- a/weasyprint/svg/defs.py
+++ b/weasyprint/svg/defs.py
@@ -9,15 +9,11 @@ from .utils import alpha_value, color, parse_url, size, transform
 
 
 def get_use_tree(svg, node, font_size):
-    from . import SVG
-
     parsed_url = parse_url(node.get_href(svg.url))
     svg_url = parse_url(svg.url)
     if svg_url.scheme == 'data':
         svg_url = parse_url('')
-    same_origin = (
-        parsed_url[:3] == ('', '', '') or
-        parsed_url[:3] == svg_url[:3])
+    same_origin = parsed_url[:3] in (('', '', ''), svg_url[:3])
     if parsed_url.fragment and same_origin:
         if parsed_url.fragment in svg.use_cache:
             tree = svg.use_cache[parsed_url.fragment].copy()
@@ -28,18 +24,7 @@ def get_use_tree(svg, node, font_size):
                 return
             else:
                 svg.use_cache[parsed_url.fragment] = tree
-    else:
-        url = parsed_url.geturl()
-        try:
-            bytestring_svg = svg.url_fetcher(url)
-            use_svg = SVG(bytestring_svg, url)
-        except Exception:
-            return
-        else:
-            use_svg.get_intrinsic_size(font_size)
-            tree = use_svg.tree
-
-    return tree
+        return tree
 
 
 def use(svg, node, font_size):


### PR DESCRIPTION
This code was never tested and didn’t work at least since #2627. For most cases, it doesn’t work in browsers because of cross-origin checks. We can assume that nobody ever used that feature.