### PR TITLE
Use stroked dashes for uniform dotted and dashed borders

### DIFF
--- a/weasyprint/draw/border.py
+++ b/weasyprint/draw/border.py
@@ -98,16 +98,16 @@ def draw_border(stream, box):
             draw_rounded_border(stream, box, styles[0], colors[0])
         return
 
-    # Dotted fast path: uniform dotted border with no rounded corners. We
-    # stroke a single rectangle with round caps and a zero-length dash
-    # pattern, which is orders of magnitude smaller in the PDF than the
-    # generic per-dot Bézier clip path.
+    # Dotted/dashed fast path: uniform border with no rounded corners. We
+    # stroke one line per side using PDF dash arrays, which is orders of
+    # magnitude smaller in the PDF than the generic per-segment clip path.
     radii = box.rounded_border_box()[4:]
     no_radii = all(rx == 0 and ry == 0 for rx, ry in radii)
-    if (set(styles) == {'dotted'} and single_color and four_sides
-            and len(set(widths)) == 1 and no_radii):
+    if (set(styles) in ({'dotted'}, {'dashed'}) and single_color
+            and four_sides and len(set(widths)) == 1 and no_radii):
         with stream.artifact():
-            draw_dotted_rect_border(stream, box, widths[0], colors[0])
+            draw_dotted_dashed_rect_border(
+                stream, box, styles[0], widths[0], colors[0])
         return
 
     # We're not smart enough to find a good way to draw the borders, we must
@@ -611,37 +611,49 @@ def draw_rect_border(stream, box, widths, style, color):
     stream.fill(even_odd=True)
 
 
-def draw_dotted_rect_border(stream, box, width, color):
-    """Fast path: uniform dotted border with no rounded corners.
+def draw_dotted_dashed_rect_border(stream, box, style, width, color):
+    """Fast path: uniform dotted or dashed border with no rounded corners.
 
-    A round line cap turns a zero-length dash into a filled circle, so one
-    stroked line per side replaces hundreds of per-dot Bézier curves. Each
-    side picks its own dash period so dots land exactly on both corners,
+    Dotted uses a round line cap with a zero-length dash, so each "on"
+    position becomes a filled circle. Dashed uses a butt cap with equal
+    dash/gap, so each "on" segment becomes a flush rectangle. Either way,
+    one stroked line per side replaces hundreds of per-segment paths. Each
+    side picks its own dash period so dots/dashes land on both corners,
     matching the per-side spacing of the generic path.
 
     """
     bbx, bby, bbw, bbh = box.rounded_border_box()[:4]
     half = width / 2
-    x0, y0 = bbx + half, bby + half
-    x1, y1 = bbx + bbw - half, bby + bbh - half
+    # Round caps extend the line by half on each end, so dotted endpoints
+    # must be inset to keep dots centered on the corners. Butt caps don't
+    # extend, so dashed runs flush from corner to corner.
+    inset = half if style == 'dotted' else 0
 
-    def period(outer_length):
-        # Match the per-side spacing of the generic path: dot count chosen
-        # from the outer side length, dots distributed between the two
-        # half-width-inset endpoints.
-        n_dots = max(2, int(outer_length // (2 * width)) + 1)
-        return (outer_length - width) / (n_dots - 1)
+    def dash(outer_length):
+        if style == 'dotted':
+            # Dot at each corner with equal spacing in between.
+            n = max(2, int(outer_length // (2 * width)) + 1)
+            return [0, (outer_length - width) / (n - 1)]
+        # Target dash size = 3 * width; equal dash/gap so an integer count
+        # fits flush between the two corners.
+        n = int(outer_length // (6 * width)) + 1
+        d = outer_length / (2 * n - 1)
+        return [d, d]
 
     with stream.stacked():
         stream.set_color(color, stroke=True)
         stream.set_line_width(width)
-        stream.set_line_cap(1)
+        stream.set_line_cap(1 if style == 'dotted' else 0)
         for x_a, y_a, x_b, y_b, outer_length in (
-                (x0, y0, x1, y0, bbw),  # top
-                (x1, y0, x1, y1, bbh),  # right
-                (x0, y1, x1, y1, bbw),  # bottom
-                (x0, y0, x0, y1, bbh)):  # left
-            stream.set_dash([0, period(outer_length)], 0)
+                (bbx + inset, bby + half,
+                 bbx + bbw - inset, bby + half, bbw),  # top
+                (bbx + bbw - half, bby + inset,
+                 bbx + bbw - half, bby + bbh - inset, bbh),  # right
+                (bbx + inset, bby + bbh - half,
+                 bbx + bbw - inset, bby + bbh - half, bbw),  # bottom
+                (bbx + half, bby + inset,
+                 bbx + half, bby + bbh - inset, bbh)):  # left
+            stream.set_dash(dash(outer_length), 0)
             stream.move_to(x_a, y_a)
             stream.line_to(x_b, y_b)
             stream.stroke()

--- a/weasyprint/draw/border.py
+++ b/weasyprint/draw/border.py
@@ -615,19 +615,36 @@ def draw_dotted_rect_border(stream, box, width, color):
     """Fast path: uniform dotted border with no rounded corners.
 
     A round line cap turns a zero-length dash into a filled circle, so one
-    stroked rectangle replaces hundreds of per-dot Bézier curves.
+    stroked line per side replaces hundreds of per-dot Bézier curves. Each
+    side picks its own dash period so dots land exactly on both corners,
+    matching the per-side spacing of the generic path.
 
     """
     bbx, bby, bbw, bbh = box.rounded_border_box()[:4]
     half = width / 2
+    x0, y0 = bbx + half, bby + half
+    x1, y1 = bbx + bbw - half, bby + bbh - half
+
+    def period(outer_length):
+        # Match the per-side spacing of the generic path: dot count chosen
+        # from the outer side length, dots distributed between the two
+        # half-width-inset endpoints.
+        n_dots = max(2, int(outer_length // (2 * width)) + 1)
+        return (outer_length - width) / (n_dots - 1)
+
     with stream.stacked():
         stream.set_color(color, stroke=True)
         stream.set_line_width(width)
         stream.set_line_cap(1)
-        stream.set_line_join(1)
-        stream.set_dash([0, 2 * width], 0)
-        stream.rectangle(bbx + half, bby + half, bbw - width, bbh - width)
-        stream.stroke()
+        for x_a, y_a, x_b, y_b, outer_length in (
+                (x0, y0, x1, y0, bbw),  # top
+                (x1, y0, x1, y1, bbh),  # right
+                (x0, y1, x1, y1, bbw),  # bottom
+                (x0, y0, x0, y1, bbh)):  # left
+            stream.set_dash([0, period(outer_length)], 0)
+            stream.move_to(x_a, y_a)
+            stream.line_to(x_b, y_b)
+            stream.stroke()
 
 
 def draw_line(stream, x1, y1, x2, y2, thickness, style, color, offset=0):

--- a/weasyprint/draw/border.py
+++ b/weasyprint/draw/border.py
@@ -98,6 +98,18 @@ def draw_border(stream, box):
             draw_rounded_border(stream, box, styles[0], colors[0])
         return
 
+    # Dotted fast path: uniform dotted border with no rounded corners. We
+    # stroke a single rectangle with round caps and a zero-length dash
+    # pattern, which is orders of magnitude smaller in the PDF than the
+    # generic per-dot Bézier clip path.
+    radii = box.rounded_border_box()[4:]
+    no_radii = all(rx == 0 and ry == 0 for rx, ry in radii)
+    if (set(styles) == {'dotted'} and single_color and four_sides
+            and len(set(widths)) == 1 and no_radii):
+        with stream.artifact():
+            draw_dotted_rect_border(stream, box, widths[0], colors[0])
+        return
+
     # We're not smart enough to find a good way to draw the borders, we must
     # draw them side by side. Order is not specified, but this one seems to be
     # close to what other browsers do.
@@ -597,6 +609,25 @@ def draw_rect_border(stream, box, widths, style, color):
             bbw - (bl + br) * 2 / 3, bbh - (bt + bb) * 2 / 3)
     stream.rectangle(bbx + bl, bby + bt, bbw - bl - br, bbh - bt - bb)
     stream.fill(even_odd=True)
+
+
+def draw_dotted_rect_border(stream, box, width, color):
+    """Fast path: uniform dotted border with no rounded corners.
+
+    A round line cap turns a zero-length dash into a filled circle, so one
+    stroked rectangle replaces hundreds of per-dot Bézier curves.
+
+    """
+    bbx, bby, bbw, bbh = box.rounded_border_box()[:4]
+    half = width / 2
+    with stream.stacked():
+        stream.set_color(color, stroke=True)
+        stream.set_line_width(width)
+        stream.set_line_cap(1)
+        stream.set_line_join(1)
+        stream.set_dash([0, 2 * width], 0)
+        stream.rectangle(bbx + half, bby + half, bbw - width, bbh - width)
+        stream.stroke()
 
 
 def draw_line(stream, x1, y1, x2, y2, thickness, style, color, offset=0):

--- a/weasyprint/draw/border.py
+++ b/weasyprint/draw/border.py
@@ -101,13 +101,12 @@ def draw_border(stream, box):
     # Dotted/dashed fast path: uniform border with no rounded corners. We
     # stroke one line per side using PDF dash arrays, which is orders of
     # magnitude smaller in the PDF than the generic per-segment clip path.
-    radii = box.rounded_border_box()[4:]
-    no_radii = all(rx == 0 and ry == 0 for rx, ry in radii)
-    if (set(styles) in ({'dotted'}, {'dashed'}) and single_color
-            and four_sides and len(set(widths)) == 1 and no_radii):
+    no_radii = all(rx == 0 and ry == 0 for rx, ry in box.rounded_border_box()[4:])
+    dotted_dashed = set(styles) in ({'dotted'}, {'dashed'})
+    one_width = len(set(widths)) == 1
+    if dotted_dashed and single_color and four_sides and one_width and no_radii:
         with stream.artifact():
-            draw_dotted_dashed_rect_border(
-                stream, box, styles[0], widths[0], colors[0])
+            draw_dotted_dashed_border(stream, box, styles[0], widths[0], colors[0])
         return
 
     # We're not smart enough to find a good way to draw the borders, we must
@@ -611,7 +610,7 @@ def draw_rect_border(stream, box, widths, style, color):
     stream.fill(even_odd=True)
 
 
-def draw_dotted_dashed_rect_border(stream, box, style, width, color):
+def draw_dotted_dashed_border(stream, box, style, width, color):
     """Fast path: uniform dotted or dashed border with no rounded corners.
 
     Dotted uses a round line cap with a zero-length dash, so each "on"
@@ -632,30 +631,28 @@ def draw_dotted_dashed_rect_border(stream, box, style, width, color):
     def dash(outer_length):
         if style == 'dotted':
             # Dot at each corner with equal spacing in between.
-            n = max(2, int(outer_length // (2 * width)) + 1)
-            return [0, (outer_length - width) / (n - 1)]
+            count = max(2, int(outer_length // (2 * width)) + 1)
+            return [0, (outer_length - width) / (count - 1)]
         # Target dash size = 3 * width; equal dash/gap so an integer count
         # fits flush between the two corners.
-        n = int(outer_length // (6 * width)) + 1
-        d = outer_length / (2 * n - 1)
-        return [d, d]
+        count = int(outer_length // (6 * width)) + 1
+        dash_length = outer_length / (2 * count - 1)
+        return [dash_length, dash_length]
 
     with stream.stacked():
         stream.set_color(color, stroke=True)
         stream.set_line_width(width)
         stream.set_line_cap(1 if style == 'dotted' else 0)
-        for x_a, y_a, x_b, y_b, outer_length in (
-                (bbx + inset, bby + half,
-                 bbx + bbw - inset, bby + half, bbw),  # top
-                (bbx + bbw - half, bby + inset,
-                 bbx + bbw - half, bby + bbh - inset, bbh),  # right
-                (bbx + inset, bby + bbh - half,
-                 bbx + bbw - inset, bby + bbh - half, bbw),  # bottom
-                (bbx + half, bby + inset,
-                 bbx + half, bby + bbh - inset, bbh)):  # left
+        sides = (
+            (bbx + inset, bby + half, bbx + bbw - inset, bby + half, bbw),
+            (bbx + bbw - half, bby + inset, bbx + bbw - half, bby + bbh - inset, bbh),
+            (bbx + inset, bby + bbh - half, bbx + bbw - inset, bby + bbh - half, bbw),
+            (bbx + half, bby + inset, bbx + half, bby + bbh - inset, bbh),
+        )
+        for x1, y1, x2, y2, outer_length in sides:
             stream.set_dash(dash(outer_length), 0)
-            stream.move_to(x_a, y_a)
-            stream.line_to(x_b, y_b)
+            stream.move_to(x1, y1)
+            stream.line_to(x2, y2)
             stream.stroke()
 
 


### PR DESCRIPTION
**Fix** #2526.

For uniform dotted borders with no rounded corners, stroke one line per
side with a round line cap and a zero-length dash pattern instead of
emitting a filled Bézier circle per dot. Each dot becomes a round-cap of
 the stroke, so we replace ~24 numbers per dot with one `moveto` +
`lineto` + dash setup per side.

Any other dotted case (mixed colors, different widths, rounded corners)
falls through to the existing slow path.

## Results

Repro case from the issue (`<body style="border: 1px dotted black">`):

| Metric | Before | After |
|---|---|---|
| PDF size | 34,445 B | 836 B |
| `curve_to` operators in content stream | 2,544 | 0 |

Equivalent dashed repro (`<body style="border: 1px dashed black">`):

| Metric | Before | After |
|---|---|---|
| PDF size | 1,185 B | 829 B |

5-case visual sample (1px / 3px / 5px uniform dotted, `border-radius`, 4
 different colors). BEFORE on the left, AFTER on the right. Cases 4 and
5 take the slow path unchanged.

| Metric | Before | After |
|---|---|---|
| PDF size | 102 K | 53 K |
| Pixel diff vs before (150 DPI) | – | 0.02% (anti-alias noise only) |

Same layout for dashed:

| Metric | Before | After |
|---|---|---|
| PDF size | 6,313 B | 5,590 B |
| Pixel diff vs before (150 DPI) | – | 0.14% (anti-alias noise only) |

## Iteration

The first attempt (27896e49) stroked a single closed rectangle with one
dash period applied across the entire perimeter. That collapsed the
whole border into one `re` + dash, but because the perimeter is rarely
an integer multiple of `2 × width`, dots near the corners landed
slightly off — visible especially in the 5px case below:

<img width="2520" height="1774" alt="visual-compare-v1" src="https://github.com/user-attachments/assets/b0957ccd-5b38-4af0-9de7-3bbd9e967ad2" />

The second commit (2e3ef796) strokes each side individually and picks
the dash period per side so dots land exactly on both corners, matching
the per-side spacing of the generic path. Corners snap to dots, and the
pixel diff against the generic path drops from 0.6% to 0.02%:

<img width="2520" height="1774" alt="visual-compare" src="https://github.com/user-attachments/assets/2e361163-8880-48b9-8795-0af74882bafd" />

The third commit (`7544edfc`) extends the same function to handle
dashed borders, per @liZe's suggestion. The dotted/dashed split is
contained to three small knobs (cap, inset, dash array); net delta vs
the dotted-only version is +12 effective lines.

<img width="1406" height="1125" alt="dashed-visual-compare" src="https://github.com/user-attachments/assets/85302afd-0d18-40f9-94b4-c261d517c728" />

## Tests

- `pytest -k 'dotted or border'`: 404 passed, 2 xfailed (same as main)
- `pytest -k 'dashed'`: passes, no new failures
- `pytest`: no new failures
- `ruff check`: clean