### PR TITLE
Use response bytes when image file path doesn't exist

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1400,9 +1400,12 @@ def test_url_fetcher_default(assert_pixels_equal):
     ('pattern.png', 'image/png'),
 ])
 def test_url_fetcher_body_replaces_missing_file(image_name, mime):
-    """A URLFetcher returning body bytes for a file: URL whose path doesn't
-    exist on disk must use the response bytes, not try to read from the
-    missing file."""
+    """A URLFetcher returning body bytes for a file.
+
+    URLs whose path doesn’t exist on disk must use the response bytes, not try to read
+    from the missing file.
+
+    """
     image_bytes = resource_path(image_name).read_bytes()
 
     class ReplacingFetcher(URLFetcher):
@@ -1411,10 +1414,9 @@ def test_url_fetcher_body_replaces_missing_file(image_name, mime):
                 return URLFetcherResponse(url, image_bytes, {'Content-Type': mime})
             return super().fetch(url, headers)
 
-    base_url = str(resource_path('dummy.html'))
+    base_url = resource_path('dummy.html')
     html = f'<body><img src="missing/replaced{Path(image_name).suffix}">'
-    FakeHTML(string=html, url_fetcher=ReplacingFetcher(),
-             base_url=base_url).write_pdf()
+    FakeHTML(string=html, url_fetcher=ReplacingFetcher(), base_url=base_url).write_pdf()
 
 
 @assert_no_logs

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1395,6 +1395,29 @@ def test_url_fetcher_default(assert_pixels_equal):
 
 
 @assert_no_logs
+@pytest.mark.parametrize(('image_name', 'mime'), [
+    ('blue.jpg', 'image/jpeg'),
+    ('pattern.png', 'image/png'),
+])
+def test_url_fetcher_body_replaces_missing_file(image_name, mime):
+    """A URLFetcher returning body bytes for a file: URL whose path doesn't
+    exist on disk must use the response bytes, not try to read from the
+    missing file."""
+    image_bytes = resource_path(image_name).read_bytes()
+
+    class ReplacingFetcher(URLFetcher):
+        def fetch(self, url, headers=None):
+            if 'missing' in url:
+                return URLFetcherResponse(url, image_bytes, {'Content-Type': mime})
+            return super().fetch(url, headers)
+
+    base_url = str(resource_path('dummy.html'))
+    html = f'<body><img src="missing/replaced{Path(image_name).suffix}">'
+    FakeHTML(string=html, url_fetcher=ReplacingFetcher(),
+             base_url=base_url).write_pdf()
+
+
+@assert_no_logs
 def test_url_fetcher_bad_image(assert_pixels_equal):
     string = '<body><img src="custom:foo/bar">'
     css = CSS(string='@page { size: 8px; margin: 2px } body { font-size: 0 }')

--- a/weasyprint/images.py
+++ b/weasyprint/images.py
@@ -108,7 +108,7 @@ class RasterImage:
         stream.draw_x_object(image_name)
 
     def cache_image_data(self, data, filename=None, slot='source'):
-        if filename:
+        if filename and Path(filename).is_file():
             return LazyLocalImage(filename)
         else:
             key = f'{self.id}-{slot}-{self._dpi or ""}'


### PR DESCRIPTION
A custom `URLFetcher` that returns body bytes as a replacement for an image whose `file:` URL points to a path that doesn't exist on disk currently crashes with `FileNotFoundError` during PDF write for JPEGs (and RGB PNGs without transparency). `RasterImage.cache_image_data()` trusted the filename and returned a `LazyLocalImage` that later tried to read the missing file.

Guard the `LazyLocalImage` path on `Path(filename).is_file()`. The response bytes are already in memory, so falling back to `LazyImage` is safe.

Regression test in `tests/test_api.py` parametrized over JPEG and PNG.

Fix #2766.