### PR TITLE
Set SVG gradient color before path construction

### DIFF
--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -768,3 +768,27 @@ def test_pdf_ua_2_namespace_type():
     pdf = FakeHTML(string='<html lang="en"><body>abc').write_pdf(
         pdf_variant='pdf/ua-2', uncompressed_pdf=True)
     assert b'/Type /Namespace' in pdf
+
+
+@assert_no_logs
+def test_svg_gradient_color_ops_before_path():
+    # Regression test for #2762. SVG gradient color-setting operators
+    # (CS/SCN) must appear before path-construction operators (m/l/c/re),
+    # per ISO 32000-1 §8.5.2.1 — color operators are forbidden in the
+    # path object state.
+    pdf = FakeHTML(string='''
+      <svg viewBox="0 0 100 10" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <linearGradient id="g">
+            <stop stop-color="transparent" offset="0"/>
+            <stop stop-color="#008dd4" offset="1"/>
+          </linearGradient>
+        </defs>
+        <path d="M 0,5 h 100" fill="none" stroke="url(#g)" stroke-width="10"/>
+      </svg>
+    ''').write_pdf()
+    cs_offset = pdf.find(b'/Pattern CS')
+    assert cs_offset != -1
+    lineto_offset = pdf.find(b'100 5 l')
+    assert lineto_offset != -1
+    assert cs_offset < lineto_offset

--- a/weasyprint/svg/__init__.py
+++ b/weasyprint/svg/__init__.py
@@ -714,26 +714,42 @@ class SVG:
         return source, color
 
     def set_graphical_state(self, node, font_size, text=False):
-        """Set stroke and fill colors, and line options."""
+        """Set stroke and fill colors, and line options.
+
+        Gradient and pattern setup must happen here (before any subsequent
+        path-construction operators) because color-setting operators are
+        forbidden inside the path object state.
+
+        """
         # Get fill data
         fill_source, fill_color = self.get_paint(node.get('fill', 'black'))
         fill_opacity = alpha_value(node.get('fill-opacity', 1))
         fill_in_gradient = fill_source in self.gradients
         fill_in_pattern = fill_source in self.patterns
-        if fill_color and not (fill_in_gradient or fill_in_pattern):
-            stream_color = color(fill_color)
-            stream_color.alpha *= fill_opacity
-            self.stream.set_color(stream_color)
+        if fill_in_gradient or fill_in_pattern:
+            node._fill_drawn = draw_gradient_or_pattern(
+                self, node, fill_source, font_size, fill_opacity, stroke=False)
+        else:
+            node._fill_drawn = False
+            if fill_color:
+                stream_color = color(fill_color)
+                stream_color.alpha *= fill_opacity
+                self.stream.set_color(stream_color)
 
         # Get stroke data
         stroke_source, stroke_color = self.get_paint(node.get('stroke'))
         stroke_opacity = alpha_value(node.get('stroke-opacity', 1))
         stroke_in_gradient = stroke_source in self.gradients
         stroke_in_pattern = stroke_source in self.patterns
-        if stroke_color and not (stroke_in_gradient or stroke_in_pattern):
-            stream_color = color(stroke_color)
-            stream_color.alpha *= stroke_opacity
-            self.stream.set_color(stream_color, stroke=True)
+        if stroke_in_gradient or stroke_in_pattern:
+            node._stroke_drawn = draw_gradient_or_pattern(
+                self, node, stroke_source, font_size, stroke_opacity, stroke=True)
+        else:
+            node._stroke_drawn = False
+            if stroke_color:
+                stream_color = color(stroke_color)
+                stream_color.alpha *= stroke_opacity
+                self.stream.set_color(stream_color, stroke=True)
         stroke_width = self.length(node.get('stroke-width', '1px'), font_size)
         if stroke_width:
             self.stream.set_line_width(stroke_width)
@@ -780,19 +796,20 @@ class SVG:
         self.stream.set_miter_limit(miter_limit)
 
     def fill_stroke(self, node, font_size, text=False):
-        """Paint fill and stroke for a node."""
-        # Get fill data
-        fill_source, fill_color = self.get_paint(node.get('fill', 'black'))
-        fill_opacity = alpha_value(node.get('fill-opacity', 1))
-        fill_drawn = draw_gradient_or_pattern(
-            self, node, fill_source, font_size, fill_opacity, stroke=False)
+        """Paint fill and stroke for a node.
+
+        Gradient and pattern color-space/color operators are emitted earlier
+        in ``set_graphical_state``; this method only paints the path.
+
+        """
+        # Get fill data (gradient/pattern state was set in set_graphical_state)
+        fill_color = self.get_paint(node.get('fill', 'black'))[1]
+        fill_drawn = getattr(node, '_fill_drawn', False)
         fill = fill_color or fill_drawn
 
-        # Get stroke data
-        stroke_source, stroke_color = self.get_paint(node.get('stroke'))
-        stroke_opacity = alpha_value(node.get('stroke-opacity', 1))
-        stroke_drawn = draw_gradient_or_pattern(
-            self, node, stroke_source, font_size, stroke_opacity, stroke=True)
+        # Get stroke data (gradient/pattern state was set in set_graphical_state)
+        stroke_color = self.get_paint(node.get('stroke'))[1]
+        stroke_drawn = getattr(node, '_stroke_drawn', False)
         stroke_width = self.length(node.get('stroke-width', '1px'), font_size)
         stroke = (stroke_color or stroke_drawn) and stroke_width
 

--- a/weasyprint/svg/__init__.py
+++ b/weasyprint/svg/__init__.py
@@ -9,7 +9,7 @@ from cssselect2 import ElementWrapper
 
 from ..urls import get_url_attribute
 from .css import parse_declarations, parse_stylesheets
-from .defs import apply_filters, draw_gradient_or_pattern, paint_mask, use
+from .defs import apply_filters, draw_gradient, draw_pattern, paint_mask, use
 from .images import image, svg
 from .path import path
 from .shapes import circle, ellipse, line, polygon, polyline, rect
@@ -461,7 +461,7 @@ class SVG:
 
         # Set graphical state
         if call_fill_stroke:
-            self.set_graphical_state(node, font_size)
+            fill, stroke = self.set_graphical_state(node, font_size)
 
         # Clip
         clip_path = parse_url(node.get('clip-path')).fragment
@@ -558,7 +558,8 @@ class SVG:
 
         # Fill and stroke
         if call_fill_stroke:
-            self.fill_stroke(node, font_size)
+            even_odd = node.get('fill-rule') == 'evenodd'
+            self.fill_stroke(fill, stroke, even_odd)
 
         # Draw markers
         self.draw_markers(node, font_size, fill_stroke)
@@ -713,46 +714,37 @@ class SVG:
 
         return source, color
 
-    def set_graphical_state(self, node, font_size, text=False):
-        """Set stroke and fill colors, and line options.
-
-        Gradient and pattern setup must happen here (before any subsequent
-        path-construction operators) because color-setting operators are
-        forbidden inside the path object state.
-
-        """
+    def set_graphical_state(self, node, font_size):
+        """Set stroke and fill colors, gradients, patterns, and line options."""
         # Get fill data
-        fill_source, fill_color = self.get_paint(node.get('fill', 'black'))
-        fill_opacity = alpha_value(node.get('fill-opacity', 1))
-        fill_in_gradient = fill_source in self.gradients
-        fill_in_pattern = fill_source in self.patterns
-        if fill_in_gradient or fill_in_pattern:
-            node._fill_drawn = draw_gradient_or_pattern(
-                self, node, fill_source, font_size, fill_opacity, stroke=False)
-        else:
-            node._fill_drawn = False
-            if fill_color:
-                stream_color = color(fill_color)
-                stream_color.alpha *= fill_opacity
-                self.stream.set_color(stream_color)
+        source, fill = self.get_paint(node.get('fill', 'black'))
+        opacity = alpha_value(node.get('fill-opacity', 1))
+        if gradient := self.gradients.get(source):
+            fill = draw_gradient(self, node, gradient, font_size, opacity, stroke=False)
+        elif pattern := self.patterns.get(source):
+            fill = draw_pattern(self, node, pattern, font_size, opacity, stroke=False)
+        elif fill:
+            stream_color = color(fill)
+            stream_color.alpha *= opacity
+            self.stream.set_color(stream_color)
 
         # Get stroke data
-        stroke_source, stroke_color = self.get_paint(node.get('stroke'))
-        stroke_opacity = alpha_value(node.get('stroke-opacity', 1))
-        stroke_in_gradient = stroke_source in self.gradients
-        stroke_in_pattern = stroke_source in self.patterns
-        if stroke_in_gradient or stroke_in_pattern:
-            node._stroke_drawn = draw_gradient_or_pattern(
-                self, node, stroke_source, font_size, stroke_opacity, stroke=True)
-        else:
-            node._stroke_drawn = False
-            if stroke_color:
-                stream_color = color(stroke_color)
-                stream_color.alpha *= stroke_opacity
+        if stroke_width := self.length(node.get('stroke-width', '1px'), font_size):
+            source, stroke = self.get_paint(node.get('stroke'))
+            opacity = alpha_value(node.get('stroke-opacity', 1))
+            if gradient := self.gradients.get(source):
+                stroke = draw_gradient(
+                    self, node, gradient, font_size, opacity, stroke=True)
+            elif pattern := self.patterns.get(source):
+                stroke = draw_pattern(
+                    self, node, pattern, font_size, opacity, stroke=True)
+            elif stroke:
+                stream_color = color(stroke)
+                stream_color.alpha *= opacity
                 self.stream.set_color(stream_color, stroke=True)
-        stroke_width = self.length(node.get('stroke-width', '1px'), font_size)
-        if stroke_width:
-            self.stream.set_line_width(stroke_width)
+                self.stream.set_line_width(stroke_width)
+        else:
+            stroke = None
 
         # Apply dash array
         dash_array = tuple(
@@ -795,28 +787,12 @@ class SVG:
             miter_limit = 4
         self.stream.set_miter_limit(miter_limit)
 
-    def fill_stroke(self, node, font_size, text=False):
-        """Paint fill and stroke for a node.
+        return fill, stroke
 
-        Gradient and pattern color-space/color operators are emitted earlier
-        in ``set_graphical_state``; this method only paints the path.
-
-        """
-        # Get fill data (gradient/pattern state was set in set_graphical_state)
-        fill_color = self.get_paint(node.get('fill', 'black'))[1]
-        fill_drawn = getattr(node, '_fill_drawn', False)
-        fill = fill_color or fill_drawn
-
-        # Get stroke data (gradient/pattern state was set in set_graphical_state)
-        stroke_color = self.get_paint(node.get('stroke'))[1]
-        stroke_drawn = getattr(node, '_stroke_drawn', False)
-        stroke_width = self.length(node.get('stroke-width', '1px'), font_size)
-        stroke = (stroke_color or stroke_drawn) and stroke_width
-
-        # Fill and stroke
-        even_odd = node.get('fill-rule') == 'evenodd'
+    def fill_stroke(self, fill, stroke, even_odd=False, text=False):
+        """Paint fill and stroke for a node."""
         if text:
-            if stroke and fill:
+            if fill and stroke:
                 text_rendering = 2
             elif stroke:
                 text_rendering = 1

--- a/weasyprint/svg/defs.py
+++ b/weasyprint/svg/defs.py
@@ -53,16 +53,6 @@ def use(svg, node, font_size):
     svg.stream.transform(e=x, f=y)
 
 
-def draw_gradient_or_pattern(svg, node, name, font_size, opacity, stroke):
-    """Draw given gradient or pattern."""
-    if name in svg.gradients:
-        return draw_gradient(
-            svg, node, svg.gradients[name], font_size, opacity, stroke)
-    elif name in svg.patterns:
-        return draw_pattern(
-            svg, node, svg.patterns[name], font_size, opacity, stroke)
-
-
 def draw_gradient(svg, node, gradient, font_size, opacity, stroke):
     """Draw given gradient node."""
     # TODO: merge with Gradient.draw

--- a/weasyprint/svg/text.py
+++ b/weasyprint/svg/text.py
@@ -128,12 +128,8 @@ def text(svg, node, font_size):
         svg.cursor_position = (x + dx, y + dy)
         return
 
-    svg.stream.push_state()
-    svg.set_graphical_state(node, font_size, text=True)
-    svg.stream.begin_text()
-    emoji_lines = []
-
-    # Draw letters
+    # Layout letters.
+    layouts = []
     for i, ((x, y, dx, dy, r), letter) in enumerate(letters_positions):
         if x:
             svg.cursor_d_position[0] = 0
@@ -157,11 +153,19 @@ def text(svg, node, font_size):
             (x_position, y_position - baseline),
             (x_position + width, y_position - baseline + height))
         # TODO: Use ink extents instead of logical from line_break.line_size().
-        node.text_bounding_box = extend_bounding_box(
-            node.text_bounding_box, points)
+        node.text_bounding_box = extend_bounding_box(node.text_bounding_box, points)
+        layouts.append((layout, x_position, y_position, x, y, angle))
 
+    # Set state after we have bounding box for gradients and patterns, before drawing.
+    svg.stream.push_state()
+    fill, stroke = svg.set_graphical_state(node, font_size)
+    svg.stream.begin_text()
+
+    # Draw letters.
+    emoji_lines = []
+    for layout, x_position, y_position, x, y, angle in layouts:
         layout.reactivate(style)
-        svg.fill_stroke(node, font_size, text=True)
+        svg.fill_stroke(fill, stroke, text=True)
         matrix = Matrix(a=scale_x, d=-1, e=x_position, f=y_position)
         if angle:
             a, c = cos(angle), sin(angle)
@@ -173,5 +177,6 @@ def text(svg, node, font_size):
     svg.stream.end_text()
     svg.stream.pop_state()
 
+    # Draw emojis.
     for x, y, emojis in emoji_lines:
         draw_emojis(svg.stream, style, x, y, emojis)


### PR DESCRIPTION
The SVG drawing code emits the gradient/pattern color-space and color (`CS`, `SCN`) inside `fill_stroke`, which runs after the path has been constructed. That sets color in the middle of path-object state, which ISO 32000-1 §8.5.2.1 forbids — Adobe Preflight and PAC reject the resulting PDF.

Move `draw_gradient_or_pattern` from `fill_stroke` to `set_graphical_state` so the pattern setup happens in page-description state, before any path operators. `fill_stroke` now only paints, reading the drawn status stashed on the node by `set_graphical_state`.

Regression test in `tests/test_pdf.py` asserts `/Pattern CS` is emitted before `100 5 l` (the path's lineto) for the SVG in the issue.

Fix #2762.