### PR TITLE
Log an error on unknown render and write_pdf options

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -371,9 +371,11 @@ def test_python_render(assert_pixels_equal, tmp_path):
 
 @assert_no_logs
 def test_unknown_options():
+    # Regression test for #2731.
     with capture_logs() as logs:
         pdf_bytes = FakeHTML(string='test').write_pdf(zoom=2, unknown=True)
     assert len(logs) == 1
+    assert logs[0].startswith('ERROR')
     assert 'unknown' in logs[0]
     assert pdf_bytes
 
@@ -1578,3 +1580,35 @@ def test_page_copy_relative():
     duplicated_pages = document.copy([*document.pages, *document.pages])
     pngs = duplicated_pages.write_png(split_images=True)
     assert pngs[0] == pngs[1]
+
+
+@assert_no_logs
+def test_unknown_render_option():
+    # Regression test for #2731.
+    with capture_logs() as logs:
+        FakeHTML(string='<body>').render(bogus_option=True)
+    assert len(logs) == 1
+    assert logs[0].startswith('ERROR')
+    assert 'bogus_option' in logs[0]
+
+
+@assert_no_logs
+def test_unknown_options_options_wrapper():
+    # Regression test for #2731: passing options={...} as a kwarg (the
+    # reporter's case) silently dropped the requested PDF variant.
+    with capture_logs() as logs:
+        FakeHTML(string='<body>').write_pdf(options={'pdf_variant': 'pdf/a-2b'})
+    assert len(logs) == 1
+    assert logs[0].startswith('ERROR')
+    assert 'options' in logs[0]
+
+
+@assert_no_logs
+def test_unknown_document_write_pdf_option():
+    # Regression test for #2731.
+    document = FakeHTML(string='<body>').render()
+    with capture_logs() as logs:
+        document.write_pdf(bogus_option=True)
+    assert len(logs) == 1
+    assert logs[0].startswith('ERROR')
+    assert 'bogus_option' in logs[0]

--- a/weasyprint/__init__.py
+++ b/weasyprint/__init__.py
@@ -213,8 +213,8 @@ class HTML:
         :returns: A :class:`document.Document` object.
 
         """
-        for unknown in set(options) - set(DEFAULT_OPTIONS):
-            LOGGER.warning('Unknown rendering option: %s.', unknown)
+        for unknown in sorted(set(options) - set(DEFAULT_OPTIONS)):
+            LOGGER.error('Unknown rendering option: %s.', unknown)
         new_options = DEFAULT_OPTIONS.copy()
         new_options.update(options)
         options = new_options
@@ -261,9 +261,12 @@ class HTML:
         new_options = DEFAULT_OPTIONS.copy()
         new_options.update(options)
         options = new_options
-        return (
-            self.render(font_config, counter_style, color_profiles, **options)
-            .write_pdf(target, zoom, finisher, **options))
+        document = self.render(
+            font_config, counter_style, color_profiles, **options)
+        # render() has already reported any unknown options; forward only the
+        # known ones so they are not reported a second time by write_pdf().
+        options = {key: options[key] for key in DEFAULT_OPTIONS}
+        return document.write_pdf(target, zoom, finisher, **options)
 
 
 class CSS:

--- a/weasyprint/document.py
+++ b/weasyprint/document.py
@@ -15,7 +15,7 @@ from .formatting_structure.build import build_formatting_structure
 from .html import get_html_metadata
 from .images import get_image_from_uri as original_get_image_from_uri
 from .layout import LayoutContext, layout_document
-from .logger import PROGRESS_LOGGER
+from .logger import LOGGER, PROGRESS_LOGGER
 from .matrix import Matrix
 from .pdf import VARIANTS, generate_pdf
 from .pdf.metadata import DocumentMetadata
@@ -327,6 +327,8 @@ class Document:
             ``target``).
 
         """
+        for unknown in sorted(set(options) - set(DEFAULT_OPTIONS)):
+            LOGGER.error('Unknown PDF option: %s.', unknown)
         new_options = DEFAULT_OPTIONS.copy()
         new_options.update(options)
         options = new_options


### PR DESCRIPTION
WeasyPrint uses Python logging that is typically silenced by default, so a typo like `write_pdf(options={"pdf_variant": "pdf/a-2b"})` silently produces a plain PDF when the caller expects PDF/A — only discovered later by a downstream validator like veraPDF. `HTML.render` only logged a `warning` (rarely seen), and `HTML.write_pdf` / `Document.write_pdf` did not validate options at all.

Log an `error` listing each unknown keyword instead. Errors are far more visible than the previous warning, so the silent-failure problem is addressed while keeping the behavior backward compatible for callers that pass extra keywords (per review feedback).

`HTML.write_pdf` forwards only known options to `Document.write_pdf`, so an unknown option already reported by `render()` is not reported a second time.

Fix #2731.