### PR TITLE
Fix /Namepace typo in PDF 2 structure-tree namespace

### DIFF
--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -766,7 +766,7 @@ def test_pdf_tags_inline_table():
 def test_pdf_ua_2_namespace_type():
     # The structure-tree namespace dictionary must use /Type /Namespace,
     # not the misspelled /Namepace.
-    pdf = FakeHTML(string='<body>abc').write_pdf(
+    pdf = FakeHTML(string='<html lang="en"><body>abc').write_pdf(
         pdf_variant='pdf/ua-2', uncompressed_pdf=True)
     assert b'/Type /Namespace' in pdf
     assert b'/Namepace' not in pdf

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -760,3 +760,13 @@ def test_pdf_tags_inline_table():
     FakeHTML(string='''
       <html lang="en"><table style="display: inline"><td>abc
     ''').write_pdf(pdf_tags=True)
+
+
+@assert_no_logs
+def test_pdf_ua_2_namespace_type():
+    # The structure-tree namespace dictionary must use /Type /Namespace,
+    # not the misspelled /Namepace.
+    pdf = FakeHTML(string='<body>abc').write_pdf(
+        pdf_variant='pdf/ua-2', uncompressed_pdf=True)
+    assert b'/Type /Namespace' in pdf
+    assert b'/Namepace' not in pdf

--- a/weasyprint/pdf/tags.py
+++ b/weasyprint/pdf/tags.py
@@ -33,7 +33,7 @@ def add_tags(pdf, document, pdf_version, page_streams):
     # Add namespace for PDF 2.
     if str(pdf_version) >= '2.0':  # Cast for bytes and None
         namespace = pydyf.Dictionary({
-            'Type': '/Namepace',
+            'Type': '/Namespace',
             'NS': pydyf.String('http://iso.org/pdf2/ssn'),
         })
         pdf.add_object(namespace)


### PR DESCRIPTION
The structure-tree namespace dictionary for tagged PDF 2.0 documents (PDF/UA-2, PDF/A-4 + tags) was emitting `/Type /Namepace` instead of `/Type /Namespace`. Introduced in c7190293 (#2770).

Fix #2786.

## Test plan
- [x] Added regression test `test_pdf_ua_2_namespace_type` that renders with `pdf_variant='pdf/ua-2'` and asserts `/Type /Namespace` is present and `/Namepace` is not
- [ ] CI green
