### PR TITLE
Accept pathlib.Path base_url in CSS()

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -248,6 +248,19 @@ def test_css_parsing():
     _test_resource(CSS, 'latin1-test.css', check_css, encoding='latin1')
 
 
+@assert_no_logs
+def test_css_base_url_as_path():
+    """Regression test for #2764.
+
+    ``CSS()`` must accept a ``pathlib.Path`` ``base_url`` like ``HTML()``
+    does, instead of raising ``TypeError`` in ``url_is_absolute()``.
+    """
+    with chdir(Path(__file__).parent):
+        path = Path('resources') / 'utf8-test.css'
+        # Must not raise.
+        CSS(string=path.read_text('utf-8'), base_url=path)
+
+
 def check_png_pattern(assert_pixels_equal, png_bytes, x2=False, blank=False,
                       rotated=False):
     if blank:

--- a/weasyprint/__init__.py
+++ b/weasyprint/__init__.py
@@ -291,6 +291,8 @@ class CSS:
             filename or url or getattr(file_obj, 'name', 'CSS string'))
         if url_fetcher is None:
             url_fetcher = URLFetcher()
+        if isinstance(base_url, Path):
+            base_url = str(base_url)
         result = select_source(
             guess, filename, url, file_obj, string, base_url=base_url,
             url_fetcher=url_fetcher, check_css_mime_type=_check_mime_type)


### PR DESCRIPTION
## Summary

Fixes #2764.

`HTML.__init__()` converts a `pathlib.Path` `base_url` to a string before passing it down, but `CSS.__init__()` was missing this step. As a result:

```python
CSS(string=..., base_url=Path(...))
```

crashed with `TypeError: expected string or bytes-like object` in `url_is_absolute()`, even though the documented type for `base_url` is "str or pathlib.Path".

This applies the same `Path` → `str` conversion to `CSS.__init__()` (the fix suggested by the reporter, and confirmed by @grewn0uille in the issue).

## Changes

- `weasyprint/__init__.py`: convert a `Path` `base_url` to `str` in `CSS.__init__()`, mirroring `HTML.__init__()`.
- `tests/test_api.py`: add `test_css_base_url_as_path` regression test.

## Note

`Attachment.__init__()` (same module) forwards `base_url` to `select_source()` without the conversion too, so it likely has the same latent issue. I left it out to keep this PR scoped to the reported crash — happy to include it here or in a follow-up if you'd prefer.

## Verification

- `ruff check weasyprint/__init__.py tests/test_api.py` — clean.
- Both files compile.
- I could not run the full `pytest` suite locally (the native Pango/Cairo stack isn't installed on my Windows machine), so I kept the change minimal and identical to the existing, working `HTML` code path. The added regression test reproduces the issue exactly and should be validated by CI.
