### PR TITLE
Keep HarfBuzz font faces alive during PDF subsetting

### DIFF
--- a/tests/test_fonts.py
+++ b/tests/test_fonts.py
@@ -3,10 +3,9 @@
 import gc
 
 from weasyprint import CSS
-from weasyprint.css import InitialStyle
 from weasyprint.pdf.fonts import Font
-from weasyprint.text.fonts import FontConfiguration, get_pango_font_key
-from weasyprint.text.line_break import create_layout
+from weasyprint.text.ffi import ffi, gobject, pango
+from weasyprint.text.fonts import FontConfiguration
 
 from .testing_utils import BASE_URL, assert_no_logs, render_pages
 
@@ -28,22 +27,23 @@ def test_font_face_harfbuzz_face_lifetime():
     font_config = FontConfiguration()
     CSS(string='''
       @font-face {
-        font-family: repro;
+        font-family: bug;
         src: url(weasyprint.otf);
       }
-    ''', base_url=BASE_URL, font_config=font_config)
-    style = InitialStyle(font_config)
-    style['font_family'] = ('repro',)
-    layout = create_layout(
-        'ab', style, context=None, max_width=None, justification_spacing=0)
-    line, _ = layout.get_first_line()
-    pango_font = line.runs.data.item.analysis.font
-    _, description, font_size = get_pango_font_key(pango_font)
-    font = Font(pango_font, description, font_size)
-
-    del font_config, layout, line, pango_font, style
+    ''',
+    base_url=BASE_URL, font_config=font_config)
+    context = ffi.gc(
+        pango.pango_font_map_create_context(font_config.font_map),
+        gobject.g_object_unref)
+    font_description = ffi.gc(
+        pango.pango_font_description_new(), pango.pango_font_description_free)
+    pango.pango_font_description_set_family(font_description, ffi.new('char[]', b'bug'))
+    pango_font = ffi.gc(
+        pango.pango_font_map_load_font(font_config.font_map, context, font_description),
+        gobject.g_object_unref)
+    font = Font(pango_font, font_description, 10)
+    del context, font_description, pango_font, font_config
     gc.collect()
-
     font.clean({1: 'a', 2: 'b'}, hinting=False)
 
 

--- a/tests/test_fonts.py
+++ b/tests/test_fonts.py
@@ -1,6 +1,14 @@
 """Test the fonts features."""
 
-from .testing_utils import assert_no_logs, render_pages
+import gc
+
+from weasyprint import CSS
+from weasyprint.css import InitialStyle
+from weasyprint.pdf.fonts import Font
+from weasyprint.text.fonts import FontConfiguration, get_pango_font_key
+from weasyprint.text.line_break import create_layout
+
+from .testing_utils import BASE_URL, assert_no_logs, render_pages
 
 
 @assert_no_logs
@@ -14,6 +22,29 @@ def test_font_face():
     body, = html.children
     line, = body.children
     assert line.width == 3 * 16
+
+
+def test_font_face_harfbuzz_face_lifetime():
+    font_config = FontConfiguration()
+    CSS(string='''
+      @font-face {
+        font-family: repro;
+        src: url(weasyprint.otf);
+      }
+    ''', base_url=BASE_URL, font_config=font_config)
+    style = InitialStyle(font_config)
+    style['font_family'] = ('repro',)
+    layout = create_layout(
+        'ab', style, context=None, max_width=None, justification_spacing=0)
+    line, _ = layout.get_first_line()
+    pango_font = line.runs.data.item.analysis.font
+    _, description, font_size = get_pango_font_key(pango_font)
+    font = Font(pango_font, description, font_size)
+
+    del font_config, layout, line, pango_font, style
+    gc.collect()
+
+    font.clean({1: 'a', 2: 'b'}, hinting=False)
 
 
 @assert_no_logs

--- a/weasyprint/text/ffi.py
+++ b/weasyprint/text/ffi.py
@@ -18,6 +18,7 @@ ffi.cdef('''
     typedef uint32_t hb_codepoint_t;
     hb_tag_t hb_tag_from_string (const char *str, int len);
     void hb_tag_to_string (hb_tag_t tag, char *buf);
+    hb_face_t * hb_face_reference (hb_face_t *face);
     void hb_face_destroy (hb_face_t *face);
     hb_blob_t * hb_face_reference_blob (hb_face_t *face);
     unsigned int hb_face_get_index (const hb_face_t *face);

--- a/weasyprint/text/ffi.py
+++ b/weasyprint/text/ffi.py
@@ -20,6 +20,7 @@ ffi.cdef('''
     void hb_tag_to_string (hb_tag_t tag, char *buf);
     hb_face_t * hb_face_reference (hb_face_t *face);
     void hb_face_destroy (hb_face_t *face);
+    hb_face_t * hb_font_get_face (hb_font_t *font);
     hb_blob_t * hb_face_reference_blob (hb_face_t *face);
     unsigned int hb_face_get_index (const hb_face_t *face);
     unsigned int hb_face_get_upem (const hb_face_t *face);

--- a/weasyprint/text/fonts.py
+++ b/weasyprint/text/fonts.py
@@ -353,7 +353,8 @@ def get_pango_font_hb_face(pango_font):
     """Get Harfbuzz face out of given Pango font."""
     fc_font = ffi.cast('PangoFcFont *', pango_font)
     fontmap = ffi.cast('PangoFcFontMap *', pango.pango_font_get_font_map(pango_font))
-    return pangoft2.pango_fc_font_map_get_hb_face(fontmap, fc_font)
+    hb_face = pangoft2.pango_fc_font_map_get_hb_face(fontmap, fc_font)
+    return ffi.gc(harfbuzz.hb_face_reference(hb_face), harfbuzz.hb_face_destroy)
 
 
 def get_hb_object_data(hb_object, ot_color=None, glyph=None):

--- a/weasyprint/text/fonts.py
+++ b/weasyprint/text/fonts.py
@@ -351,9 +351,8 @@ def get_font_description(style):
 
 def get_pango_font_hb_face(pango_font):
     """Get Harfbuzz face out of given Pango font."""
-    fc_font = ffi.cast('PangoFcFont *', pango_font)
-    fontmap = ffi.cast('PangoFcFontMap *', pango.pango_font_get_font_map(pango_font))
-    hb_face = pangoft2.pango_fc_font_map_get_hb_face(fontmap, fc_font)
+    hb_font = pango.pango_font_get_hb_font(pango_font)
+    hb_face = harfbuzz.hb_font_get_face(hb_font)
     return ffi.gc(harfbuzz.hb_face_reference(hb_face), harfbuzz.hb_face_destroy)
 
 


### PR DESCRIPTION
This fixes a production crash we hit when rendering a document with multiple fonts + svg objects to PDF. The crash was a segfault during font subsetting, after layout had already finished.

`Font` stores an `hb_face_t*` during layout and uses it later when the PDF is finalized. That face was borrowed from Pango, but WeasyPrint kept the borrowed pointer. If the Pango/fontconfig owner was released or reused before subsetting, HarfBuzz could receive an invalid face pointer.

The first commit fixes the ownership issue by keeping the existing PangoFc lookup path, but taking an explicit HarfBuzz reference with `hb_face_reference()` and releasing it with `hb_face_destroy()` through `ffi.gc()`.

The second commit is optional cleanup: it gets the face through Pango’s HarfBuzz font API instead of the PangoFc font-map helper.

The regression test creates a `Font` from an `@font-face` font, releases the original layout/font configuration objects, forces collection, and then subsets the font. Without the first commit, this segfaults for me on CPython 3.13.