### PR TITLE
Fix inline width after backtracked line breaks

### DIFF
--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -86,6 +86,54 @@ def test_line_breaking_nbsp():
 
 
 @assert_no_logs
+def test_line_breaking_trailing_inline_width():
+    page, = render_pages('''
+      <style>
+        @page { size: 520px 180px; margin: 20px }
+        body {
+          margin: 0;
+          font-family: weasyprint;
+          font-size: 16px;
+          line-height: 1.25;
+        }
+        div {
+          width: 27ch;
+          text-align: right;
+          border-right: 1px solid black;
+        }
+      </style>
+      <div>
+        <span>
+          aaaaaaaaaa bbbbbbbbbb cccccccccc ddddd <span>e. 43</span>
+          ff&nbsp;<span>ggggg</span>.
+        </span>
+      </div>
+    ''')
+    html, = page.children
+    body, = html.children
+    div, = body.children
+    _, line_2, line_3 = div.children
+    span_2, = line_2.children
+    text_2, nested_2 = span_2.children
+    number, = nested_2.children
+    span_3, = line_3.children
+    text_3, nested_3, dot = span_3.children
+    word, = nested_3.children
+
+    assert text_2.text == 'cccccccccc ddddd '
+    assert number.text == 'e. 43'
+    assert text_3.text == 'ff\xa0'
+    assert word.text == 'ggggg'
+    assert dot.text == '.'
+
+    div_right = div.position_x + div.width
+    number_right = nested_2.position_x + nested_2.width
+    span_right = span_2.position_x + span_2.width
+    assert number_right == pytest.approx(div_right)
+    assert span_right == pytest.approx(number_right)
+
+
+@assert_no_logs
 def test_text_dimension():
     string = 'This is a text for test. This is a test for text.py'
     _, _, _, width_1, height_1, _ = make_text(string, 200, font_size=12)

--- a/weasyprint/layout/inline.py
+++ b/weasyprint/layout/inline.py
@@ -742,7 +742,6 @@ def split_inline_box(context, box, position_x, max_x, bottom_space, skip_stack,
         box.padding_left + box.margin_left + box.border_left_width)
     right_spacing = (
         box.padding_right + box.margin_right + box.border_right_width)
-    content_box_left = position_x
 
     children = []
     waiting_children = []
@@ -905,7 +904,16 @@ def split_inline_box(context, box, position_x, max_x, bottom_space, skip_stack,
         if translation_needed:
             for child in new_box.children:
                 child.translate(dx=left_spacing)
-        new_box.width = position_x - content_box_left
+        new_box.width = 0
+        children = new_box.children
+        if new_box.style['direction'] == 'ltr':
+            children = children[::-1]
+        for child in children:
+            if child.is_in_normal_flow():
+                new_box.width = (
+                    child.position_x + child.margin_width() -
+                    new_box.content_box_x())
+                break
         new_box.translate(dx=float_widths['left'], ignore_floats=True)
 
     _adjust_line_height(new_box)

--- a/weasyprint/layout/inline.py
+++ b/weasyprint/layout/inline.py
@@ -867,7 +867,7 @@ def split_inline_box(context, box, position_x, max_x, bottom_space, skip_stack,
         children.extend(waiting_children)
         resume_at = None
 
-    # Reorder inline blocks when direction is rtl
+    # Reorder inline blocks when direction is right-to-left.
     if box.style['direction'] == 'rtl' and len(children) > 1:
         in_flow_children = [
             box_child for _, box_child, _ in children
@@ -878,43 +878,34 @@ def split_inline_box(context, box, position_x, max_x, bottom_space, skip_stack,
                 dx=(position_x - child.position_x), ignore_floats=True)
             position_x += child.margin_width()
 
+    # Remove decoration.
     is_end = resume_at is None
     new_box = box.copy_with_children(
         [box_child for index, box_child, _ in children])
     new_box.remove_decoration(start=not is_start, end=not is_end)
-    if isinstance(box, boxes.LineBox):
-        # We must reset line box width according to its new children
-        new_box.width = 0
-        children = new_box.children
-        if new_box.style['direction'] == 'ltr':
-            children = children[::-1]
-        for child in children:
-            if child.is_in_normal_flow():
-                new_box.width = (
-                    child.position_x + child.margin_width() -
-                    new_box.position_x)
-                break
-    else:
+
+    # Translate boxes to respect box decoration and floats.
+    if not isinstance(box, boxes.LineBox):
         new_box.position_x = initial_position_x
-        if box.style['box_decoration_break'] == 'clone':
-            translation_needed = True
-        else:
-            translation_needed = (
-                is_start if box.style['direction'] == 'ltr' else is_end)
-        if translation_needed:
+        left_decoration = left_spacing and (
+            box.style['box_decoration_break'] == 'clone' or
+            (is_start if box.style['direction'] == 'ltr' else is_end))
+        if left_decoration:
             for child in new_box.children:
                 child.translate(dx=left_spacing)
-        new_box.width = 0
-        children = new_box.children
-        if new_box.style['direction'] == 'ltr':
-            children = children[::-1]
-        for child in children:
-            if child.is_in_normal_flow():
-                new_box.width = (
-                    child.position_x + child.margin_width() -
-                    new_box.content_box_x())
-                break
         new_box.translate(dx=float_widths['left'], ignore_floats=True)
+
+    # Reset line box width according to its new children.
+    new_box.width = 0
+    children = new_box.children
+    if new_box.style['direction'] == 'ltr':
+        children = children[::-1]
+    for child in children:
+        if child.is_in_normal_flow():
+            new_box.width = (
+                child.position_x + child.margin_width() -
+                new_box.content_box_x())
+            break
 
     _adjust_line_height(new_box)
 


### PR DESCRIPTION
Recompute split inline box width from retained children instead of using a stale cursor position. This avoids phantom trailing width when later inline content is moved to the next line.

Before:
[test.pdf](https://github.com/user-attachments/files/29092395/test.pdf)
After:
[test.pdf](https://github.com/user-attachments/files/29092364/test.pdf)

Co-authored-by: ChatGPT <noreply@openai.com>
