### PR TITLE
Switch to MSYS2 UCRT64 environment

### DIFF
--- a/.github/workflows/exe.yml
+++ b/.github/workflows/exe.yml
@@ -12,11 +12,11 @@ jobs:
           python-version: '3.13'
       - name: Use absolute imports and install Pango (Windows)
         run: |
-          C:\msys64\usr\bin\bash -lc 'pacman -S mingw-w64-x86_64-pango mingw-w64-x86_64-sed --noconfirm'
-          C:\msys64\mingw64\bin\sed -i 's/^from \. /from weasyprint /' weasyprint/__main__.py
-          C:\msys64\mingw64\bin\sed  -i 's/^from \./from weasyprint\./' weasyprint/__main__.py
-          echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH
-          rm C:\msys64\mingw64\bin\python.exe
+          C:\msys64\usr\bin\bash -lc 'pacman -S mingw-w64-ucrt-x86_64-pango mingw-w64-ucrt-x86_64-sed --noconfirm'
+          C:\msys64\ucrt64\bin\sed -i 's/^from \. /from weasyprint /' weasyprint/__main__.py
+          C:\msys64\ucrt64\bin\sed  -i 's/^from \./from weasyprint\./' weasyprint/__main__.py
+          echo "C:\msys64\ucrt64\bin" | Out-File -FilePath $env:GITHUB_PATH
+          rm C:\msys64\ucrt64\bin\python.exe
       - name: Install requirements
         run: python -m pip install . pyinstaller
       - name: Generate executable

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,10 +31,10 @@ jobs:
       - name: Install DejaVu, Pango and Ghostscript (Windows)
         if: matrix.os == 'windows-latest'
         run: |
-          C:\msys64\usr\bin\bash -lc 'pacman -S mingw-w64-x86_64-ttf-dejavu mingw-w64-x86_64-pango mingw-w64-x86_64-ghostscript --noconfirm'
-          xcopy "C:\msys64\mingw64\share\fonts\TTF" "C:\Users\runneradmin\.fonts" /e /i
-          echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH
-          rm C:\msys64\mingw64\bin\python.exe
+          C:\msys64\usr\bin\bash -lc 'pacman -S mingw-w64-ucrt-x86_64-ttf-dejavu mingw-w64-ucrt-x86_64-pango mingw-w64-ucrt-x86_64-ghostscript --noconfirm'
+          xcopy "C:\msys64\ucrt64\share\fonts\TTF" "C:\Users\runneradmin\.fonts" /e /i
+          echo "C:\msys64\ucrt64\bin" | Out-File -FilePath $env:GITHUB_PATH
+          rm C:\msys64\ucrt64\bin\python.exe
       - name: Upgrade pip and setuptools
         run: python -m pip install --upgrade pip setuptools
       - name: Install tests’ requirements

--- a/docs/first_steps.rst
+++ b/docs/first_steps.rst
@@ -195,7 +195,7 @@ easiest way to install these libraries is to use MSYS2. Here are the steps you
 have to follow:
 
 - Install `MSYS2`_ keeping the default options.
-- After installation, in MSYS2’s shell, execute ``pacman -S mingw-w64-x86_64-pango``.
+- After installation, in MSYS2 UCRT64 shell, execute ``pacman -S mingw-w64-ucrt-x86_64-pango``.
 - Close MSYS2’s shell.
 
 You can then launch a Windows command prompt by clicking on the Start menu,
@@ -298,7 +298,7 @@ On Windows, you can set the ``WEASYPRINT_DLL_DIRECTORIES`` environment variable
 to list the folders where the DLL files can be found. For example, in
 ``cmd.exe``::
 
-  set WEASYPRINT_DLL_DIRECTORIES=C:\msys64\mingw64\bin
+  set WEASYPRINT_DLL_DIRECTORIES=C:\msys64\ucrt64\bin
 
 On macOS, you can set the ``DYLD_FALLBACK_LIBRARY_PATH`` environment variable::
 

--- a/weasyprint/text/ffi.py
+++ b/weasyprint/text/ffi.py
@@ -467,7 +467,8 @@ def _dlopen(ffi, *names, allow_fail=False):
 if hasattr(os, 'add_dll_directory') and not hasattr(sys, 'frozen'):  # pragma: no cover
     dll_directories = os.getenv(
         'WEASYPRINT_DLL_DIRECTORIES',
-        'C:\\msys64\\mingw64\\bin;'
+        'C:\\msys64\\ucrt64\\bin;'
+        'C:\\msys64\\mingw64\\bin;' # keep mingw64 for backward compatibility
         'C:\\Program Files\\GTK3-Runtime Win64\\bin').split(';')
     for dll_directory in dll_directories:
         with suppress((OSError, FileNotFoundError)):


### PR DESCRIPTION
Relates to issue #2809. Backward compatibility with the deprecated MINGW64 environment is retained, so it will not break existing installations.