### PR TITLE
Share computed styles between elements

### DIFF
--- a/tests/css/test_common.py
+++ b/tests/css/test_common.py
@@ -119,7 +119,7 @@ def test_annotate_document():
 
     # The href attr should be as in the source, not made absolute.
     assert after['content'] == (
-        ('string', ' ['), ('string', 'home.html'), ('string', ']'))
+        ('string', ' ['), ('attr()', ('href', 'string', '')), ('string', ']'))
     assert after['background_color'] == (1, 0, 0, 1)
     assert after['border_top_width'] == 42
     assert after['border_bottom_width'] == 3

--- a/tests/resources/doc1.html
+++ b/tests/resources/doc1.html
@@ -42,7 +42,7 @@
 <body style="font-size: 20px">
     <h1 style="font-size: 2em">WeasyPrint test document (with Ünicōde)</h1>
     <p style="color: blue; font-size: x-large;
-              -weasy-link: attr(foo-link)  /* no such attribute */">Hello</p>
+              -weasy-link: '#none'  /* no such target */">Hello</p>
     <ul style="font-family: weasyprint; font-size: 1.25ex">
         <li style="font-size: 6pt; font-weight: bold">
             <a href=home.html

--- a/tests/resources/tests_ua.css
+++ b/tests/resources/tests_ua.css
@@ -23,7 +23,6 @@ colgroup  { display: table-column-group }
 td, th    { display: table-cell }
 caption   { display: table-caption }
 
-*[lang]   { -weasy-lang: attr(lang) }
 a[href]   { -weasy-link: attr(href) }
 a[name]   { -weasy-anchor: attr(name) }
 *[id]     { -weasy-anchor: attr(id) }

--- a/tests/resources/tests_ua.css
+++ b/tests/resources/tests_ua.css
@@ -23,7 +23,6 @@ colgroup  { display: table-column-group }
 td, th    { display: table-cell }
 caption   { display: table-caption }
 
-a[href]   { -weasy-link: attr(href) }
 a[name]   { -weasy-anchor: attr(name) }
 *[id]     { -weasy-anchor: attr(id) }
 h1        { bookmark-level: 1; bookmark-label: content(text) }

--- a/tests/resources/tests_ua.css
+++ b/tests/resources/tests_ua.css
@@ -23,8 +23,6 @@ colgroup  { display: table-column-group }
 td, th    { display: table-cell }
 caption   { display: table-caption }
 
-a[name]   { -weasy-anchor: attr(name) }
-*[id]     { -weasy-anchor: attr(id) }
 h1        { bookmark-level: 1; bookmark-label: content(text) }
 h2        { bookmark-level: 2; bookmark-label: content(text) }
 h3        { bookmark-level: 3; bookmark-label: content(text) }

--- a/weasyprint/css/__init__.py
+++ b/weasyprint/css/__init__.py
@@ -326,14 +326,17 @@ def find_style_attributes(tree, presentational_hints=False, base_url=None):
             declarations = tinycss2.parse_blocks_contents(style)
             yield specificity, element, declarations, base_url
 
-        # Apply presentational hints.
-        if not presentational_hints:
-            continue
-
         specificity = (0, 0, 0)
         def parse_declaration(style_attribute, element=element):
             declaration = tinycss2.parse_one_declaration(style_attribute)
             return specificity, element, (declaration,), base_url
+
+        if lang := element.get('lang'):
+            yield parse_declaration(f'-weasy-lang:"{lang}"')
+
+        # Apply presentational hints.
+        if not presentational_hints:
+            continue
 
         if element.tag == 'body':
             # TODO: we should check the container frame element.

--- a/weasyprint/css/__init__.py
+++ b/weasyprint/css/__init__.py
@@ -174,7 +174,7 @@ class StyleFor:
 
         cascaded = cascaded_styles.get((element, pseudo_type), {})
         computed = computed_styles[element, pseudo_type] = ComputedStyle(
-            parent_style, cascaded, element, pseudo_type, root_style, base_url,
+            parent_style, cascaded, pseudo_type, root_style, base_url,
             self.font_config, self.initial_page_sizes)
         if target_collector and computed['anchor']:
             target_collector.collect_anchor(computed['anchor'])
@@ -1087,13 +1087,12 @@ class AnonymousStyle(Style):
 
 class ComputedStyle(Style):
     """Computed style used for non-anonymous boxes."""
-    def __init__(self, parent_style, cascaded, element, pseudo_type,
-                 root_style, base_url, font_config, initial_page_sizes):
+    def __init__(self, parent_style, cascaded, pseudo_type, root_style, base_url,
+                 font_config, initial_page_sizes):
         self.specified = {}
         self.parent_style = parent_style
         self.cascaded = cascaded
         self.is_root_element = parent_style is None
-        self.element = element
         self.pseudo_type = pseudo_type
         self.root_style = root_style
         self.base_url = base_url
@@ -1103,8 +1102,8 @@ class ComputedStyle(Style):
 
     def copy(self):
         copy = ComputedStyle(
-            self.parent_style, self.cascaded, self.element, self.pseudo_type,
-            self.root_style, self.base_url, self.font_config, self.initial_page_sizes)
+            self.parent_style, self.cascaded, self.pseudo_type, self.root_style,
+            self.base_url, self.font_config, self.initial_page_sizes)
         copy.update(self)
         copy.specified = self.specified.copy()
         return copy

--- a/weasyprint/css/__init__.py
+++ b/weasyprint/css/__init__.py
@@ -72,7 +72,7 @@ class StyleFor:
         # values: style dict objects:
         #     keys: property name as a string
         #     values: a PropertyValue-like object
-        self._computed_styles = {}
+        self._computed_styles = computed_styles = {}
 
         # Set when the first page is created, used for viewport-based units.
         self.initial_page_sizes = {'box': None, 'area': None}
@@ -82,9 +82,11 @@ class StyleFor:
 
         PROGRESS_LOGGER.info('Step 3 - Applying CSS')
         layer_order = inf
+        elements_declarations = {}
         for specificity, element, declarations, base_url in find_style_attributes(
                 html.etree_element, presentational_hints, html.base_url):
             style = cascaded_styles.setdefault((element, None), {})
+            elements_declarations[element] = tuple(declarations)
             for name, values, importance in preprocess_declarations(
                     base_url, declarations):
                 precedence = declaration_precedence('author', importance)
@@ -98,25 +100,40 @@ class StyleFor:
         # computed styles before their children, for inheritance.
 
         # Iterate on all elements, even if there is no cascaded style for them.
+        computed_cache = {}
         for element in html.wrapper_element.iter_subtree():
+            etree_element = element.etree_element
+            parent = element.parent.etree_element if element.parent else None
+            parent_id = id(computed_styles[parent, None]) if element.parent else None
+            element_declarations = elements_declarations.get(etree_element)
+            selectors_keys = []
             for sheet, origin, sheet_specificity in sheets:
-                # Add declarations for matched elements
+                # Add declarations for matching elements.
                 for selector in sheet.matcher.match(element):
                     specificity, order, pseudo_type, (declarations, layer) = selector
                     layer_order = inf if layer is None else sheet.layers.index(layer)
+                    selectors_keys.append(
+                        (sheet, specificity, id(declarations), layer_order))
                     specificity = sheet_specificity or specificity
-                    style = cascaded_styles.setdefault(
-                        (element.etree_element, pseudo_type), {})
+                    style = cascaded_styles.setdefault((etree_element, pseudo_type), {})
                     for name, values, importance in declarations:
                         precedence = declaration_precedence(origin, importance)
                         weight = (precedence, layer_order, specificity)
                         old_weight = style.get(name, (None, None))[1]
                         if old_weight is None or old_weight <= weight:
                             style[name] = values, weight
-            parent = element.parent.etree_element if element.parent else None
-            self.set_computed_styles(
-                element.etree_element, root=html.etree_element, parent=parent,
-                base_url=html.base_url, target_collector=target_collector)
+
+            # Store computed styles.
+            key = (parent_id, element_declarations, tuple(selectors_keys))
+            if key in computed_cache:
+                # Equivalent computed style already exsists, share it.
+                computed_styles[etree_element, None] = computed_cache[key]
+            else:
+                # No equivalent computed style found, create it.
+                self.set_computed_styles(
+                    etree_element, root=html.etree_element, parent=parent,
+                    base_url=html.base_url, target_collector=target_collector)
+                computed_cache[key] = computed_styles[etree_element, None]
 
         # Then computed styles for pseudo elements, in any order.
         # Pseudo-elements inherit from their associated element so they come

--- a/weasyprint/css/__init__.py
+++ b/weasyprint/css/__init__.py
@@ -334,6 +334,9 @@ def find_style_attributes(tree, presentational_hints=False, base_url=None):
         if lang := element.get('lang'):
             yield parse_declaration(f'-weasy-lang:"{lang}"')
 
+        if href := element.get('href'):
+            yield parse_declaration(f'-weasy-link:"{href}"')
+
         # Apply presentational hints.
         if not presentational_hints:
             continue
@@ -1503,8 +1506,7 @@ def preprocess_stylesheet(device_media_type, base_url, stylesheet_rules, url_fet
                 if tokens[0].type == 'string':
                     url = url_join(
                         base_url, tokens[0].value, allow_relative=False,
-                        context='@import at %s:%s',
-                        context_args=(rule.source_line, rule.source_column))
+                        context=f'@import at {rule.source_line}:{rule.source_column}')
                 else:
                     url_tuple = get_url(tokens[0], base_url)
                     if url_tuple and url_tuple[1][0] == 'external':

--- a/weasyprint/css/__init__.py
+++ b/weasyprint/css/__init__.py
@@ -337,6 +337,13 @@ def find_style_attributes(tree, presentational_hints=False, base_url=None):
         if href := element.get('href'):
             yield parse_declaration(f'-weasy-link:"{href}"')
 
+        if id_ := element.get('id'):
+            yield parse_declaration(f'-weasy-anchor:"{id_}"')
+
+        if element.tag == 'a':
+            if name := element.get('name'):
+                yield parse_declaration(f'-weasy-anchor:"{name}"')
+
         # Apply presentational hints.
         if not presentational_hints:
             continue

--- a/weasyprint/css/computed_values.py
+++ b/weasyprint/css/computed_values.py
@@ -7,7 +7,7 @@ from tinycss2.color5 import parse_color
 
 from ..logger import LOGGER
 from ..text.line_break import strut
-from ..urls import get_link_attribute, get_url_tuple
+from ..urls import get_link, get_url_tuple
 from .functions import check_math
 from .properties import INITIAL_VALUES, ZERO_PIXELS, Dimension
 from .units import ANGLE_TO_RADIANS, LENGTH_UNITS, to_pixels
@@ -749,11 +749,9 @@ def anchor(style, name, values):
 @register_computer('link')
 def link(style, name, values):
     """Compute the ``link`` property."""
-    if values == 'none':
-        return
-    type_, value = values
-    if type_ == 'attr()':
-        return get_link_attribute(style.element, value, style.base_url)
+    name, value = values
+    if name == 'string':
+        return get_link(value, style.base_url)
     return values
 
 
@@ -762,11 +760,9 @@ def lang(style, name, values):
     """Compute the ``lang`` property."""
     if values == 'none':
         return
-    name, key = values
-    if name == 'attr()':
-        return style.element.get(key) or None
-    elif name == 'string':
-        return key
+    name, value = values
+    if name == 'string':
+        return value
 
 
 @register_computer('tab-size')

--- a/weasyprint/css/computed_values.py
+++ b/weasyprint/css/computed_values.py
@@ -737,29 +737,19 @@ def line_height(style, name, value):
     return ('PIXELS', pixels)
 
 
-@register_computer('anchor')
-def anchor(style, name, values):
-    """Compute the ``anchor`` property."""
-    if values != 'none':
-        _, key = values
-        anchor_name = style.element.get(key) or None
-        return anchor_name
-
-
 @register_computer('link')
 def link(style, name, values):
     """Compute the ``link`` property."""
     name, value = values
     if name == 'string':
         return get_link(value, style.base_url)
-    return values
+    elif name == 'url':
+        return values
 
 
 @register_computer('lang')
 def lang(style, name, values):
     """Compute the ``lang`` property."""
-    if values == 'none':
-        return
     name, value = values
     if name == 'string':
         return value

--- a/weasyprint/css/computed_values.py
+++ b/weasyprint/css/computed_values.py
@@ -7,10 +7,10 @@ from tinycss2.color5 import parse_color
 
 from ..logger import LOGGER
 from ..text.line_break import strut
-from ..urls import get_link, get_url_tuple
+from ..urls import get_link
 from .functions import check_math
 from .properties import INITIAL_VALUES, ZERO_PIXELS, Dimension
-from .units import ANGLE_TO_RADIANS, LENGTH_UNITS, to_pixels
+from .units import LENGTH_UNITS, to_pixels
 
 # Value in pixels of font-size for <absolute-size> keywords: 12pt (16px) for
 # medium, and scaling factors given in CSS3 for others:
@@ -219,40 +219,6 @@ def register_computer(name):
         COMPUTER_FUNCTIONS[name] = function
         return function
     return decorator
-
-
-def compute_attr(style, values):
-    # TODO: use real token parsing instead of casting with Python types, and follow new
-    # syntax. See https://drafts.csswg.org/css-values-5/#attr-notation.
-    func_name, value = values
-    assert func_name == 'attr()'
-    attr_name, type_or_unit, fallback = value
-    try:
-        attr_value = style.element.get(attr_name, fallback)
-        if type_or_unit == 'string':
-            pass  # Keep the string
-        elif type_or_unit == 'url':
-            attr_value = get_url_tuple(attr_value, style.base_url)
-        elif type_or_unit == 'color':
-            attr_value = parse_color(attr_value.strip(), style['color_scheme'])
-        elif type_or_unit == 'integer':
-            attr_value = int(attr_value.strip())
-        elif type_or_unit == 'number':
-            attr_value = float(attr_value.strip())
-        elif type_or_unit == '%':
-            attr_value = Dimension(float(attr_value.strip()), '%')
-            type_or_unit = 'length'
-        elif type_or_unit in LENGTH_UNITS:
-            attr_value = Dimension(float(attr_value.strip()), type_or_unit)
-            type_or_unit = 'length'
-        elif type_or_unit in ANGLE_TO_RADIANS:
-            attr_value = Dimension(float(attr_value.strip()), type_or_unit)
-            type_or_unit = 'angle'
-        else:
-            return
-    except Exception:
-        return
-    return (type_or_unit, attr_value)
 
 
 @register_computer('background-image')
@@ -517,35 +483,13 @@ def gap(style, name, value):
 def _content_list(style, values):
     computed_values = []
     for value in values:
-        if value[0] in ('string', 'content', 'url', 'quote', 'leader()'):
-            computed_value = value
-        elif value[0] == 'attr()':
-            assert value[1][1] == 'string'
-            computed_value = compute_attr(style, value)
-        elif value[0] in (
-                'counter()', 'counters()', 'content()', 'element()',
-                'string()'):
-            # Other values need layout context, their computed value cannot be
-            # better than their specified value yet.
-            # See build.compute_content_list.
-            computed_value = value
-        elif value[0] in (
-                'target-counter()', 'target-counters()', 'target-text()'):
-            anchor_token = value[1][0]
-            if anchor_token[0] == 'attr()':
-                attr = compute_attr(style, anchor_token)
-                if attr is None:
-                    computed_value = None
-                else:
-                    computed_value = (value[0], (attr, *value[1][1:]))
-            else:
-                computed_value = value
-        if computed_value is None:
-            LOGGER.warning('Unable to compute %r value for content: %r' % (
-                style.element, ', '.join(str(item) for item in value)))
+        if value[0] in (
+                'string', 'content', 'url', 'quote', 'leader()',
+                'counter()', 'counters()', 'content()', 'element()', 'string()',
+                'attr()', 'target-counter()', 'target-counters()', 'target-text()'):
+            computed_values.append(value)
         else:
-            computed_values.append(computed_value)
-
+            LOGGER.warning(f'Unable to compute content: {value}')
     return tuple(computed_values)
 
 

--- a/weasyprint/css/html5_ua.css
+++ b/weasyprint/css/html5_ua.css
@@ -14,7 +14,6 @@ https://dev.w3.org/html5/spec-LC/rendering.html#the-css-user-agent-style-sheet-a
 
 [id] { -weasy-anchor: attr(id) }
 a[name] { -weasy-anchor: attr(name) }
-a[href] { -weasy-link: attr(href) }
 
 /* Display and visibility */
 

--- a/weasyprint/css/html5_ua.css
+++ b/weasyprint/css/html5_ua.css
@@ -10,11 +10,6 @@ https://dev.w3.org/html5/spec-LC/rendering.html#the-css-user-agent-style-sheet-a
 
 */
 
-/* WeasyPrint-only features */
-
-[id] { -weasy-anchor: attr(id) }
-a[name] { -weasy-anchor: attr(name) }
-
 /* Display and visibility */
 
 [hidden], area, base, basefont, command, datalist, head, input[type=hidden i], link, menu[type=context i], meta, noembed, noframes, param, rp, script, source, style, template, title, track { display: none }

--- a/weasyprint/css/html5_ua.css
+++ b/weasyprint/css/html5_ua.css
@@ -14,7 +14,6 @@ https://dev.w3.org/html5/spec-LC/rendering.html#the-css-user-agent-style-sheet-a
 
 [id] { -weasy-anchor: attr(id) }
 a[name] { -weasy-anchor: attr(name) }
-[lang] { -weasy-lang: attr(lang) }
 a[href] { -weasy-link: attr(href) }
 
 /* Display and visibility */

--- a/weasyprint/css/targets.py
+++ b/weasyprint/css/targets.py
@@ -9,6 +9,7 @@ targeted anchors has been done.
 import copy
 
 from ..logger import LOGGER
+from ..urls import get_url_tuple
 
 
 class TargetLookupItem:
@@ -104,9 +105,16 @@ class TargetCollector:
         tree again.
 
         """
+        if anchor_token[0] == 'attr()':
+            attr_name, type_, fallback = anchor_token[1]
+            attr_value = source_box.element.get(attr_name, fallback)
+            if type_ == 'string':
+                anchor_token = ('string', attr_value)
+            elif type_ == 'url':
+                url_tuple = get_url_tuple(attr_value, source_box.style.base_url)
+                anchor_token = ('url', url_tuple)
         anchor_name = anchor_name_from_token(anchor_token)
-        item = self.target_lookup_items.get(
-            anchor_name, TargetLookupItem('undefined'))
+        item = self.target_lookup_items.get(anchor_name, TargetLookupItem('undefined'))
 
         if item.state == 'pending':
             self.had_pending_targets = True

--- a/weasyprint/css/validation/properties.py
+++ b/weasyprint/css/validation/properties.py
@@ -1893,16 +1893,10 @@ def anchor(token):
 @single_token
 def link(token, base_url):
     """Validation for ``link``."""
-    if get_keyword(token) == 'none':
-        return 'none'
-    parsed_url = get_url(token, base_url)
-    if parsed_url:
-        return parsed_url
-    function = Function(token)
-    if arguments := function.split_space():
-        prototype = (function.name, [argument.type for argument in arguments])
-        if prototype == ('attr', ['ident']):
-            return ('attr()', arguments[0].value)
+    if token.type == 'url':
+        return get_url(token, base_url)
+    elif token.type == 'string':
+        return ('string', token.value)
 
 
 @property()

--- a/weasyprint/css/validation/properties.py
+++ b/weasyprint/css/validation/properties.py
@@ -1987,11 +1987,6 @@ def lang(token):
     """Validation for ``lang``."""
     if get_keyword(token) == 'none':
         return 'none'
-    function = Function(token)
-    if arguments := function.split_space():
-        prototype = (function.name, [argument.type for argument in arguments])
-        if prototype == ('attr', ['ident']):
-            return ('attr()', arguments[0].value)
     elif token.type == 'string':
         return ('string', token.value)
 

--- a/weasyprint/css/validation/properties.py
+++ b/weasyprint/css/validation/properties.py
@@ -49,7 +49,7 @@ def property(property_name=None, proprietary=False, unstable=False,
 
     :param proprietary:
         Proprietary (vendor-specific, non-standard) are prefixed: anchors can
-        for example be set using ``-weasy-anchor: attr(id)``.
+        for example be set using ``-weasy-anchor: "id"``.
         See https://www.w3.org/TR/CSS/#proprietary
     :param unstable:
         Mark properties that are defined in specifications that didn't reach
@@ -1880,13 +1880,8 @@ def size(tokens):
 @single_token
 def anchor(token):
     """Validation for ``anchor``."""
-    if get_keyword(token) == 'none':
-        return 'none'
-    function = Function(token)
-    if arguments := function.split_space():
-        prototype = (function.name, [argument.type for argument in arguments])
-        if prototype == ('attr', ['ident']):
-            return ('attr()', arguments[0].value)
+    if token.type == 'string':
+        return token.value
 
 
 @property(proprietary=True, wants_base_url=True)

--- a/weasyprint/formatting_structure/build.py
+++ b/weasyprint/formatting_structure/build.py
@@ -195,6 +195,7 @@ def element_to_box(element, style_for, get_image_from_uri, base_url,
 
         if child_boxes and child_boxes[0].style['float'] == 'footnote':
             footnote = child_boxes[0]
+            footnote.style = footnote.style.copy()
             footnote.style['float'] = 'none'
             footnotes.append(footnote)
             call_style = style_for(footnote.element, 'footnote-call')

--- a/weasyprint/formatting_structure/build.py
+++ b/weasyprint/formatting_structure/build.py
@@ -422,6 +422,14 @@ def compute_content_list(content_list, parent_box, counter_values, css_token,
             if image is not None:
                 content_boxes.append(
                     boxes.InlineReplacedBox.anonymous_from(parent_box, image))
+        elif type_ == 'attr()':
+            attr_name, attr_type, attr_fallback = value
+            if attr_type == 'string':
+                add_text(parent_box.element.get(attr_name, ''))
+            else:
+                LOGGER.warning(
+                    'Only strings are allowed for content attr() functions,'
+                    f' not {attr_type}')
         elif type_ == 'content()':
             added_text = extract_text(value, parent_box)
             add_text(added_text)

--- a/weasyprint/urls.py
+++ b/weasyprint/urls.py
@@ -110,11 +110,9 @@ def get_url_attribute(element, attr_name, base_url, allow_relative=False):
     Otherwise return an URI, absolute if possible.
 
     """
-    value = element.get(attr_name, '').strip()
-    if value:
-        return url_join(
-            base_url or '', value, allow_relative, '<%s %s="%s">',
-            (element.tag, attr_name, value))
+    if value := element.get(attr_name, '').strip():
+        context = f'<{element.tag} {attr_name}="{value}">'
+        return url_join(base_url or '', value, allow_relative, context)
 
 
 def get_url_tuple(url, base_url):
@@ -127,7 +125,7 @@ def get_url_tuple(url, base_url):
         return ('external', iri_to_uri(urljoin(base_url, url)))
 
 
-def url_join(base_url, url, allow_relative, context, context_args):
+def url_join(base_url, url, allow_relative, context):
     """Like urllib.urljoin, but warn if base_url is required but missing."""
     if url_is_absolute(url):
         return iri_to_uri(url)
@@ -136,24 +134,21 @@ def url_join(base_url, url, allow_relative, context, context_args):
     elif allow_relative:
         return iri_to_uri(url)
     else:
-        LOGGER.error(
-            f'Relative URI reference without a base URI: {context}',
-            *context_args)
+        LOGGER.error(f'Relative URI reference without a base URI: {context}')
         return None
 
 
-def get_link_attribute(element, attr_name, base_url):
+def get_link(url, base_url):
     """Get the URL value of an element attribute.
 
     Return ``('external', absolute_uri)``, or ``('internal',
     unquoted_fragment_id)``, or ``None``.
 
     """
-    attr_value = element.get(attr_name, '').strip()
-    if attr_value.startswith('#') and len(attr_value) > 1:
+    if url.startswith('#') and len(url) > 1:
         # Do not require a base_url when the value is just a fragment.
-        return ('url', ('internal', unquote(attr_value[1:])))
-    uri = get_url_attribute(element, attr_name, base_url, allow_relative=True)
+        return ('url', ('internal', unquote(url[1:])))
+    uri = url_join(base_url or '', url, allow_relative=True, context=url)
     if uri:
         if base_url:
             try:


### PR DESCRIPTION
Removing lines of code to get the same documents with better performances is always a cool achievement. 😄

Most of the work has been done to remove the element from the computed style, so that we can share it between elements easily.

I get pretty good results, going from 52s, 1.68GB to 37s, 1.00GB with the large document I use for this kind of tests.

It probably requires more work and more tests, but that’s a start!