### PR TITLE
Support COLR fonts

### DIFF
--- a/tests/draw/svg/test_gradients.py
+++ b/tests/draw/svg/test_gradients.py
@@ -107,7 +107,7 @@ def test_linear_gradient_multicolor_userspace(assert_pixels):
     assert_pixels('''
         __________
         BBBBBBBBBB
-        BBBBBBBBBB
+        zBBBBBBBBz
         RRRRRRRRRR
         RRRRRRRRRR
         GGGGGGGGGG
@@ -806,6 +806,39 @@ def test_radial_gradient_userspace(assert_pixels):
           </radialGradient>
         </defs>
         <rect x="1" y="1" width="10" height="10" fill="url(#grad)" />
+      </svg>
+    ''')
+
+
+@assert_no_logs
+def test_radial_gradient_negative_rect_userspace(assert_pixels):
+    assert_pixels('''
+        ____________
+        rrrrrrrrrrr_
+        rrrrrrrrrrr_
+        rrrrrBBrrrr_
+        rrrrBBBBrrr_
+        rrrBBBBBBrr_
+        rrrBBBBBBrr_
+        rrrrBBBBrrr_
+        rrrrrBBrrrr_
+        rrrrrrrrrrr_
+        rrrrrrrrrrr_
+        ____________
+    ''', '''
+      <style>
+        @page { size: 12px }
+        svg { display: block }
+      </style>
+      <svg width="12px" height="12px" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <radialGradient id="grad" cx="6" cy="6" r="5" fx="6" fy="6" fr="2"
+            gradientUnits="userSpaceOnUse">
+            <stop stop-color="blue" offset="25%"></stop>
+            <stop stop-color="red" offset="25%"></stop>
+          </radialGradient>
+        </defs>
+        <rect x="-9" y="1" width="20" height="10" fill="url(#grad)" />
       </svg>
     ''')
 

--- a/weasyprint/draw/text.py
+++ b/weasyprint/draw/text.py
@@ -275,7 +275,13 @@ def draw_first_line(stream, textbox, text_overflow, block_ellipsis, matrix):
                     f = f * FROM_UNITS / font_size - font_size
                     emojis.append([image, font, a, d, x_advance, f])
             elif font.colr:
-                breakpoint()
+                svg_data = get_hb_object_data(font.hb_font, 'colr', glyph_id)
+                if svg_data:
+                    tree = ElementTree.fromstring(svg_data)
+                    image = SVGImage(tree, None, None, None)
+                    a = d = 1
+                    e = x_advance - kerning
+                    emojis.append([image, font, a, d, e, -textbox.baseline])
 
             x_advance += (logical_width + offset - kerning) / 1000
 

--- a/weasyprint/draw/text.py
+++ b/weasyprint/draw/text.py
@@ -274,6 +274,8 @@ def draw_first_line(stream, textbox, text_overflow, block_ellipsis, matrix):
                     f = -stream.logical_rect.y
                     f = f * FROM_UNITS / font_size - font_size
                     emojis.append([image, font, a, d, x_advance, f])
+            elif font.colr:
+                breakpoint()
 
             x_advance += (logical_width + offset - kerning) / 1000
 

--- a/weasyprint/draw/text.py
+++ b/weasyprint/draw/text.py
@@ -275,6 +275,8 @@ def draw_first_line(stream, textbox, text_overflow, block_ellipsis, matrix):
                     f = -stream.logical_rect.y
                     f = f * FROM_UNITS / font_size - font_size
                     emojis.append([image, font, a, d, x_advance, f])
+            elif font.colr:
+                breakpoint()
 
             x_advance += (logical_width + offset - kerning) / 1000
 

--- a/weasyprint/draw/text.py
+++ b/weasyprint/draw/text.py
@@ -276,7 +276,13 @@ def draw_first_line(stream, textbox, text_overflow, block_ellipsis, matrix):
                     f = f * FROM_UNITS / font_size - font_size
                     emojis.append([image, font, a, d, x_advance, f])
             elif font.colr:
-                breakpoint()
+                svg_data = get_hb_object_data(font.hb_font, 'colr', glyph_id)
+                if svg_data:
+                    tree = ElementTree.fromstring(svg_data)
+                    image = SVGImage(tree, None, None, None)
+                    a = d = 1
+                    e = x_advance - kerning
+                    emojis.append([image, font, a, d, e, -textbox.baseline])
 
             x_advance += (logical_width + offset - kerning) / 1000
 

--- a/weasyprint/pdf/fonts.py
+++ b/weasyprint/pdf/fonts.py
@@ -97,6 +97,10 @@ class Font:
         self.upem = harfbuzz.hb_face_get_upem(self.hb_face)
         self.png = harfbuzz.hb_ot_color_has_png(self.hb_face)
         self.svg = harfbuzz.hb_ot_color_has_svg(self.hb_face)
+        if harfbuzz.hb_version_atleast(7, 0, 0):
+            self.colr = harfbuzz.hb_ot_color_has_paint(self.hb_face)
+        else:
+            self.colr = False
         self.glyph_count = harfbuzz.hb_face_get_glyph_count(self.hb_face)
         self.stemv = 80
         self.stemh = 80
@@ -160,7 +164,7 @@ class Font:
                 self.file_content = partial_font.getvalue()
 
         # Remove images.
-        if self.png or self.svg:
+        if self.png or self.svg or self.colr:
             full_font = io.BytesIO(self.file_content)
             ttfont = TTFont(full_font, fontNumber=self.index)
             try:
@@ -175,7 +179,7 @@ class Font:
                 else:
                     for glyph in ttfont['glyf'].glyphs:
                         ttfont['glyf'][glyph] = ttFont.getTableModule('glyf').Glyph()
-                for table_name in ('CBDT', 'CBLC', 'SVG '):
+                for table_name in ('CBDT', 'CBLC', 'SVG ', 'COLR'):
                     if table_name in ttfont:
                         del ttfont[table_name]
                 output_font = io.BytesIO()

--- a/weasyprint/pdf/fonts.py
+++ b/weasyprint/pdf/fonts.py
@@ -12,8 +12,10 @@ from fontTools.varLib.instancer import instantiateVariableFont
 
 from ..logger import LOGGER
 from ..text.constants import PANGO_STRETCH_PERCENT
-from ..text.ffi import FROM_UNITS, ffi, harfbuzz, harfbuzz_subset, pango
 from ..text.fonts import get_hb_object_data, get_pango_font_hb_face
+
+from ..text.ffi import (  # isort:skip
+    FROM_UNITS, ffi, harfbuzz, harfbuzz_subset, harfbuzz_vector, pango)
 
 
 class Font:
@@ -98,7 +100,13 @@ class Font:
         self.png = harfbuzz.hb_ot_color_has_png(self.hb_face)
         self.svg = harfbuzz.hb_ot_color_has_svg(self.hb_face)
         if harfbuzz.hb_version_atleast(7, 0, 0):
-            self.colr = harfbuzz.hb_ot_color_has_paint(self.hb_face)
+            self.colr = (
+                harfbuzz.hb_ot_color_has_paint(self.hb_face) or
+                harfbuzz.hb_ot_color_has_layers(self.hb_face))
+            if self.colr and not harfbuzz_vector:
+                LOGGER.warning(
+                    'Please install harfbuzz-vector to display '
+                    f'"{self.family}" COLR emoji fonts.')
         else:
             self.colr = False
         self.glyph_count = harfbuzz.hb_face_get_glyph_count(self.hb_face)

--- a/weasyprint/pdf/fonts.py
+++ b/weasyprint/pdf/fonts.py
@@ -12,8 +12,10 @@ from fontTools.varLib.instancer import instantiateVariableFont
 
 from ..logger import LOGGER
 from ..text.constants import PANGO_STRETCH_PERCENT
-from ..text.ffi import FROM_UNITS, ffi, harfbuzz, harfbuzz_subset, pango
 from ..text.fonts import get_hb_object_data, get_pango_font_hb_face
+
+from ..text.ffi import (  # isort:skip
+    FROM_UNITS, ffi, harfbuzz, harfbuzz_subset, harfbuzz_vector, pango)
 
 
 class Font:
@@ -98,7 +100,13 @@ class Font:
         self.png = harfbuzz.hb_ot_color_has_png(self.hb_face)
         self.svg = harfbuzz.hb_ot_color_has_svg(self.hb_face)
         if harfbuzz.hb_version_atleast(7, 0, 0):
-            self.colr = harfbuzz.hb_ot_color_has_paint(self.hb_face)
+            self.colr = (
+                harfbuzz.hb_ot_color_has_paint(self.hb_face) or
+                harfbuzz.hb_ot_color_has_layers(self.hb_face))
+            if self.colr and not harfbuzz_vector:
+                LOGGER.warning(
+                    'Please install HarfBuzz version 13+ with harfbuzz-vector '
+                    'to display %s COLR emoji fonts.', self.family)
         else:
             self.colr = False
         self.glyph_count = harfbuzz.hb_face_get_glyph_count(self.hb_face)

--- a/weasyprint/svg/defs.py
+++ b/weasyprint/svg/defs.py
@@ -77,13 +77,11 @@ def draw_gradient(svg, node, gradient, font_size, opacity, stroke):
     if not is_valid_bounding_box(bounding_box):
         return False
     if gradient.get('gradientUnits') == 'userSpaceOnUse':
-        width, height = svg.inner_width, svg.inner_height
-        bx1, by1 = bounding_box[:2]
+        bx1, by1, width, height = bounding_box
         matrix = Matrix()
     else:
-        width, height = 1, 1
+        bx1, by1, width, height = 0, 0, 1, 1
         e, f, a, d = bounding_box
-        bx1, by1 = 0, 0
         matrix = Matrix(a=a, d=d, e=e, f=f)
 
     spread = gradient.get('spreadMethod', 'pad')

--- a/weasyprint/svg/text.py
+++ b/weasyprint/svg/text.py
@@ -156,7 +156,7 @@ def text(svg, node, font_size):
             (x_position + width, y_position - baseline + height))
         # TODO: Use ink extents instead of logical from line_break.line_size().
         node.text_bounding_box = extend_bounding_box(node.text_bounding_box, points)
-        layouts.append((layout, x_position, y_position, x, y, angle))
+        layouts.append((layout, x_position, y_position, x, y, angle, baseline))
 
     # Set state after we have bounding box for gradients and patterns, before drawing.
     svg.stream.push_state()
@@ -165,15 +165,16 @@ def text(svg, node, font_size):
 
     # Draw letters.
     emoji_lines = []
-    for layout, x_position, y_position, x, y, angle in layouts:
+    for layout, x_position, y_position, x, y, angle, baseline in layouts:
         layout.reactivate(style)
         svg.fill_stroke(fill, stroke, text=True)
         matrix = Matrix(a=scale_x, d=-1, e=x_position, f=y_position)
         if angle:
             a, c = cos(angle), sin(angle)
             matrix = Matrix(a, -c, c, a) @ matrix
-        emojis = draw_first_line(
-            svg.stream, TextBox(layout, style), 'none', 'none', matrix)
+        text_box = TextBox(layout, style)
+        text_box.baseline = baseline
+        emojis = draw_first_line(svg.stream, text_box, 'none', 'none', matrix)
         emoji_lines.append((x, y, emojis))
 
     svg.stream.end_text()

--- a/weasyprint/text/ffi.py
+++ b/weasyprint/text/ffi.py
@@ -32,6 +32,7 @@ ffi.cdef('''
     hb_blob_t * hb_ot_color_glyph_reference_png (hb_font_t *font, hb_codepoint_t glyph);
     bool hb_ot_color_has_svg (hb_face_t *face);
     hb_blob_t * hb_ot_color_glyph_reference_svg (hb_face_t *face, hb_codepoint_t glyph);
+    bool hb_ot_color_has_paint (hb_face_t *face);
     void hb_blob_destroy (hb_blob_t *blob);
     unsigned int hb_face_get_table_tags (
         const hb_face_t *face, unsigned int start_offset, unsigned int *table_count,

--- a/weasyprint/text/ffi.py
+++ b/weasyprint/text/ffi.py
@@ -32,6 +32,7 @@ ffi.cdef('''
     hb_blob_t * hb_ot_color_glyph_reference_png (hb_font_t *font, hb_codepoint_t glyph);
     bool hb_ot_color_has_svg (hb_face_t *face);
     hb_blob_t * hb_ot_color_glyph_reference_svg (hb_face_t *face, hb_codepoint_t glyph);
+    bool hb_ot_color_has_layers (hb_face_t *face);
     bool hb_ot_color_has_paint (hb_face_t *face);
     void hb_blob_destroy (hb_blob_t *blob);
     unsigned int hb_face_get_table_tags (
@@ -80,6 +81,27 @@ ffi.cdef('''
     void hb_subset_input_set_flags (hb_subset_input_t *input, unsigned  value);
     hb_set_t * hb_subset_input_set (
         hb_subset_input_t *input, hb_subset_sets_t set_type);
+
+    // Harfbuzz Vector
+
+    typedef enum {
+        HB_VECTOR_FORMAT_INVALID = 0,
+        HB_VECTOR_FORMAT_SVG = 1937139488, /* hb_tag('svg ') */
+        HB_VECTOR_FORMAT_PDF = 1885627936, /* hb_tag('pdf ') */
+    } hb_vector_format_t;
+
+    typedef enum {
+        HB_VECTOR_EXTENTS_MODE_NONE,
+        HB_VECTOR_EXTENTS_MODE_EXPAND,
+    } hb_vector_extents_mode_t;
+
+    typedef ... hb_vector_paint_t;
+
+    hb_vector_paint_t * hb_vector_paint_create_or_fail (hb_vector_format_t format);
+    void hb_vector_paint_glyph(
+        hb_vector_paint_t *paint, hb_font_t *font, hb_codepoint_t glyph,
+        hb_vector_extents_mode_t extents_mode);
+    hb_blob_t * hb_vector_paint_render (hb_vector_paint_t *paint);
 
     // Pango
 
@@ -489,6 +511,10 @@ harfbuzz = _dlopen(
 harfbuzz_subset = _dlopen(
     ffi, 'libharfbuzz-subset-0', 'harfbuzz-subset', 'harfbuzz-subset-0.0',
     'libharfbuzz-subset.so.0', 'libharfbuzz-subset.0.dylib', 'libharfbuzz-subset-0.dll',
+    allow_fail=True)
+harfbuzz_vector = _dlopen(
+    ffi, 'libharfbuzz-vector-0', 'harfbuzz-vector', 'harfbuzz-vector-0.0',
+    'libharfbuzz-vector.so.0', 'libharfbuzz-vector.0.dylib', 'libharfbuzz-vector-0.dll',
     allow_fail=True)
 fontconfig = _dlopen(
     ffi, 'libfontconfig-1', 'fontconfig-1', 'fontconfig',

--- a/weasyprint/text/fonts.py
+++ b/weasyprint/text/fonts.py
@@ -18,8 +18,8 @@ from .constants import (  # isort:skip
     CAPS_KEYS, EAST_ASIAN_KEYS, FONTCONFIG_STRETCH, FONTCONFIG_STYLE, FONTCONFIG_WEIGHT,
     LIGATURE_KEYS, NUMERIC_KEYS, PANGO_STRETCH, PANGO_STYLE, PANGO_VARIANT)
 from .ffi import (  # isort:skip
-    FROM_UNITS, TO_UNITS, ffi, fontconfig, gobject, harfbuzz, pango, pangoft2,
-    unicode_to_char_p)
+    FROM_UNITS, TO_UNITS, ffi, fontconfig, gobject, harfbuzz, harfbuzz_vector, pango,
+    pangoft2, unicode_to_char_p)
 
 PREFERRED_ENCODING = getpreferredencoding(False)
 
@@ -366,6 +366,14 @@ def get_hb_object_data(hb_object, ot_color=None, glyph=None):
         hb_blob = harfbuzz.hb_ot_color_glyph_reference_png(hb_object, glyph)
     elif ot_color == 'svg':
         hb_blob = harfbuzz.hb_ot_color_glyph_reference_svg(hb_object, glyph)
+    elif ot_color == 'colr':
+        if not harfbuzz_vector:
+            return
+        paint = harfbuzz_vector.hb_vector_paint_create_or_fail(
+            harfbuzz_vector.HB_VECTOR_FORMAT_SVG)
+        harfbuzz_vector.hb_vector_paint_glyph(
+            paint, hb_object, glyph, harfbuzz.HB_VECTOR_EXTENTS_MODE_EXPAND)
+        hb_blob = harfbuzz_vector.hb_vector_paint_render(paint)
     else:
         hb_blob = harfbuzz.hb_face_reference_blob(hb_object)
     with ffi.new('unsigned int *') as length:

--- a/weasyprint/text/fonts.py
+++ b/weasyprint/text/fonts.py
@@ -18,8 +18,8 @@ from .constants import (  # isort:skip
     CAPS_KEYS, EAST_ASIAN_KEYS, FONTCONFIG_STRETCH, FONTCONFIG_STYLE, FONTCONFIG_WEIGHT,
     LIGATURE_KEYS, NUMERIC_KEYS, PANGO_STRETCH, PANGO_STYLE, PANGO_VARIANT)
 from .ffi import (  # isort:skip
-    FROM_UNITS, TO_UNITS, ffi, fontconfig, gobject, harfbuzz, pango, pangoft2,
-    unicode_to_char_p)
+    FROM_UNITS, TO_UNITS, ffi, fontconfig, gobject, harfbuzz, harfbuzz_vector, pango,
+    pangoft2, unicode_to_char_p)
 
 PREFERRED_ENCODING = getpreferredencoding(False)
 
@@ -367,6 +367,14 @@ def get_hb_object_data(hb_object, ot_color=None, glyph=None):
         hb_blob = harfbuzz.hb_ot_color_glyph_reference_png(hb_object, glyph)
     elif ot_color == 'svg':
         hb_blob = harfbuzz.hb_ot_color_glyph_reference_svg(hb_object, glyph)
+    elif ot_color == 'colr':
+        if not harfbuzz_vector:
+            return
+        paint = harfbuzz_vector.hb_vector_paint_create_or_fail(
+            harfbuzz_vector.HB_VECTOR_FORMAT_SVG)
+        harfbuzz_vector.hb_vector_paint_glyph(
+            paint, hb_object, glyph, harfbuzz.HB_VECTOR_EXTENTS_MODE_EXPAND)
+        hb_blob = harfbuzz_vector.hb_vector_paint_render(paint)
     else:
         hb_blob = harfbuzz.hb_face_reference_blob(hb_object)
     with ffi.new('unsigned int *') as length:


### PR DESCRIPTION
A few notes:

- It works with Noto, to be tested with other fonts.
- PDF renderers are not all happy with the result:
  - Chrome is perfect, 
  - Firefox is a bit slow and misses some gradients, 
  - Epiphany is randomly broken,
  - Poppler is ultra slow but renders correctly,
  - Ghostscript fails with an endless loop.
- The code relies on Harfbuzz 13+ and Harfbuzz-Vector, that is not packaged for Debian/Ubuntu for example,
- So… it can’t be tested on GitHub CI.

We have to do better before merging.
