### PR TITLE
Resolve calc() division by zero to infinity instead of crashing

### DIFF
--- a/tests/css/test_math.py
+++ b/tests/css/test_math.py
@@ -88,6 +88,38 @@ def test_math_functions(width):
 
 
 @assert_no_logs
+@pytest.mark.parametrize(('width', 'reference'), [
+    # A positive numerator over zero is +infinity, ...
+    ('calc(100px / 0)', 'calc(infinity * 1px)'),
+    ('calc(50px / 0)', 'calc(infinity * 1px)'),
+    ('calc(10em / 0)', 'calc(infinity * 1px)'),
+    # ... a negative numerator is -infinity, ...
+    ('calc(-100px / 0)', 'calc(-infinity * 1px)'),
+    # ... and zero over zero is NaN.
+    ('calc(0px / 0)', 'calc(nan * 1px)'),
+    # The divisor may evaluate to zero rather than being a literal zero.
+    ('calc(100px / (1 - 1))', 'calc(infinity * 1px)'),
+    # The resulting infinity keeps propagating through later operations.
+    ('calc(100px / 0 + 100px)', 'calc(infinity * 1px)'),
+    ('calc(-1px / 0 * 100)', 'calc(-infinity * 1px)'),
+])
+def test_calc_division_by_zero(width, reference):
+    # A division by zero inside calc() resolves to +/-infinity or NaN
+    # (IEEE-754), as required by CSS Values and Units 4, instead of raising a
+    # ZeroDivisionError. The result must match the equivalent calc(infinity *
+    # ...) / calc(nan * ...) expression that WeasyPrint already supports.
+    def render(value):
+        page, = render_pages(
+            '<div style="font-size: 10px; height: 1px; width: %s"></div>'
+            % value)
+        html, = page.children
+        body, = html.children
+        div, = body.children
+        return div.width
+    assert render(width) == render(reference)
+
+
+@assert_no_logs
 @pytest.mark.parametrize('width', [
     'calc',
     '(calc)',

--- a/weasyprint/css/__init__.py
+++ b/weasyprint/css/__init__.py
@@ -720,6 +720,11 @@ def _resolve_calc_product(computed, tokens, property_name, refer_to):
                     unit = '%'
             if sign == '*':
                 value *= calc.value
+            elif calc.value == 0:
+                # Division by zero resolves to ±infinity or NaN (IEEE-754), as
+                # required by CSS Values 4, instead of raising. This matches the
+                # value of an equivalent calc(infinity * ...) expression.
+                value = math.nan if value == 0 else math.copysign(inf, value)
             else:
                 value /= calc.value
             sign = None


### PR DESCRIPTION
### The bug

A division by zero inside a `calc()` expression raises `ZeroDivisionError` and aborts the entire render:

```python
from weasyprint import HTML
HTML(string='<div style="width: calc(100px / 0)">x</div>').write_pdf()
# Traceback ...
#   File ".../weasyprint/css/__init__.py", line 724, in _resolve_calc_product
#     value /= calc.value
# ZeroDivisionError: division by zero
```

It also fires when the divisor merely *evaluates* to zero, e.g. `calc(100px / (1 - 1))`.

### Why the expected behaviour is unambiguous

[CSS Values and Units 4 §10.10](https://www.w3.org/TR/css-values-4/#calc-type-checking) requires a division by zero to resolve to `+∞`, `−∞`, or `NaN` following IEEE-754, not to be an error: a positive numerator gives `+∞`, a negative one `−∞`, and `0 / 0` gives `NaN`. WeasyPrint already supports infinite and NaN values in `calc()` (`calc(infinity * 1px)`, `calc(nan * 1px)`, and the `clamp()` tests use `calc(-infinity * 1px)`), so only the division operator was missing the case.

### The fix

In `_resolve_calc_product`, when the divisor is zero, produce `±infinity`/`NaN` (IEEE-754) instead of dividing. The result is identical to the equivalent `calc(infinity * …)` / `calc(nan * …)` expression, which then flows through the existing infinity handling (an infinite width renders as `inf`, a negative-infinite/NaN width clamps to `0`, exactly as the keyword forms already do).

### Tests

`test_calc_division_by_zero` asserts the rendered width of each division-by-zero form equals that of its `calc(infinity * …)` / `calc(nan * …)` counterpart — covering positive/negative numerators, relative units, a divisor that evaluates to zero, `0 / 0` (NaN), and infinity propagating through a following `+`/`*`. All eight cases fail on `main` with the original `ZeroDivisionError` and pass with the fix; the full `tests/css/test_math.py` (439 passed) and `test_validation.py` stay green, `ruff check` clean.
