### PR TITLE
Ignore unresolvable math in border-image-slice/mask-border-slice instead of crashing

### DIFF
--- a/tests/css/test_validation.py
+++ b/tests/css/test_validation.py
@@ -10,7 +10,7 @@ from weasyprint.css import preprocess_declarations
 from weasyprint.css.validation.properties import PROPERTIES
 from weasyprint.images import LinearGradient, RadialGradient
 
-from ..testing_utils import assert_no_logs, capture_logs
+from ..testing_utils import assert_no_logs, capture_logs, render_pages
 
 
 def get_value(css, expected_error=None, level=None):
@@ -375,6 +375,9 @@ def test_image_orientation_invalid(rule):
     ('1% 2% 3% 4%', ((1, '%'), (2, '%'), (3, '%'), (4, '%'))),
     ('fill 10% 20', ('fill', (10, '%'), (20, None))),
     ('0 1 0.5 fill', ((0, None), (1, None), (0.5, None), 'fill')),
+    ('calc(10%)', ((10, '%'),)),
+    ('min(10%, 20%)', ((10, '%'),)),
+    ('clamp(0%, 50%, 100%) fill', ((50, '%'), 'fill')),
 ])
 def test_border_image_slice(rule, value):
     assert get_value(f'border-image-slice: {rule}') == value
@@ -390,9 +393,34 @@ def test_border_image_slice(rule, value):
     '-0.3',
     '1 fill 2',
     'fill 1 2 3 fill',
+    # A math function that cannot resolve to a number or percentage must be
+    # rejected, not crash with an AttributeError on a FunctionBlock.
+    'scale(calc(0))',
+    'min(0px, 0)',
 ])
 def test_border_image_slice_invalid(rule):
     assert_invalid(f'border-image-slice: {rule}')
+
+
+@assert_no_logs
+@pytest.mark.parametrize(('prop', 'value'), [
+    ('border-image-slice', 'scale(calc(0))'),
+    ('border-image-slice', 'min(0px, 0)'),
+    ('mask-border-slice', 'scale(calc(0))'),
+    ('mask-border-slice', 'rgb(calc(0%) 0 0)'),
+])
+def test_border_image_slice_math_no_crash(prop, value):
+    # Regression test: an unresolvable math function in *-border-slice used to
+    # raise an AttributeError out of get_percentage that aborted the whole
+    # render. It must instead be ignored with an "invalid value" warning.
+    with capture_logs() as logs:
+        page, = render_pages(f'<div style="{prop}: {value}">a</div>')
+    assert len(logs) == 1
+    assert 'invalid value' in logs[0]
+    # The page still renders.
+    html, = page.children
+    body, = html.children
+    assert body.children
 
 
 @assert_no_logs
@@ -498,6 +526,8 @@ def test_mask_border_slice(rule, value):
     '-0.3',
     '1 fill 2',
     'fill 1 2 3 fill',
+    'scale(calc(0))',
+    'rgb(calc(0%) 0 0)',
 ])
 def test_mask_border_slice_invalid(rule):
     assert_invalid(f'mask-border-slice: {rule}')

--- a/weasyprint/css/tokens.py
+++ b/weasyprint/css/tokens.py
@@ -390,8 +390,10 @@ def get_percentage(token, negative=True):
         except (PercentageInMath, RelativeLengthInMath):
             return
         else:
-            # Range clamp.
-            if not negative:
+            # Range clamp. Skip function/number tokens, which have no value to
+            # clamp: a math function wrapping a non-resolvable argument (e.g.
+            # scale(calc(0))) stays a FunctionBlock here, like in get_length().
+            if not negative and token.type not in ('function', 'number'):
                 token.value = max(0, token.value)
     if token.type == 'percentage' and (negative or token.value >= 0):
         return Dimension(token.value, '%')

--- a/weasyprint/css/tokens.py
+++ b/weasyprint/css/tokens.py
@@ -390,10 +390,8 @@ def get_percentage(token, negative=True):
         except (PercentageInMath, RelativeLengthInMath):
             return
         else:
-            # Range clamp. Skip function/number tokens, which have no value to
-            # clamp: a math function wrapping a non-resolvable argument (e.g.
-            # scale(calc(0))) stays a FunctionBlock here, like in get_length().
-            if not negative and token.type not in ('function', 'number'):
+            # Range clamp percentages.
+            if token.type == 'percentage' and not negative:
                 token.value = max(0, token.value)
     if token.type == 'percentage' and (negative or token.value >= 0):
         return Dimension(token.value, '%')


### PR DESCRIPTION
### The bug

A math function that can't resolve to a number or percentage inside `border-image-slice` (or `mask-border-slice`) crashes the **entire** render with an uncaught `AttributeError`, instead of the declaration being ignored:

```python
import io
from weasyprint import HTML
HTML(string='<style>div{border-image-slice:scale(calc(0))}</style><div>x</div>').write_pdf(io.BytesIO())
# Traceback ...
#   File ".../weasyprint/css/tokens.py", line 395, in get_percentage
#     token.value = max(0, token.value)
# AttributeError: 'FunctionBlock' object has no attribute 'value'
```

Also triggered by `border-image-slice: min(0px, 0)` and `mask-border-slice: rgb(calc(0%) 0 0)`. Since WeasyPrint is routinely used to render untrusted HTML/CSS to PDF, a single malformed value taking down the whole render is a robustness problem.

### Why the expected behaviour is unambiguous

WeasyPrint's CSS pipeline is built on the invariant that an invalid declaration is dropped with an *"invalid value"* warning and rendering continues — `preprocess_declarations` catches `InvalidValues`, but any *other* exception escapes. The sibling parser in the same file, `get_length()` (line 415), already guards exactly this case:

```python
if not negative and token.type not in ('function', 'number'):
    token.value = max(0, token.value)
```

`get_percentage()` (line 394) omitted the `token.type` check, so `width: scale(calc(0))` (via `get_length`) is gracefully ignored while `border-image-slice: scale(calc(0))` (via `get_percentage`) crashes.

### Root cause

In `get_percentage()`, `token = resolve_math(token) or token` can leave a `FunctionBlock`: a non-math function wrapping a math argument (`scale(calc(0))`) is rebuilt and returned by `resolve_math`, and a function whose math can't resolve (`min(0px, 0)`) makes `resolve_math` return `None`, so `or token` reverts to the original function block. The unconditional `token.value = max(0, token.value)` then fails because a `FunctionBlock` has no `.value`.

### The fix

Add the same `token.type not in ('function', 'number')` guard `get_length()` uses. The function token then falls through to `if token.type == 'percentage'` (False) and the value is rejected as invalid.

### Tests

In `tests/css/test_validation.py`: the crashing inputs are added to `test_border_image_slice_invalid` and `test_mask_border_slice_invalid` (must be rejected, not crash); valid math (`calc(10%)`, `min(10%, 20%)`, `clamp(0%, 50%, 100%) fill`) is added to `test_border_image_slice` to pin that the guard doesn't reject legitimate math; and a new `test_border_image_slice_math_no_crash` renders the malformed CSS through `render_pages` for both properties, asserting exactly one *"invalid value"* warning and that the page still renders (the actual reported symptom). All eight new/changed cases fail on `main` with the original `AttributeError` and pass with the fix; the full `tests/css/` suite stays green (2127 passed), `ruff check` clean.
