### PR TITLE
Don't forget children overflowing fixed-height boxes at page breaks

### DIFF
--- a/tests/draw/test_overflow.py
+++ b/tests/draw/test_overflow.py
@@ -116,6 +116,46 @@ def test_overflow_5(assert_pixels):
 
 
 @assert_no_logs
+@pytest.mark.parametrize('edge', (
+    'border: 2px solid blue',
+    'padding: 2px; background: blue',
+))
+def test_overflow_6(edge, assert_pixels):
+    # Regression test for #2798. The second div’s unbreakable border or
+    # padding overflows the page bottom, the following text must not be
+    # forgotten but rendered on the next page.
+    assert_pixels('''
+        RRRRRRRR
+        RRRRRRRR
+        RRRRRRRR
+        RRRRRRRR
+        RRRRRRRR
+        BBBBBBBB
+        BBBBBBBB
+        BBBBBBBB
+
+        BBBB____
+        BBBB____
+        ________
+        ________
+        ________
+        ________
+        ________
+        ________
+    ''', f'''
+      <style>
+        @page {{ size: 8px }}
+        html {{ height: 100% }}
+        body {{ color: blue; font-family: weasyprint; line-height: 1;
+                font-size: 2px }}
+      </style>
+      <div style="height: 5px; background: red"></div>
+      <div style="{edge}"></div>
+      ab
+      ''')
+
+
+@assert_no_logs
 @pytest.mark.parametrize(('number', 'css', 'pixels'), [
     (1, '5px, 5px, 9px, auto', '''
         ______________

--- a/tests/draw/test_overflow.py
+++ b/tests/draw/test_overflow.py
@@ -116,10 +116,10 @@ def test_overflow_5(assert_pixels):
 
 
 @assert_no_logs
-@pytest.mark.parametrize('edge', (
+@pytest.mark.parametrize('edge', [
     'border: 2px solid blue',
     'padding: 2px; background: blue',
-))
+])
 def test_overflow_6(edge, assert_pixels):
     # Regression test for #2798. The second div’s unbreakable border or
     # padding overflows the page bottom, the following text must not be
@@ -152,6 +152,36 @@ def test_overflow_6(edge, assert_pixels):
       <div style="height: 5px; background: red"></div>
       <div style="{edge}"></div>
       ab
+      ''')
+
+
+@assert_no_logs
+@pytest.mark.parametrize('edge', [
+    'border: 2px solid blue',
+    'padding: 2px; background: blue',
+])
+def test_overflow_7(edge, assert_pixels):
+    assert_pixels('''
+        RRRRRRRR
+        RRRRRRRR
+        RRRRRRRR
+        RRRRRRRR
+        RRRRRRRR
+        BBBBBBBB
+        BBBBBBBB
+        BBBBBBBB
+    ''', '''
+      <style>
+        @page { size: 8px }
+        body { color: blue; font-family: weasyprint; line-height: 1;
+                font-size: 2px }
+        article { height: 8px }
+      </style>
+      <article>
+        <div style="height: 5px; background: red"></div>
+        <div style="{edge}"></div>
+        ab
+      </article>
       ''')
 
 

--- a/weasyprint/layout/block.py
+++ b/weasyprint/layout/block.py
@@ -810,9 +810,14 @@ def block_container_layout(context, box, bottom_space, skip_stack, page_is_empty
             if box.height != 'auto':
                 box_bottom = box.position_y + box.border_height()
                 bottom_margin = collapse_margin(adjoining_margins)
-                if context.overflows(box_bottom, position_y - bottom_margin):
-                    # Box height is fixed and it overflows the page, forget
-                    # overflowing children.
+                content_bottom = position_y - bottom_margin
+                if (context.overflows(box_bottom, content_bottom) and
+                        not context.overflows_page(bottom_space, content_bottom)):
+                    # Box height is fixed and children overflow its bottom
+                    # inside the current page, forget overflowing children. If
+                    # children also overflow the page, the break is a page
+                    # break and the next children have to be rendered on the
+                    # next page.
                     resume_at = None
             adjoining_margins = []
             break


### PR DESCRIPTION
When a fixed-height box stops its layout with content past its bottom, the remaining children were always forgotten. But when the last child's border or padding cannot be fragmented and pushes the content past the page bottom itself, the stop is a page break: the remaining children must be rendered on the next page instead of being silently discarded.

Only forget overflowing children when the content bottom stays within the current page.

Fixes #2798.