### PR TITLE
Transform SVG size into CSS to apply the CSS sizing algorithm

### DIFF
--- a/tests/draw/test_image.py
+++ b/tests/draw/test_image.py
@@ -186,6 +186,7 @@ def test_resized_images(assert_pixels, filename):
       <div><img src="%s"></div>''' % filename)
 
 
+@assert_no_logs
 def test_image_overflow(assert_pixels):
     assert_pixels(centered_image_overflow, '''
       <style>
@@ -222,6 +223,26 @@ def test_svg_sizing(assert_pixels, viewbox, width, height):
 
 
 @assert_no_logs
+@pytest.mark.parametrize('attributes', [
+    'style="width: 100%; height: 100%"',
+    'width="100%" height="100%"',
+])
+def test_svg_sizing_percentage(assert_pixels, attributes):
+    assert_pixels(centered_image, '''
+      <style>
+        @page { size: 8px }
+        body { margin: 2px 0 0 0; font-size: 0 }
+        svg { display: block }
+      </style>
+      <div style="height: 4px">
+        <svg viewBox="0 0 8 8" %s>
+          <rect width="8" height="8" fill="#00f" />
+          <rect width="2" height="2" fill="#f00" />
+        </svg>
+      </div>''' % attributes)
+
+
+@assert_no_logs
 @pytest.mark.parametrize(('viewbox', 'width', 'height', 'image'), [
     (None, None, None, small_resized_image),
     (None, 8, None, small_resized_image),
@@ -231,7 +252,6 @@ def test_svg_sizing(assert_pixels, viewbox, width, height):
     ('0 0 4 4', 8, None, resized_image),
     ('0 0 4 4', None, 8, resized_image),
     ('0 0 4 4', 8, 8, resized_image),
-    ('0 0 4 4', 800, 800, resized_image),
 ])
 def test_svg_resizing(assert_pixels, viewbox, width, height, image):
     assert_pixels(image, '''

--- a/weasyprint/css/__init__.py
+++ b/weasyprint/css/__init__.py
@@ -40,8 +40,8 @@ from .validation.properties import validate_non_shorthand
 
 from .tokens import (  # isort:skip
     E, MINUS_INFINITY, NAN, PI, PLUS_INFINITY, InvalidValues, Pending, PercentageInMath,
-    RelativeLengthInMath, get_angle, get_url, remove_whitespace, split_on_comma,
-    tokenize)
+    RelativeLengthInMath, get_angle, get_length, get_url, remove_whitespace,
+    split_on_comma, tokenize)
 
 # Reject anything not in here:
 PSEUDO_ELEMENTS = frozenset((
@@ -366,6 +366,16 @@ def find_style_attributes(tree, presentational_hints=False, base_url=None):
             if name := element.get('name'):
                 yield parse_declaration(f'-weasy-anchor:"{name}"')
 
+        if element.tag == '{http://www.w3.org/2000/svg}svg':
+            # Handle presentation attributes. Only do that for height and width at top
+            # level now, so that intrinsic size is defined by CSS, not SVG.
+            # See: https://www.w3.org/TR/SVG2/styling.html#PresentationAttributes.
+            for attribute in ('width', 'height'):
+                if length := element.get(attribute):
+                    token = tinycss2.parse_one_component_value(length)
+                    if get_length(token, percentage=True):
+                        yield parse_declaration(f'{attribute}:{length}')
+
         # Apply presentational hints.
         if not presentational_hints:
             continue
@@ -528,9 +538,7 @@ def find_style_attributes(tree, presentational_hints=False, base_url=None):
             if color := element.get('color'):
                 color = html.parse_legacy_color(color)
                 yield parse_declaration(f'color:{color}')
-        elif element.tag in (
-                'iframe', 'applet', 'embed', 'img', 'input', 'object',
-                '{http://www.w3.org/2000/svg}svg'):
+        elif element.tag in ('iframe', 'applet', 'embed', 'img', 'input', 'object'):
             if element.tag != 'input' or element.get('type', '').lower() == 'image':
                 align = element.get('align', '').lower()
                 if align in ('middle', 'center'):


### PR DESCRIPTION
That’s a more reliable way to fix #2556. Without that, dimensions with units different from pixels and percentages were transformed into pixels by the HTML attribute parser.