### PR TITLE
Don't let a deferred float inflate its block formatting context

### DIFF
--- a/tests/layout/test_float.py
+++ b/tests/layout/test_float.py
@@ -308,17 +308,11 @@ def test_float_overflow_splits_formatting_context():
     # context on the current page, or the whole block is pushed to the next page
     # instead of being split across the page break.
     page_1, page_2 = render_pages('''
-      <style>
-        @page { size: 100px; margin: 0 }
-        body { margin: 0 }
-        div.bfc { display: flow-root }
-        p { height: 20px; margin: 0 }
-        div.float { float: right; width: 30px; height: 40px }
-      </style>
+      <style>@page { size: 100px }</style>
       <div style="height: 70px"></div>
-      <div class="bfc">
-        <p>a</p>
-        <div class="float"></div>
+      <div style="display: flow-root">
+        <p style="height: 20px">a</p>
+        <div style="float: right; width: 30px; height: 40px"></div>
         <p>b</p>
       </div>
     ''')

--- a/tests/layout/test_float.py
+++ b/tests/layout/test_float.py
@@ -303,6 +303,48 @@ def test_floats_page_breaks_3():
 
 
 @assert_no_logs
+def test_float_overflow_splits_formatting_context():
+    # A deferred (overflowing) float must not inflate its block formatting
+    # context on the current page, or the whole block is pushed to the next page
+    # instead of being split across the page break.
+    page_1, page_2 = render_pages('''
+      <style>
+        @page { size: 100px; margin: 0 }
+        body { margin: 0 }
+        div.bfc { display: flow-root }
+        p { height: 20px; margin: 0 }
+        div.float { float: right; width: 30px; height: 40px }
+      </style>
+      <div style="height: 70px"></div>
+      <div class="bfc">
+        <p>a</p>
+        <div class="float"></div>
+        <p>b</p>
+      </div>
+    ''')
+
+    # Page 1 keeps the spacer and the first paragraph: the block is split, not
+    # deferred whole.
+    html, = page_1.children
+    body, = html.children
+    spacer, bfc_1 = body.children
+    assert spacer.height == 70
+    paragraph_a, = bfc_1.children
+    assert paragraph_a.element_tag == 'p'
+    assert paragraph_a.position_y == 70
+
+    # Page 2 resumes the block with the deferred float and the last paragraph.
+    html, = page_2.children
+    body, = html.children
+    bfc_2, = body.children
+    float_box, paragraph_b = bfc_2.children
+    assert float_box.is_floated()
+    assert float_box.position_y == 0
+    assert paragraph_b.element_tag == 'p'
+    assert paragraph_b.position_y == 0
+
+
+@assert_no_logs
 def test_preferred_widths_1():
     def get_float_width(body_width):
         page, = render_pages('''

--- a/weasyprint/layout/block.py
+++ b/weasyprint/layout/block.py
@@ -285,11 +285,7 @@ def _out_of_flow_layout(context, box, index, child, new_children,
             resume_at = {index: None}
             out_of_flow_resume_at = None
             stop = True
-            # Deferred to the next page: drop the float from the excluded shapes
-            # so it doesn’t inflate this fragment and push the whole block down.
-            context.excluded_shapes = [
-                shape for shape in context.excluded_shapes
-                if shape is not new_child]
+            remove_placeholders(context, [new_child], absolute_boxes, fixed_boxes)
             if new_children and avoid_page_break(page_break, context):
                 # Can’t break inside float, find an earlier page break.
                 result = find_earlier_page_break(
@@ -1111,8 +1107,7 @@ def remove_placeholders(context, box_list, absolute_boxes, fixed_boxes):
     """
     for box in box_list:
         if isinstance(box, boxes.ParentBox):
-            remove_placeholders(
-                context, box.children, absolute_boxes, fixed_boxes)
+            remove_placeholders(context, box.children, absolute_boxes, fixed_boxes)
         if box.style['position'] == 'absolute' and box in absolute_boxes:
             absolute_boxes.remove(box)
         elif box.style['position'] == 'fixed' and box in fixed_boxes:
@@ -1121,6 +1116,8 @@ def remove_placeholders(context, box_list, absolute_boxes, fixed_boxes):
             context.unlayout_footnote(box.footnote)
         if box in context.broken_out_of_flow:
             context.broken_out_of_flow.pop(box)
+        if box in context.excluded_shapes:
+            context.excluded_shapes.remove(box)
 
 
 def avoid_page_break(page_break, context):

--- a/weasyprint/layout/block.py
+++ b/weasyprint/layout/block.py
@@ -285,6 +285,11 @@ def _out_of_flow_layout(context, box, index, child, new_children,
             resume_at = {index: None}
             out_of_flow_resume_at = None
             stop = True
+            # Deferred to the next page: drop the float from the excluded shapes
+            # so it doesn’t inflate this fragment and push the whole block down.
+            context.excluded_shapes = [
+                shape for shape in context.excluded_shapes
+                if shape is not new_child]
             if new_children and avoid_page_break(page_break, context):
                 # Can’t break inside float, find an earlier page break.
                 result = find_earlier_page_break(


### PR DESCRIPTION
## What's wrong

When a block that establishes a block formatting context (`display: flow-root`, `overflow` other than `visible`, etc.) contains floats, a float that doesn't fit on the current page can push the **entire** block to the next page

This is very visible in print documents full of figures that use `float` + wrapping text: blocks jump to a fresh page instead of partially filling the current one.

## Minimal example

```html
<style>
  @page { size: 100px; margin: 0 }
  body { margin: 0 }
  div.bfc { display: flow-root }
  p { height: 20px; margin: 0 }
  div.float { float: right; width: 30px; height: 40px }
</style>
<div style="height: 70px"></div>
<div class="bfc">
  <p>a</p>
  <div class="float"></div>
  <p>b</p>
</div>
```
- **Expected:** page 1 = spacer + `a`; page 2 = float + `b`.
- **Actual:** page 1 = spacer only; the whole `.bfc` (both paragraphs *and* the float) is pushed to page 2, wasting ~30px of page 1.

## Cause

`float_layout` appends every laid-out float to `context.excluded_shapes`. When the float overflows and `_out_of_flow_layout` breaks *before* it (deferring it to the next page via `resume_at`), the float is left in `excluded_shapes`.

`finish_block_formatting_context` then grows the BFC box's height to `max(shape bottoms)` including the deferred float, which floated up beside the content that stays on the page. The fragment's height therefore exceeds the page, the caller rejects it, and the whole block is moved to the next page instead of keeping the part that fits.

## Fix

When breaking before an overflowing float, drop it from the current formatting context's excluded shapes so it no longer inflates the fragment that stays on the page:

```python
context.excluded_shapes = [
    shape for shape in context.excluded_shapes
    if shape is not new_child]
```

## Test

Adds `test_float_overflow_splits_formatting_context` in `tests/layout/test_float.py`, reproducing the example above and asserting the block is split (paragraph `a` stays on page 1). It fails before the change and passes after. The full `tests/layout/` suite passes with the change.
