### PR TITLE
Keep side-by-side floats on the same page

### DIFF
--- a/tests/layout/test_float.py
+++ b/tests/layout/test_float.py
@@ -272,6 +272,27 @@ def test_floats_page_breaks_2():
 
 
 @assert_no_logs
+def test_floats_page_breaks_side_by_side():
+    # Don’t move an overflowing float when it’s next to another float.
+    page, = render_pages('''
+      <style>
+        @page { size: 100px; margin: 10px }
+        div { height: 81px; float: left }
+        .left { width: 20% }
+        .right { width: 80% }
+      </style>
+      <div class="left">left</div>
+      <div class="right">right</div>
+    ''')
+
+    divs = [
+        box for box in page.descendants()
+        if box.element_tag == 'div' and box.is_floated()]
+    assert [(div.position_x, div.position_y) for div in divs] == [
+        (10, 10), (26, 10)]
+
+
+@assert_no_logs
 def test_floats_page_breaks_3():
     # Tests floated images shorter than the page
     pages = render_pages('''

--- a/weasyprint/layout/block.py
+++ b/weasyprint/layout/block.py
@@ -270,7 +270,8 @@ def _out_of_flow_layout(context, box, index, child, new_children,
         page_overflow = context.overflows_page(
             bottom_space, new_child.position_y + new_child.height)
         add_child = (
-            (page_is_empty and not new_children) or
+            (page_is_empty and (
+                not new_children or new_child.position_y == box.content_box_y())) or
             not page_overflow or
             box.is_monolithic())
         if add_child:


### PR DESCRIPTION
Fixes #2790.

An overflowing float was deferred whenever an earlier sibling float existed, even when both remained side by side at the top of an otherwise empty page. Keep that top-aligned float on the current page while preserving page breaks for floats pushed down by earlier content.

The regression test fails by creating two pages before the fix and passes with both floats on one page. The float layout tests pass (36 passed, 1 xfailed); the broader layout suite passes with the pre-existing Ghostscript/font-dependent cases excluded (900 passed, 12 xfailed).
