### PR TITLE
Keep manual hyphens after line breaks

### DIFF
--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -818,6 +818,22 @@ def test_hyphenate_manual_4():
 
 
 @assert_no_logs
+def test_hyphenate_manual_after_previous_line():
+    # Regression test for #2614.
+    page, = render_pages('''
+        <style>
+          p { width: 55px; font-size: 11pt; hyphens: manual }
+        </style>
+        <p>An extreme&shy;ly long English word</p>
+    ''')
+    html, = page.children
+    body, = html.children
+    paragraph, = body.children
+    lines = paragraph.children
+    assert lines[1].children[0].text == 'extreme\xad‐'
+
+
+@assert_no_logs
 def test_hyphenate_limit_zone_1():
     page, = render_pages(
         '<html style="width: 12em; font-family: weasyprint">'

--- a/weasyprint/text/line_break.py
+++ b/weasyprint/text/line_break.py
@@ -339,6 +339,7 @@ def split_first_line(text, style, context, max_width, justification_spacing,
         break_point = get_next_break_point(second_line_log_attrs)
         if break_point is not None:
             break_point -= len(first_line_text) + 1
+    soft_hyphen = '\xad'
     next_word = second_line_text[:break_point].rstrip(' ')
     if next_word:
         if space_collapse and second_line_text[break_point or -1] == ' ':
@@ -358,7 +359,7 @@ def split_first_line(text, style, context, max_width, justification_spacing,
                     resume_index = first_line.length + 1
                     if resume_index >= len(text.encode()):
                         resume_index = None
-    elif first_line_text:
+    elif first_line_text and not first_line_text.endswith(soft_hyphen):
         # We found something on the first line but we did not find a word on
         # the next line, no need to hyphenate, we can keep the current layout.
         return first_line_metrics(
@@ -369,7 +370,6 @@ def split_first_line(text, style, context, max_width, justification_spacing,
     lang = style['lang'] and pyphen.language_fallback(style['lang'])
     total, left, right = style['hyphenate_limit_chars']
     hyphenated = False
-    soft_hyphen = '\xad'
 
     auto_hyphenation = manual_hyphenation = False
 


### PR DESCRIPTION
At 11pt, Pango can return a fitting line ending in the invisible soft hyphen. The no-next-word fast path returned before manual hyphenation appended `hyphenate-character`; letting that case continue fixes the reported rendering.

The regression test reproduces the missing visible hyphen without the source change and passes with it. `tests/test_text.py`: 153 passed, 1 xfailed.

Fixes #2614.
