### PR TITLE
Support leading partial column spans

### DIFF
--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -693,8 +693,8 @@ specification, content can be flowed into multiple columns with a gap and a
 rule between them."
 
 Simple multi-column layouts are supported in WeasyPrint. Features such as
-constrained height, spanning columns or column breaks are **not**
-supported. Pagination and overflow are not seriously tested.
+constrained height or column breaks are **not** supported. Pagination and
+overflow are not seriously tested.
 
 The ``column-width`` and ``column-count`` properties, and the ``columns``
 shorthand property are supported.
@@ -707,11 +707,20 @@ The ``break-before``, ``break-after`` and ``break-inside`` properties are
 supported.
 
 The ``column-span`` property is supported for direct children of columns.
+Alongside ``none`` and ``all``, a limited form of the positive integer syntax
+from `CSS Multi-column Layout Module Level 2`_ is supported. A leading direct
+child can span the first N columns in the logical direction. Following content
+sequentially fills the shorter covered columns before using the full-height
+uncovered columns. A value of ``1`` behaves as ``none`` and a value equal to or
+greater than the column count behaves as ``all``. Other placements and column
+balancing for partial spans are not supported because their behavior is still
+undefined in the draft specification.
 
 The ``column-fill`` property is supported, with a column balancing algorithm
 that should be efficient with simple cases.
 
 .. _CSS Multi-column Layout Module: https://www.w3.org/TR/css-multicol-1/
+.. _CSS Multi-column Layout Module Level 2: https://drafts.csswg.org/css-multicol-2/
 
 CSS Fragmentation Module Level 3 / 4
 ++++++++++++++++++++++++++++++++++++

--- a/tests/css/test_validation.py
+++ b/tests/css/test_validation.py
@@ -54,6 +54,25 @@ def test_unstable_prefix():
 
 
 @assert_no_logs
+@pytest.mark.parametrize(('rule', 'value'), [
+    ('none', 'none'),
+    ('all', 'all'),
+    ('1', 1),
+    ('2', 2),
+])
+def test_column_span(rule, value):
+    """Integer spans are preserved for the multicol layout algorithm."""
+    assert get_value(f'column-span: {rule}') == value
+
+
+@assert_no_logs
+@pytest.mark.parametrize('rule', ['0', '-1', '1.5'])
+def test_column_span_invalid(rule):
+    """The Level 2 grammar only accepts strictly positive integers."""
+    assert_invalid(f'column-span: {rule}')
+
+
+@assert_no_logs
 def test_normal_prefix():
     assert_invalid(
         '-weasy-display: block', 'prefix on this attribute is not supported')

--- a/tests/draw/test_column.py
+++ b/tests/draw/test_column.py
@@ -83,6 +83,39 @@ def test_column_rule_span(assert_pixels):
 
 
 @assert_no_logs
+def test_leading_partial_column_span(assert_pixels):
+    """A partial spanner and irregular column rules paint in their own areas."""
+    assert_pixels('''
+        RRRra
+        arara
+        arara
+    ''', '''
+      <style>
+        @page { margin: 0; size: 5px 3px }
+        body { margin: 0; font-size: 0 }
+        div {
+          columns: 3; column-gap: 1px; column-fill: auto;
+          column-rule: 1px solid red;
+          width: 5px; height: 3px;
+        }
+        section {
+          column-span: 2; height: 1px; background: red;
+        }
+        img { display: block; width: 1px; height: 1px }
+      </style>
+      <div>
+        <section></section>
+        <img src=blue.jpg>
+        <img src=blue.jpg>
+        <img src=blue.jpg>
+        <img src=blue.jpg>
+        <img src=blue.jpg>
+        <img src=blue.jpg>
+        <img src=blue.jpg>
+      </div>''')
+
+
+@assert_no_logs
 def test_column_rule_normal(assert_pixels):
     # Regression test for #2217.
     assert_pixels('''

--- a/tests/layout/test_column.py
+++ b/tests/layout/test_column.py
@@ -438,6 +438,303 @@ def test_column_span_balance():
 
 
 @assert_no_logs
+def test_leading_partial_column_span():
+    """A leading partial spanner reserves only the columns it covers.
+
+    This test records the deliberately narrow first implementation of integer
+    ``column-span``. The two covered columns start below the spanner and have
+    room for three lines each. The uncovered third column retains the full
+    four-line height. Checking the words as well as the box positions ensures
+    that content stays in one CSS-owned flow instead of being assigned to
+    physical columns before layout.
+    """
+    page, = render_pages('''
+      <style>
+        @page { margin: 0; size: 12px 4px }
+        body { margin: 0; font-family: weasyprint; font-size: 1px }
+        div {
+          columns: 3; column-gap: 0; column-fill: auto;
+          height: 4px; line-height: 1;
+        }
+        section { column-span: 2 }
+      </style>
+      <div>
+        <section>head</section>
+        abc def ghi jkl mno pqr stu vwx yz1 yz2
+      </div>
+    ''')
+    html, = page.children
+    body, = html.children
+    div, = body.children
+    header, column1, column2, column3 = div.children
+
+    assert (header.position_x, header.position_y, header.width) == (0, 0, 8)
+    assert [column.position_x for column in (column1, column2, column3)] == [0, 4, 8]
+    assert [column.position_y for column in (column1, column2, column3)] == [1, 1, 0]
+    assert [column.height for column in (column1, column2, column3)] == [3, 3, 4]
+
+    words = []
+    for column in (column1, column2, column3):
+        words.append([
+            line.children[0].text
+            for line in column.children[0].children
+        ])
+    assert words == [
+        ['abc', 'def', 'ghi'],
+        ['jkl', 'mno', 'pqr'],
+        ['stu', 'vwx', 'yz1', 'yz2'],
+    ]
+
+
+@assert_no_logs
+def test_leading_partial_column_span_rtl():
+    """Partial spans cover the first columns in the logical direction."""
+    page, = render_pages('''
+      <style>
+        @page { margin: 0; size: 12px 4px }
+        body { margin: 0; font-family: weasyprint; font-size: 1px }
+        div {
+          columns: 3; column-gap: 0; column-fill: auto; direction: rtl;
+          height: 4px; line-height: 1;
+        }
+        section { column-span: 2 }
+      </style>
+      <div>
+        <section>head</section>
+        abc def ghi jkl mno pqr stu vwx yz1 yz2
+      </div>
+    ''')
+    html, = page.children
+    body, = html.children
+    div, = body.children
+    header, column1, column2, column3 = div.children
+
+    assert (header.position_x, header.position_y, header.width) == (4, 0, 8)
+    assert [column.position_x for column in (column1, column2, column3)] == [8, 4, 0]
+    assert [column.position_y for column in (column1, column2, column3)] == [1, 1, 0]
+
+
+@assert_no_logs
+def test_leading_partial_column_span_gap():
+    """The partial spanner includes gaps between the columns it covers."""
+    page, = render_pages('''
+      <style>
+        @page { margin: 0; size: 16px 4px }
+        body { margin: 0; font-family: weasyprint; font-size: 1px }
+        div {
+          columns: 3; column-gap: 2px; column-fill: auto;
+          height: 4px; line-height: 1;
+        }
+        section { column-span: 2 }
+      </style>
+      <div>
+        <section>head</section>
+        abc def ghi jkl mno pqr stu vwx yz1 yz2
+      </div>
+    ''')
+    html, = page.children
+    body, = html.children
+    div, = body.children
+    header, column1, column2, column3 = div.children
+
+    assert (header.position_x, header.position_y, header.width) == (0, 0, 10)
+    assert [column.position_x for column in (column1, column2, column3)] == [0, 6, 12]
+    assert [column.position_y for column in (column1, column2, column3)] == [1, 1, 0]
+
+
+@assert_no_logs
+def test_leading_partial_column_span_four_columns():
+    """Every column outside a partial span keeps its full block size."""
+    page, = render_pages('''
+      <style>
+        @page { margin: 0; size: 16px 4px }
+        body { margin: 0; font-family: weasyprint; font-size: 1px }
+        div {
+          columns: 4; column-gap: 0; column-fill: auto;
+          height: 4px; line-height: 1;
+        }
+        section { column-span: 2 }
+      </style>
+      <div>
+        <section>head</section>
+        a01 a02 a03 a04 a05 a06 a07 a08 a09 a10 a11 a12 a13 a14
+      </div>
+    ''')
+    html, = page.children
+    body, = html.children
+    div, = body.children
+    header, *columns = div.children
+
+    assert (header.position_x, header.position_y, header.width) == (0, 0, 8)
+    assert [column.position_x for column in columns] == [0, 4, 8, 12]
+    assert [column.position_y for column in columns] == [1, 1, 0, 0]
+    assert [column.height for column in columns] == [3, 3, 4, 4]
+
+
+@assert_no_logs
+def test_integer_column_span_all():
+    """An integer covering every column has the established ``all`` layout."""
+    page, = render_pages('''
+      <style>
+        @page { margin: 0; size: 12px 4px }
+        body { margin: 0; font-family: weasyprint; font-size: 1px }
+        div {
+          columns: 3; column-gap: 0; column-fill: auto;
+          height: 4px; line-height: 1;
+        }
+        section { column-span: 3 }
+      </style>
+      <div>
+        <section>head</section>
+        abc def ghi
+      </div>
+    ''')
+    html, = page.children
+    body, = html.children
+    div, = body.children
+    header, column1 = div.children
+
+    assert (header.position_x, header.position_y, header.width) == (0, 0, 12)
+    assert (column1.position_x, column1.position_y) == (0, 1)
+
+
+@assert_no_logs
+def test_partial_column_span_without_following_content():
+    """A lone partial spanner defines the multicol container's auto height."""
+    page, = render_pages('''
+      <style>
+        @page { margin: 0; size: 12px 4px }
+        body { margin: 0; font-family: weasyprint; font-size: 1px }
+        div { columns: 3; column-gap: 0; line-height: 1 }
+        section { column-span: 2 }
+      </style>
+      <div><section>head</section></div>
+    ''')
+    html, = page.children
+    body, = html.children
+    div, = body.children
+    header, = div.children
+
+    assert (header.position_x, header.position_y, header.width) == (0, 0, 8)
+    assert div.height == 1
+
+
+@assert_no_logs
+def test_column_span_one_is_not_a_spanner():
+    """The unresolved integer value ``1`` follows the ``none`` behavior."""
+    page, = render_pages('''
+      <style>
+        @page { margin: 0; size: 12px 4px }
+        body { margin: 0; font-family: weasyprint; font-size: 1px }
+        div {
+          columns: 3; column-gap: 0; column-fill: auto;
+          height: 4px; line-height: 1;
+        }
+        section { column-span: 1 }
+      </style>
+      <div><section>head</section>abc def</div>
+    ''')
+    html, = page.children
+    body, = html.children
+    div, = body.children
+
+    assert all(child.is_column for child in div.children)
+    section = next(
+        box for box in div.children[0].descendants()
+        if box.element_tag == 'section')
+    assert section.width == 4
+
+
+@assert_no_logs
+def test_non_leading_partial_column_span_is_not_a_spanner():
+    """Unsupported partial spans remain in their normal flow column."""
+    page, = render_pages('''
+      <style>
+        @page { margin: 0; size: 12px 4px }
+        body { margin: 0; font-family: weasyprint; font-size: 1px }
+        div {
+          columns: 3; column-gap: 0; column-fill: auto;
+          height: 4px; line-height: 1;
+        }
+        p, section { margin: 0 }
+        section { column-span: 2 }
+      </style>
+      <div><p>abc</p><section>head</section>def</div>
+    ''')
+    html, = page.children
+    body, = html.children
+    div, = body.children
+
+    assert all(child.is_column for child in div.children)
+    section = next(
+        box for box in div.children[0].descendants()
+        if box.element_tag == 'section')
+    assert (section.position_x, section.width) == (0, 4)
+
+
+@assert_no_logs
+def test_partial_column_span_multipage():
+    """Only the first page reserves space for a consumed leading spanner."""
+    page1, page2 = render_pages('''
+      <style>
+        @page { margin: 0; size: 12px 4px }
+        body { margin: 0; font-family: weasyprint; font-size: 1px }
+        div {
+          columns: 3; column-gap: 0; column-fill: auto;
+          line-height: 1;
+        }
+        section { column-span: 2 }
+      </style>
+      <div>
+        <section>head</section>
+        a01 a02 a03 a04 a05 a06 a07 a08 a09 a10
+        a11 a12 a13 a14 a15 a16 a17 a18 a19 a20
+      </div>
+    ''')
+    html, = page1.children
+    body, = html.children
+    div, = body.children
+    header, *columns = div.children
+    assert header.element_tag == 'section'
+    assert [column.position_y for column in columns] == [1, 1, 0]
+
+    html, = page2.children
+    body, = html.children
+    div, = body.children
+    assert all(child.is_column for child in div.children)
+    assert [column.position_y for column in div.children] == [0, 0, 0]
+
+
+@assert_no_logs
+def test_partial_column_span_overflow_columns():
+    """Inline overflow columns are not shortened by a leading spanner."""
+    page, = render_pages('''
+      <style>
+        @page { margin: 0; size: 20px 4px }
+        body { margin: 0; font-family: weasyprint; font-size: 1px }
+        div {
+          columns: 3; column-gap: 0; column-fill: auto;
+          width: 12px; height: 4px; line-height: 1;
+        }
+        section { column-span: 2 }
+      </style>
+      <div>
+        <section>head</section>
+        a01 a02 a03 a04 a05 a06 a07 a08 a09 a10 a11 a12 a13 a14
+      </div>
+    ''')
+    html, = page.children
+    body, = html.children
+    div, = body.children
+    header, *columns = div.children
+
+    assert header.width == 8
+    assert [column.position_x for column in columns] == [0, 4, 8, 12]
+    assert [column.position_y for column in columns] == [1, 1, 0, 0]
+    assert [column.height for column in columns] == [3, 3, 4, 4]
+
+
+@assert_no_logs
 def test_columns_multipage():
     page1, page2 = render_pages('''
       <style>

--- a/weasyprint/css/validation/properties.py
+++ b/weasyprint/css/validation/properties.py
@@ -521,10 +521,15 @@ def column_width(token):
 
 
 @property(unstable=True)
-@single_keyword
-def column_span(keyword):
+@single_token
+def column_span(token):
     """``column-span`` property validation."""
-    return keyword in ('all', 'none')
+    keyword = get_keyword(token)
+    if keyword in ('all', 'none'):
+        return keyword
+    if number := get_number(token, integer=True):
+        if number.value >= 1:
+            return number.value
 
 
 @property()

--- a/weasyprint/draw/border.py
+++ b/weasyprint/draw/border.py
@@ -30,7 +30,7 @@ def draw_column_rules(stream, box):
     border_widths = (0, 0, 0, box.style['column_rule_width'])
     skip_next = True
     for child in box.children:
-        if child.style['column_span'] == 'all':
+        if not child.is_column:
             skip_next = True
             continue
         elif skip_next:

--- a/weasyprint/layout/column.py
+++ b/weasyprint/layout/column.py
@@ -67,12 +67,24 @@ def columns_layout(context, box, bottom_space, skip_stack, containing_block,
     column_children = []
     skip, = skip_stack.keys() if skip_stack else (0,)
     for i, child in enumerate(box.children[skip:], start=skip):
-        if child.style['column_span'] == 'all':
+        span = child.style['column_span']
+        full_span = (
+            span == 'all' or (isinstance(span, int) and span >= count))
+        partial_span = (
+            isinstance(span, int) and 1 < span < count and i == skip and
+            not columns_and_blocks and not column_children)
+        if full_span:
             if column_children:
                 columns_and_blocks.append(
                     (i - len(column_children), column_children))
             columns_and_blocks.append((i, child.copy()))
             column_children = []
+            continue
+        if partial_span:
+            # Integer column spans are underspecified in Multicol Level 2.
+            # Keep the first implementation deliberately narrow: only a
+            # leading direct child can reserve a subset of the columns.
+            columns_and_blocks.append((i, (span, child.copy())))
             continue
         column_children.append(child.copy())
     if column_children:
@@ -109,18 +121,34 @@ def columns_layout(context, box, bottom_space, skip_stack, containing_block,
         0 if context.current_footnote_area.height == 'auto'
         else context.current_footnote_area.margin_height()]
     last_footnotes_height = 0
+    pending_column_positions = None
     for index, column_children_or_block in columns_and_blocks:
         if not isinstance(column_children_or_block, list):
             # We have a spanning block, we display it like other blocks
-            block = column_children_or_block
-            resolve_percentages(block, containing_block)
-            block.position_x = box.content_box_x()
+            block_start_y = current_position_y
+            partial_span = isinstance(column_children_or_block, tuple)
+            if partial_span:
+                span, block = column_children_or_block
+                span_width = span * width + (span - 1) * gap
+                block_containing_block = box.copy()
+                block_containing_block.width = span_width
+                resolve_percentages(block, block_containing_block)
+                if style['direction'] == 'rtl':
+                    block.position_x = box.content_box_x() + box.width - span_width
+                else:
+                    block.position_x = box.content_box_x()
+            else:
+                block = column_children_or_block
+                block_containing_block = containing_block
+                resolve_percentages(block, block_containing_block)
+                block.position_x = box.content_box_x()
             block.position_y = current_position_y
             new_child, resume_at, next_page, adjoining_margins, _, _ = (
                 block_level_layout(
-                    context, block, original_bottom_space, skip_stack, containing_block,
-                    page_is_empty, absolute_boxes, fixed_boxes, adjoining_margins,
-                    first_letter_style, first_line_style))
+                    context, block, original_bottom_space, skip_stack,
+                    block_containing_block, page_is_empty, absolute_boxes,
+                    fixed_boxes, adjoining_margins, first_letter_style,
+                    first_line_style))
             skip_stack = None
             if new_child is None:
                 last_loop = True
@@ -136,18 +164,36 @@ def columns_layout(context, box, bottom_space, skip_stack, containing_block,
                 column_skip_stack = resume_at
                 break
             page_is_empty = False
+            if partial_span:
+                # The spanner is an exclusion at the block-start edge of its
+                # covered columns. Uncovered columns keep the original start,
+                # so following content can continue there at full height.
+                span_bottom = (
+                    new_child.position_y + new_child.margin_height())
+                pending_column_positions = (
+                    [span_bottom] * span + [block_start_y] * (count - span))
+                current_position_y = block_start_y
+                adjoining_margins = []
+                continue
             continue
 
         # We have a list of children that we have to balance between columns
         column_children = column_children_or_block
 
         # Find the total height available for the first run
-        current_position_y += collapse_margin(adjoining_margins)
+        if pending_column_positions is None:
+            current_position_y += collapse_margin(adjoining_margins)
+            column_positions = [current_position_y] * count
+        else:
+            column_positions = pending_column_positions
+            pending_column_positions = None
+            current_position_y = min(column_positions)
         adjoining_margins = []
-        column_box = _create_column_box(
-            box, containing_block, column_children, width, current_position_y)
-        height = max_height = (
-            context.page_bottom - current_position_y - original_bottom_space)
+        max_heights = [
+            context.page_bottom - position_y - original_bottom_space
+            for position_y in column_positions]
+        irregular_columns = len(set(column_positions)) > 1
+        height = max_height = max_heights[0]
 
         # Try to render columns until the content fits, increase the column
         # height step by step
@@ -167,9 +213,14 @@ def columns_layout(context, box, bottom_space, skip_stack, containing_block,
             new_boxes = []
             for i in range(count):
                 # Render one column
+                column_position_y = column_positions[i]
+                column_height = max_heights[i] if irregular_columns else height
+                column_box = _create_column_box(
+                    box, containing_block, column_children, width,
+                    column_position_y)
                 new_box, resume_at, next_page, _, _, _ = block_box_layout(
                     context, column_box,
-                    context.page_bottom - current_position_y - height,
+                    context.page_bottom - column_position_y - column_height,
                     column_skip_stack, containing_block,
                     page_is_empty or not balancing, [], [], [], first_letter_style,
                     first_line_style, discard=False, max_lines=None)
@@ -188,8 +239,8 @@ def columns_layout(context, box, bottom_space, skip_stack, containing_block,
                     # Get the empty space at the bottom of the column box
                     consumed_height = (
                         in_flow_children[-1].margin_height() +
-                        in_flow_children[-1].position_y - current_position_y)
-                    empty_space = height - consumed_height
+                        in_flow_children[-1].position_y - column_position_y)
+                    empty_space = column_height - consumed_height
                     consumed_height -= in_flow_children[-1].margin_bottom
 
                     # Get the minimum size needed to render the next box
@@ -237,6 +288,22 @@ def columns_layout(context, box, bottom_space, skip_stack, containing_block,
             if last_loop:
                 break
 
+            if irregular_columns:
+                if last_footnotes_height not in footnote_area_heights:
+                    # Keep every column's bottom edge aligned when footnotes
+                    # reduce the page area available to the irregular row.
+                    height_difference = (
+                        last_footnotes_height - footnote_area_heights[-1])
+                    max_heights = [
+                        max_height - height_difference
+                        for max_height in max_heights]
+                    footnote_area_heights.append(last_footnotes_height)
+                    continue
+                if column_skip_stack is None:
+                    break
+                stop_rendering = True
+                break
+
             if balancing:
                 if column_skip_stack is None:
                     # We rendered the whole content, stop
@@ -278,24 +345,41 @@ def columns_layout(context, box, bottom_space, skip_stack, containing_block,
                     break
 
         # TODO: check style['max']-height
-        bottom_space = max(
-            bottom_space, context.page_bottom - current_position_y - height)
+        if irregular_columns:
+            bottom_space = original_bottom_space
+        else:
+            bottom_space = max(
+                bottom_space, context.page_bottom - current_position_y - height)
 
         # Replace the current box children with real columns
         i = 0
         max_column_height = 0
         columns = []
+        column_heights = []
         while True:
+            if i < count:
+                column_position_y = column_positions[i]
+                column_height = max_heights[i]
+            else:
+                # A constrained multicol container can create overflow columns
+                # after its declared columns. They are not covered by a leading
+                # partial spanner and therefore retain the full block size.
+                column_position_y = min(column_positions)
+                column_height = (
+                    context.page_bottom - column_position_y -
+                    original_bottom_space)
             column_box = _create_column_box(
                 box, containing_block, column_children, width,
-                current_position_y)
+                column_position_y)
             if style['direction'] == 'rtl':
                 column_box.position_x += box.width - (i + 1) * width - i * gap
             else:
                 column_box.position_x += i * (width + gap)
             new_child, column_skip_stack, column_next_page, _, _, _ = (
                 block_box_layout(
-                    context, column_box, bottom_space, skip_stack, containing_block,
+                    context, column_box,
+                    original_bottom_space if irregular_columns else bottom_space,
+                    skip_stack, containing_block,
                     original_page_is_empty, absolute_boxes, fixed_boxes, None,
                     first_letter_style, first_line_style, discard=False,
                     max_lines=None))
@@ -306,6 +390,7 @@ def columns_layout(context, box, bottom_space, skip_stack, containing_block,
             next_page = column_next_page
             skip_stack = column_skip_stack
             columns.append(new_child)
+            column_heights.append(column_height)
             max_column_height = max(
                 max_column_height, new_child.margin_height())
             if skip_stack is None:
@@ -320,10 +405,18 @@ def columns_layout(context, box, bottom_space, skip_stack, containing_block,
                 break
 
         # Update the current y position and set the columns’ height
-        current_position_y += min(max_height, max_column_height)
-        for column in columns:
-            column.height = max_column_height
-            new_children.append(column)
+        if irregular_columns:
+            current_position_y = max(
+                column.position_y + column_height
+                for column, column_height in zip(columns, column_heights))
+            for column, column_height in zip(columns, column_heights):
+                column.height = column_height
+                new_children.append(column)
+        else:
+            current_position_y += min(max_height, max_column_height)
+            for column in columns:
+                column.height = max_column_height
+                new_children.append(column)
 
         skip_stack = None
         page_is_empty = False
@@ -333,6 +426,11 @@ def columns_layout(context, box, bottom_space, skip_stack, containing_block,
 
     # Report footnotes above the defined footnotes height
     _report_footnotes(context, footnote_area_heights[-1])
+
+    if pending_column_positions is not None:
+        # A partial spanner with no following column content still contributes
+        # its own block size to an auto-height multicol container.
+        current_position_y = max(pending_column_positions)
 
     if box.children and not new_children:
         # The box has children but none can be drawn, let's skip the whole box


### PR DESCRIPTION
Closes #2845.

### Summary

* Accept strictly positive integer values for `column-span`.
* Lay out a leading partial spanner across the first requested logical columns.
* Start covered columns below the spanner while uncovered columns retain their full block size.
* Preserve sequential content flow through irregular column areas without assigning content to columns in application code.
* Keep column-rule painting correct when column rows have different block-start positions.
* Document the deliberately limited behavior and the unresolved specification questions.

### Scope

The [CSS Multi-column Layout Level 2 editor's draft](https://drafts.csswg.org/css-multicol-2/#column-span) accepts integer values but explicitly says that their definition is not yet sufficient. This implementation therefore provides a narrow initial model:

* `1` behaves like `none`.
* A value greater than or equal to the column count behaves like `all`.
* Only a leading direct child creates a partial span.
* The span covers the first *N* logical columns, including right-to-left layout.
* Non-leading partial spans remain in normal flow.
* Partial-span balancing is not attempted.

These constraints are documented so the behavior can be extended deliberately as the specification and project direction become clearer.

### Tests

Generic regression tests cover:

* property parsing and invalid values;
* normal and right-to-left layout;
* nonzero column gaps;
* multiple uncovered columns;
* equivalence with full spans;
* automatic container height;
* non-leading fallback;
* pagination and fixed-height overflow columns;
* painting and column rules.

Local results with Python 3.14:

* 964 parser and column-layout tests passed.
* 631 drawing tests passed, with 25 expected failures.
* Ruff passed.
* The broader suite reported 4,269 passes and 41 expected failures. One unrelated local command-line test remains affected by spaces in the checkout's absolute path.

The implementation originated from a real production-tooling layout requirement and was exercised there during development. All code, documentation, and regression examples included in this pull request are generic and contain no project data.

### Authorship and review

The initial implementation and tests were authored with ChatGPT Codex using the GPT-5.6-Sol model at high reasoning effort, under human direction and review. Maintainer review is required, particularly for the intentionally narrow interpretation of currently unresolved partial-span semantics. I am happy to revise the design and implementation based on maintainer feedback.
