### PR TITLE
Use native Ghostscript commands on Windows

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,13 @@ from . import draw
 
 MAGIC_NUMBER = b'\x89\x50\x4e\x47\x0d\x0a\x1a\x0a'
 
+if os.name == 'nt':
+    # Official Windows installers expose platform-specific command names.
+    GHOSTSCRIPT = (
+        shutil.which('gswin64c') or shutil.which('gswin32c') or 'gs')
+else:
+    GHOSTSCRIPT = 'gs'
+
 
 def document_write_png(document, target=None, resolution=96, antialiasing=1,
                        zoom=4/30, split_images=False):
@@ -29,7 +36,8 @@ def document_write_png(document, target=None, resolution=96, antialiasing=1,
     with NamedTemporaryFile(delete=False) as pdf:
         document.write_pdf(pdf, zoom=zoom)
     command = (
-        'gs', '-q', '-sDEVICE=png16m', f'-dTextAlphaBits={antialiasing}',
+        GHOSTSCRIPT, '-q', '-sDEVICE=png16m',
+        f'-dTextAlphaBits={antialiasing}',
         f'-dGraphicsAlphaBits={antialiasing}', '-dBATCH', '-dNOPAUSE',
         '-dPDFSTOPONERROR', f'-r{resolution / zoom}', '-dUsePDFX3Profile',
         '-sOutputFile=-', pdf.name)


### PR DESCRIPTION
Closes #2848.

### Summary

* Discover the native 64-bit or 32-bit Ghostscript command on Windows.
* Keep using `gs` on other platforms.
* Preserve the existing test helper behavior after command discovery.

Official native Windows Ghostscript installations expose `gswin64c.exe` or `gswin32c.exe`, rather than `gs`. As a result, WeasyPrint's drawing tests could not use an otherwise correctly installed native Ghostscript from `PATH`.

The helper now selects `gswin64c`, then `gswin32c`, and falls back to `gs` so existing environments remain compatible.

### Tests

With Ghostscript 10.07.1 installed natively on Windows and available through `PATH`, the complete drawing suite ran successfully:

* 631 tests passed.
* 25 tests had their existing expected-failure status.

Ruff also passed.

### Authorship and review

This change was authored with ChatGPT Codex using the GPT-5.6-Sol model at high reasoning effort, under human direction and review. Maintainer review is required, and I am happy to adjust the discovery order or platform handling to match the project's preferences.
