### PR TITLE
Support lossless zero-blur box shadows

### DIFF
--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -580,10 +580,11 @@ WeasyPrint also supports the `border images part`_ of this module, including the
 ``border-image-width``, ``border-image-outset`` and ``border-image-repeat``
 properties.
 
-WeasyPrint does **not** support the `box shadow part`_ of this module,
-including the ``box-shadow`` property. This feature has been implemented in a
-`git branch`_ that is not released, as it relies on raster implementation of
-shadows.
+The ``box-shadow`` property is supported when every shadow has a zero blur
+radius. Multiple outer and inner shadows, spread distances, colors, and rounded
+corners are supported and remain vector graphics in PDF output. Declarations
+with a nonzero blur radius are ignored with a warning because PDF has no native
+Gaussian blur operation and raster shadows do not scale losslessly.
 
 .. _CSS Backgrounds and Borders Level 3: https://www.w3.org/TR/css-backgrounds-3/
 .. _border part: https://www.w3.org/TR/css-backgrounds-3/#borders
@@ -591,7 +592,6 @@ shadows.
 .. _rounded corners part: https://www.w3.org/TR/css-backgrounds-3/#corners
 .. _border images part: https://www.w3.org/TR/css-backgrounds-3/#border-images
 .. _box shadow part: https://www.w3.org/TR/css-backgrounds-3/#misc
-.. _git branch: https://github.com/Kozea/WeasyPrint/pull/149
 
 CSS Image Values and Replaced Content Module Level 3 / 4
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/tests/css/test_validation.py
+++ b/tests/css/test_validation.py
@@ -224,6 +224,61 @@ def test_background_image_invalid(rule):
     assert_invalid(f'background-image: {rule}')
 
 
+def serialize_box_shadow(shadow):
+    """Return a stable representation of a parsed box shadow for assertions."""
+    offset_x, offset_y, blur, spread, inset, color = shadow
+    lengths = tuple((length.value, length.unit) for length in (
+        offset_x, offset_y, blur, spread))
+    return lengths, inset, color.serialize() if color is not None else None
+
+
+@assert_no_logs
+@pytest.mark.parametrize(('rule', 'value'), [
+    ('none', ()),
+    ('1px 2em', (((1, 'px'), (2, 'em'), (0, 'px'), (0, 'px')), False, None)),
+    (
+        'inset rgb(255 0 0 / 50%) -1px 2px 0 3pt',
+        (((-1, 'px'), (2, 'px'), (0, None), (3, 'pt')), True,
+         'rgb(255 0 0 / 50%)'),
+    ),
+])
+def test_box_shadow(rule, value):
+    """Zero-blur shadows preserve lengths, color, and inset semantics."""
+    result = get_value(f'box-shadow: {rule}')
+    if not result:
+        assert result == value
+    else:
+        assert serialize_box_shadow(result[0]) == value
+
+
+@assert_no_logs
+def test_box_shadow_multiple():
+    """Comma-separated shadows keep their author-specified front-to-back order."""
+    result = get_value('box-shadow: 1px 2px red, blue 3px 4px inset')
+    assert tuple(serialize_box_shadow(shadow) for shadow in result) == (
+        (((1, 'px'), (2, 'px'), (0, 'px'), (0, 'px')), False, 'red'),
+        (((3, 'px'), (4, 'px'), (0, 'px'), (0, 'px')), True, 'blue'),
+    )
+
+
+@pytest.mark.parametrize(('rule', 'message'), [
+    ('1px', 'two to four lengths'),
+    ('1px 2px 3px 4px 5px', 'two to four lengths'),
+    ('1px red 2px', 'lengths must be consecutive'),
+    ('1px 2px red blue', 'color specified more than once'),
+    ('inset 1px 2px inset', 'inset keyword specified more than once'),
+    ('1px 2px -1px', 'blur radius must not be negative'),
+    ('1px 2px 1px', 'nonzero box-shadow blur radius is not supported'),
+    ('1px 2px,', 'empty box shadow'),
+    (',1px 2px', 'empty box shadow'),
+    ('none, 1px 2px', 'invalid box-shadow component'),
+    ('1% 2px', 'invalid box-shadow component'),
+])
+def test_box_shadow_invalid(rule, message):
+    """Invalid or raster-only shadows are rejected with actionable diagnostics."""
+    assert_invalid(f'box-shadow: {rule}', message)
+
+
 @pytest.mark.parametrize(('rule', 'value'), [
     # One token, vertical
     ('top', (('left', (50, '%'), 'top', (0, '%')),)),

--- a/tests/draw/test_shadow.py
+++ b/tests/draw/test_shadow.py
@@ -1,0 +1,260 @@
+"""Test lossless CSS shadow painting."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from weasyprint import HTML
+from weasyprint.draw.shadow import _shadow_box
+
+from ..testing_utils import assert_no_logs
+
+
+@assert_no_logs
+def test_box_shadow_outset(assert_pixels):
+    """An outer shadow is offset and painted below the box background."""
+    assert_pixels('''
+        ____________
+        ____________
+        ____________
+        ___RRRR_____
+        ___RRRR_____
+        ___RRRRBB___
+        ___RRRRBB___
+        _____BBBB___
+        _____BBBB___
+        ____________
+        ____________
+        ____________
+    ''', '''
+      <style>
+        @page { size: 12px; margin: 0 }
+        div {
+          background: red;
+          box-shadow: 2px 2px blue;
+          height: 4px;
+          left: 3px;
+          position: absolute;
+          top: 3px;
+          width: 4px;
+        }
+      </style>
+      <div></div>
+    ''')
+
+
+@assert_no_logs
+def test_box_shadow_outset_transparent_knockout(assert_pixels):
+    """Outer shadows stay clipped out of a transparent element's border box."""
+    assert_pixels('''
+        __________
+        __________
+        __________
+        __________
+        ______BB__
+        ______BB__
+        ____BBBB__
+        ____BBBB__
+        __________
+        __________
+    ''', '''
+      <style>
+        @page { size: 10px; margin: 0 }
+        div {
+          box-shadow: 2px 2px blue;
+          height: 4px;
+          left: 2px;
+          position: absolute;
+          top: 2px;
+          width: 4px;
+        }
+      </style>
+      <div></div>
+    ''')
+
+
+@assert_no_logs
+def test_box_shadow_inset(assert_pixels):
+    """A positive horizontal inset offset casts the shadow from the left edge."""
+    assert_pixels('''
+        ____________
+        ____________
+        __BBRRRRRR__
+        __BBRRRRRR__
+        __BBRRRRRR__
+        __BBRRRRRR__
+        __BBRRRRRR__
+        __BBRRRRRR__
+        __BBRRRRRR__
+        __BBRRRRRR__
+        ____________
+        ____________
+    ''', '''
+      <style>
+        @page { size: 12px; margin: 0 }
+        div {
+          background: red;
+          box-shadow: inset 2px 0 blue;
+          height: 8px;
+          left: 2px;
+          position: absolute;
+          top: 2px;
+          width: 8px;
+        }
+      </style>
+      <div></div>
+    ''')
+
+
+@assert_no_logs
+def test_box_shadow_multiple_order(assert_pixels):
+    """The first declared shadow is painted over later shadows."""
+    assert_pixels('''
+        ____________
+        ____________
+        __RRRRgB____
+        __RRRRgB____
+        __RRRRgB____
+        __RRRRgB____
+        ____________
+        ____________
+    ''', '''
+      <style>
+        @page { size: 12px 8px; margin: 0 }
+        div {
+          background: red;
+          box-shadow: 1px 0 green, 2px 0 blue;
+          height: 4px;
+          left: 2px;
+          position: absolute;
+          top: 2px;
+          width: 4px;
+        }
+      </style>
+      <div></div>
+    ''')
+
+
+@assert_no_logs
+def test_box_shadow_spread_and_currentcolor(assert_pixels):
+    """Spread changes the vector perimeter and omitted colors use currentcolor."""
+    assert_pixels('''
+        ____________
+        _BBBBBBBB___
+        _BRRRRRRB___
+        _BRRRRRRB___
+        _BRRRRRRB___
+        _BRRRRRRB___
+        _BBBBBBBB___
+        ____________
+    ''', '''
+      <style>
+        @page { size: 12px 8px; margin: 0 }
+        div {
+          background: red;
+          box-shadow: 0 0 0 1px;
+          color: blue;
+          height: 4px;
+          left: 2px;
+          position: absolute;
+          top: 2px;
+          width: 6px;
+        }
+      </style>
+      <div></div>
+    ''')
+
+
+@assert_no_logs
+def test_box_shadow_rounded(assert_same_renderings):
+    """A zero-spread shadow keeps the border box's rounded vector shape."""
+    assert_same_renderings('''
+      <style>
+        @page { size: 20px; margin: 0 }
+        div {
+          background: red;
+          border-radius: 4px;
+          box-shadow: 3px 2px blue;
+          height: 8px;
+          left: 4px;
+          position: absolute;
+          top: 4px;
+          width: 8px;
+        }
+      </style>
+      <div></div>
+    ''', '''
+      <style>
+        @page { size: 20px; margin: 0 }
+        div {
+          border-radius: 4px;
+          height: 8px;
+          position: absolute;
+          width: 8px;
+        }
+        .shadow { background: blue; left: 7px; top: 6px }
+        .box { background: red; left: 4px; top: 4px }
+      </style>
+      <div class="shadow"></div><div class="box"></div>
+    ''')
+
+
+@assert_no_logs
+def test_box_shadow_inset_negative_spread_rounded():
+    """Negative inset spread expands corners using the CSS outset algorithm."""
+    corners = ((4, 4),) * 4
+    box = SimpleNamespace(rounded_padding_box=lambda: (10, 10, 20, 20, *corners))
+    shadow = _shadow_box(box, 10, 10, -8, inset=True)
+    coverage = 2 * 4 / 20
+    expected_radius = 4 + 8 * (1 - (1 - 4 / 8) ** 3 * (1 - coverage ** 3))
+    assert shadow[:4] == (12, 12, 36, 36)
+    assert tuple(value for corner in shadow[4:] for value in corner) == (
+        pytest.approx((expected_radius,) * 8))
+
+
+@assert_no_logs
+def test_box_shadow_collapsed_table(assert_same_renderings):
+    """Collapsed internal table boxes ignore only outer shadows, per CSS."""
+    assert_same_renderings('''
+      <style>
+        table { border-collapse: collapse }
+        td {
+          background: red;
+          box-shadow: 1em 0 blue, inset 0.5em 0 green;
+          height: 4em;
+          padding: 0;
+          width: 4em;
+        }
+      </style>
+      <table><tr><td></td></tr></table>
+    ''', '''
+      <style>
+        table { border-collapse: collapse }
+        td {
+          background: red;
+          box-shadow: inset 0.5em 0 green;
+          height: 4em;
+          padding: 0;
+          width: 4em;
+        }
+      </style>
+      <table><tr><td></td></tr></table>
+    ''')
+
+
+@assert_no_logs
+def test_box_shadow_is_vector():
+    """Zero-blur shadows add PDF paths without introducing raster images."""
+    pdf = HTML(string='''
+      <style>
+        div {
+          background: white;
+          border-radius: 1em;
+          box-shadow: 1em 1em 0 0.5em black, inset 0.5em 0.5em blue;
+          height: 4em;
+          width: 4em;
+        }
+      </style>
+      <div></div>
+    ''').write_pdf()
+    assert b'/Subtype /Image' not in pdf

--- a/weasyprint/css/computed_values.py
+++ b/weasyprint/css/computed_values.py
@@ -258,6 +258,27 @@ def color(style, name, values):
     return parse_color(values, style['color_scheme'])
 
 
+@register_computer('box-shadow')
+def box_shadow(style, name, values):
+    """Compute lengths and current colors for zero-blur box shadows."""
+    shadows = []
+    for offset_x, offset_y, blur, spread, inset, color_token in values:
+        color = (
+            parse_color(color_token, style['color_scheme'])
+            if color_token is not None else 'currentcolor')
+        if color == 'currentcolor':
+            color = style['color']
+        shadows.append((
+            length(style, name, offset_x, pixels_only=True),
+            length(style, name, offset_y, pixels_only=True),
+            length(style, name, blur, pixels_only=True),
+            length(style, name, spread, pixels_only=True),
+            inset,
+            color,
+        ))
+    return tuple(shadows)
+
+
 @register_computer('background-position')
 @register_computer('object-position')
 def compute_position(style, name, values):

--- a/weasyprint/css/properties.py
+++ b/weasyprint/css/properties.py
@@ -49,6 +49,7 @@ INITIAL_VALUES = {
                              'top', Dimension(0, '%')),),
     'background_repeat': (('repeat', 'repeat'),),
     'background_size': (('auto', 'auto'),),
+    'box_shadow': (),
     'border_bottom_color': 'currentcolor',
     'border_bottom_left_radius': (ZERO_PIXELS, ZERO_PIXELS),
     'border_bottom_right_radius': (ZERO_PIXELS, ZERO_PIXELS),

--- a/weasyprint/css/validation/properties.py
+++ b/weasyprint/css/validation/properties.py
@@ -17,7 +17,8 @@ from ..tokens import (  # isort:skip
     InvalidValues, Pending, comma_separated_list, get_angle, get_content_list,
     get_content_list_token, get_custom_ident, get_image, get_keyword, get_length,
     get_number, get_percentage, get_resolution, get_single_keyword, get_url,
-    parse_2d_position, parse_position, remove_whitespace, single_keyword, single_token)
+    parse_2d_position, parse_position, remove_whitespace, single_keyword, single_token,
+    split_on_comma)
 
 PREFIX = '-weasy-'
 PROPRIETARY = set()
@@ -175,6 +176,75 @@ def background_image(token, base_url):
     if get_keyword(token) == 'none':
         return 'none', None
     return get_image(token, base_url)
+
+
+def _parse_box_shadow(tokens):
+    """Parse one box shadow whose blur radius must be zero.
+
+    The length group is intentionally kept consecutive, as required by the
+    grammar. Color and ``inset`` may occur before or after that group.
+    Supporting nonzero blur radii would require raster output, so valid
+    nonzero values get a specific diagnostic instead of being silently
+    accepted and omitted while painting.
+
+    """
+    lengths = []
+    color = None
+    inset = False
+    lengths_closed = False
+
+    for token in tokens:
+        keyword = get_keyword(token)
+        if keyword == 'inset':
+            if inset:
+                raise InvalidValues('inset keyword specified more than once')
+            inset = True
+            lengths_closed = lengths_closed or bool(lengths)
+            continue
+
+        parsed_color = parse_color(token)
+        if parsed_color is not None:
+            if color is not None:
+                raise InvalidValues('shadow color specified more than once')
+            color = token
+            lengths_closed = lengths_closed or bool(lengths)
+            continue
+
+        length = get_length(token)
+        if length is None:
+            raise InvalidValues('invalid box-shadow component')
+        if lengths_closed:
+            raise InvalidValues('shadow lengths must be consecutive')
+        lengths.append(token)
+
+    if not 2 <= len(lengths) <= 4:
+        raise InvalidValues('box-shadow requires two to four lengths')
+
+    offset_x = get_length(lengths[0])
+    offset_y = get_length(lengths[1])
+    blur = get_length(lengths[2], negative=False) if len(lengths) >= 3 else ZERO_PIXELS
+    spread = get_length(lengths[3]) if len(lengths) == 4 else ZERO_PIXELS
+    if blur is None:
+        raise InvalidValues('box-shadow blur radius must not be negative')
+    if getattr(blur, 'value', None) != 0:
+        raise InvalidValues('nonzero box-shadow blur radius is not supported')
+
+    return offset_x, offset_y, blur, spread, inset, color
+
+
+@property('box-shadow')
+def box_shadow(tokens):
+    """Validation for the lossless, zero-blur ``box-shadow`` subset."""
+    if get_single_keyword(tokens) == 'none':
+        return ()
+
+    shadows = []
+    for part in split_on_comma(tokens):
+        part = remove_whitespace(part)
+        if not part:
+            raise InvalidValues('empty box shadow')
+        shadows.append(_parse_box_shadow(part))
+    return tuple(shadows)
 
 
 @property('list-style-image', wants_base_url=True)

--- a/weasyprint/draw/__init__.py
+++ b/weasyprint/draw/__init__.py
@@ -12,6 +12,7 @@ from ..matrix import Matrix
 from ..stacking import StackingContext
 from .border import draw_border, draw_line, draw_outline, rounded_box, set_mask_border
 from .color import styled_color
+from .shadow import draw_box_shadows
 from .text import draw_text
 
 
@@ -75,8 +76,7 @@ def draw_stacking_context(stream, stacking_context):
                             boxes.GridContainerBox, boxes.ReplacedBox)):
             set_mask_border(stream, box)
             # The canvas background was removed by layout_backgrounds.
-            draw_background(stream, box.background)
-            draw_border(stream, box)
+            draw_box_background_and_border(stream, box)
 
         with stream.stacked():
             # Dont clip the page box, see #35.
@@ -102,8 +102,7 @@ def draw_stacking_context(stream, stacking_context):
                 if isinstance(block, boxes.TableBox):
                     draw_table(stream, block)
                 else:
-                    draw_background(stream, block.background)
-                    draw_border(stream, block)
+                    draw_box_background_and_border(stream, block)
 
             # Point 5.
             for child_context in stacking_context.float_contexts:
@@ -235,6 +234,20 @@ def draw_background(stream, bg, clip_box=True, bleed=None, marks=()):
             draw_background_image(stream, layer, bg.style)
 
 
+def draw_box_background(stream, box, outer_shadows=True):
+    """Draw a box's outer shadows, background, and inner shadows."""
+    if outer_shadows:
+        draw_box_shadows(stream, box, inset=False)
+    draw_background(stream, box.background)
+    draw_box_shadows(stream, box, inset=True)
+
+
+def draw_box_background_and_border(stream, box):
+    """Draw shadows and background below a box's border."""
+    draw_box_background(stream, box)
+    draw_border(stream, box)
+
+
 def draw_background_image(stream, layer, style):
     if layer.image is None or 0 in layer.size:
         return
@@ -323,22 +336,23 @@ def draw_background_image(stream, layer, style):
 
 def draw_table(stream, table):
     # Draw backgrounds.
-    draw_background(stream, table.background)
+    draw_box_background(stream, table)
+    separate_borders = table.style['border_collapse'] != 'collapse'
     for column_group in table.column_groups:
-        draw_background(stream, column_group.background)
+        draw_box_background(stream, column_group, separate_borders)
         for column in column_group.children:
-            draw_background(stream, column.background)
+            draw_box_background(stream, column, separate_borders)
     for row_group in table.children:
-        draw_background(stream, row_group.background)
+        draw_box_background(stream, row_group, separate_borders)
         for row in row_group.children:
-            draw_background(stream, row.background)
+            draw_box_background(stream, row, separate_borders)
             for cell in row.children:
                 draw_cell_background = (
                     table.style['border_collapse'] == 'collapse' or
                     cell.style['empty_cells'] == 'show' or
                     not cell.empty)
                 if draw_cell_background:
-                    draw_background(stream, cell.background)
+                    draw_box_background(stream, cell, separate_borders)
 
     # Draw borders.
     if table.style['border_collapse'] == 'collapse':
@@ -495,8 +509,7 @@ def draw_inline_level(stream, page, box, offset_x=0, text_overflow='clip',
         draw_stacking_context(stream, stacking_context)
     else:
         set_mask_border(stream, box)
-        draw_background(stream, box.background)
-        draw_border(stream, box)
+        draw_box_background_and_border(stream, box)
         if isinstance(box, (boxes.InlineBox, boxes.LineBox)):
             if isinstance(box, boxes.LineBox):
                 text_overflow = box.text_overflow

--- a/weasyprint/draw/shadow.py
+++ b/weasyprint/draw/shadow.py
@@ -1,0 +1,134 @@
+"""Draw lossless CSS shadows."""
+
+from .border import rounded_box
+
+
+def _normalize_radii(width, height, corners):
+    """Scale corner radii so opposing radii do not overlap."""
+    top_left, top_right, bottom_right, bottom_left = corners
+    ratio = min([1] + [
+        extent / radii_sum
+        for extent, radii_sum in (
+            (width, top_left[0] + top_right[0]),
+            (width, bottom_left[0] + bottom_right[0]),
+            (height, top_left[1] + bottom_left[1]),
+            (height, top_right[1] + bottom_right[1]),
+        )
+        if radii_sum > 0
+    ])
+    return tuple((x * ratio, y * ratio) for x, y in corners)
+
+
+def _outset_radius(radius, spread, coverage):
+    """Return one outset-adjusted radius dimension from CSS Backgrounds."""
+    if spread <= 0:
+        return max(0, radius + spread)
+    if radius > spread or coverage > 1:
+        return radius + spread
+    ratio = radius / spread
+    return radius + spread * (1 - (1 - ratio) ** 3 * (1 - coverage ** 3))
+
+
+def _shadow_box(box, offset_x, offset_y, spread, inset):
+    """Return the rounded perimeter casting an inner or outer shadow."""
+    source = box.rounded_padding_box() if inset else box.rounded_border_box()
+    x, y, width, height, *corners = source
+
+    if inset:
+        original_width, original_height = width, height
+        x += offset_x + spread
+        y += offset_y + spread
+        width = max(0, width - 2 * spread)
+        height = max(0, height - 2 * spread)
+        if spread < 0:
+            adjusted_corners = []
+            for radius_x, radius_y in corners:
+                coverage = 2 * min(
+                    radius_x / original_width if original_width else 0,
+                    radius_y / original_height if original_height else 0)
+                adjusted_corners.append((
+                    _outset_radius(radius_x, -spread, coverage),
+                    _outset_radius(radius_y, -spread, coverage),
+                ))
+            corners = tuple(adjusted_corners)
+        else:
+            corners = tuple(
+                (max(0, radius_x - spread), max(0, radius_y - spread))
+                for radius_x, radius_y in corners)
+    else:
+        original_width, original_height = width, height
+        x += offset_x - spread
+        y += offset_y - spread
+        width = max(0, width + 2 * spread)
+        height = max(0, height + 2 * spread)
+        adjusted_corners = []
+        for radius_x, radius_y in corners:
+            coverage = 2 * min(
+                radius_x / original_width if original_width else 0,
+                radius_y / original_height if original_height else 0)
+            adjusted_corners.append((
+                _outset_radius(radius_x, spread, coverage),
+                _outset_radius(radius_y, spread, coverage),
+            ))
+        corners = tuple(adjusted_corners)
+
+    corners = _normalize_radii(width, height, corners)
+    return x, y, width, height, *corners
+
+
+def _clip_outside_box(stream, box, painting_box):
+    """Clip subsequent painting to the area outside ``box``."""
+    x, y, width, height, *_ = box
+    paint_x, paint_y, paint_width, paint_height, *_ = painting_box
+    left = min(x, paint_x) - 1
+    top = min(y, paint_y) - 1
+    right = max(x + width, paint_x + paint_width) + 1
+    bottom = max(y + height, paint_y + paint_height) + 1
+    stream.rectangle(left, top, right - left, bottom - top)
+    rounded_box(stream, box)
+    stream.clip(even_odd=True)
+    stream.end()
+
+
+def draw_box_shadows(stream, box, inset):
+    """Draw zero-blur inner or outer shadows in CSS painting order."""
+    if box.style['visibility'] != 'visible':
+        return
+
+    source_box = box.rounded_padding_box() if inset else box.rounded_border_box()
+    for offset_x, offset_y, blur, spread, shadow_inset, color in reversed(
+            box.style['box_shadow']):
+        assert blur == 0
+        if shadow_inset != inset or color.alpha == 0:
+            continue
+
+        shadow_box = _shadow_box(box, offset_x, offset_y, spread, inset)
+        with stream.artifact(), stream.stacked():
+            stream.set_color(color)
+            if inset:
+                # Inner shadows are the shifted shadow perimeter's inverse,
+                # clipped to the rounded padding edge. Use an outer rectangle
+                # beyond the clip instead of repeating the padding path: two
+                # coincident antialiased paths can otherwise leave a colored
+                # seam on an edge that the shifted perimeter should clear.
+                rounded_box(stream, source_box)
+                stream.clip()
+                stream.end()
+                source_x, source_y, source_width, source_height, *_ = source_box
+                shadow_x, shadow_y, shadow_width, shadow_height, *_ = shadow_box
+                left = min(source_x, shadow_x) - 1
+                top = min(source_y, shadow_y) - 1
+                right = max(
+                    source_x + source_width, shadow_x + shadow_width) + 1
+                bottom = max(
+                    source_y + source_height, shadow_y + shadow_height) + 1
+                stream.rectangle(left, top, right - left, bottom - top)
+                if shadow_box[2] and shadow_box[3]:
+                    rounded_box(stream, shadow_box)
+                stream.fill(even_odd=True)
+            elif shadow_box[2] and shadow_box[3]:
+                # Outer shadows are clipped out of the border box even when
+                # the element's own background is transparent.
+                _clip_outside_box(stream, source_box, shadow_box)
+                rounded_box(stream, shadow_box)
+                stream.fill()


### PR DESCRIPTION
Partially addresses #13.

## Summary

* Parse and compute the CSS `box-shadow` grammar when every blur radius is zero.
* Paint multiple outer and inset shadows in the specified front-to-back order.
* Support offsets, positive and negative spread, explicit colors, `currentColor`, rounded corners, transparent-box knockout, and collapsed-border table rules.
* Keep PDF output lossless and scalable by representing shadows entirely as vector paths.
* Reject nonzero blur radii with an actionable warning instead of silently accepting an effect that cannot be painted faithfully by this implementation.

## Rationale

The previous implementations in #149 and #859 rasterized shadows. That adds image data to PDF output, scales poorly, and was the central reason those approaches were not merged.

Zero-blur shadows do not have that constraint: their sharp perimeters can be represented directly with PDF paths. A maintainer explicitly noted that this subset would be useful and invited further work in the #13 discussion: https://github.com/Kozea/WeasyPrint/pull/149#issuecomment-1254718532.

This pull request deliberately implements only that lossless subset. It does not introduce Pillow, a blur library, image surfaces, or any new dependency. Blurred shadows, `text-shadow`, and `filter: drop-shadow()` remain separate concerns with different painting and output-policy tradeoffs.

## Implementation notes

* Outer shadows use the border box and are knocked out inside that box even when its background is transparent.
* Inset shadows use the inverse of the shifted padding-box perimeter and are clipped to the rounded padding edge.
* Spread-adjusted radii follow the current CSS Backgrounds radius-expansion algorithm, including its coverage correction for rounded shapes.
* Outer shadows are skipped on internal table boxes in the collapsing-border model; inset shadows remain paintable.
* Shadows are marked as PDF artifacts and participate in the existing transform, opacity, clipping, and stacking machinery.

## Verification

* 913 CSS validation tests pass.
* 9 generic shadow drawing tests pass, covering outer and inset painting, transparent knockout, layer order, spread and `currentColor`, rounded geometry, negative inset spread, collapsed tables, and vector-only PDF output.
* The complete suite reports 4,282 passed and 41 expected failures. The sole failure is the pre-existing Windows path-with-spaces behavior in `test_command_line_render`, where the test helper applies `args.split()` to this checkout's absolute path.
* Ruff reports no issues in the changed Python and test files.
* A generic six-case HTML specimen was rendered to PDF with Ghostscript 10.07.1 and visually inspected. No project-specific data or fixtures are included.

The full suite used the Windows Ghostscript discovery from #2847 as a temporary local test-harness change; that unrelated change is not included in this branch.

## AI assistance disclosure

This change was authored with ChatGPT Codex under human direction and review. Maintainer review remains necessary, particularly for CSS conformance, painting integration, and long-term architecture.
