### PR TITLE
Handle spaces and newlines in URLs

### DIFF
--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -33,6 +33,30 @@ def test_malformed_url_link(url, base_url):
 
 
 @assert_no_logs
+@pytest.mark.parametrize('whitespace', ['\t', '\n', '\r\n'])
+def test_html_url_whitespace(whitespace):
+    """Test HTML whitespace in URLs."""
+    pdf = FakeHTML(string=(
+        f'<a href=" \t\nhttps://weasyprint.org/foo{whitespace}bar\r\n ">'
+        'My Link</a>')).write_pdf()
+
+    assert re.findall(b'/URI \\((.*)\\)', pdf) == [
+        b'https://weasyprint.org/foobar']
+
+
+@assert_no_logs
+def test_html_base_url_whitespace():
+    """Test HTML whitespace in the base URL."""
+    pdf = FakeHTML(string='''
+        <base href=" https://weasyprint.org/foo\nbar/ ">
+        <a href="baz">My Link</a>
+    ''').write_pdf()
+
+    assert re.findall(b'/URI \\((.*)\\)', pdf) == [
+        b'https://weasyprint.org/foobar/baz']
+
+
+@assert_no_logs
 def test_base_url_in_var():
     # Regression test for #2789.
     FakeHTML(

--- a/weasyprint/__init__.py
+++ b/weasyprint/__init__.py
@@ -91,7 +91,7 @@ __all__ = [
 
 
 # Import after setting the version, as the version is used in other modules
-from .urls import URLFetcher, select_source  # noqa: I001, E402
+from .urls import URLFetcher, normalize_url, select_source  # noqa: I001, E402
 from .logger import LOGGER, PROGRESS_LOGGER  # noqa: E402
 # Some imports are at the end of the file (after the CSS class)
 # to work around circular imports.
@@ -105,7 +105,7 @@ def _find_base_url(html_document, fallback_base_url):
     """
     first_base_element = next(iter(html_document.iter('base')), None)
     if first_base_element is not None:
-        href = first_base_element.get('href', '').strip()
+        href = normalize_url(first_base_element.get('href', ''))
         if href:
             return urljoin(fallback_base_url, href)
     return fallback_base_url

--- a/weasyprint/css/__init__.py
+++ b/weasyprint/css/__init__.py
@@ -28,7 +28,13 @@ from PIL.ImageCms import ImageCmsProfile
 from .. import CSS
 from ..logger import LOGGER, PROGRESS_LOGGER
 from ..text.fonts import FontConfiguration
-from ..urls import URLFetchingError, fetch, get_url_attribute, url_join
+from ..urls import (
+    URLFetchingError,
+    fetch,
+    get_url_attribute,
+    normalize_url,
+    url_join,
+)
 from . import counters, media_queries
 from .computed_values import COMPUTER_FUNCTIONS, PHYSICAL_FUNCTIONS
 from .functions import Function, check_math, check_var
@@ -356,7 +362,7 @@ def find_style_attributes(tree, presentational_hints=False, base_url=None):
         if lang := element.get('lang'):
             yield parse_declaration(f'-weasy-lang:"{lang}"')
 
-        if href := element.get('href', '').strip(html.WHITESPACE):
+        if href := normalize_url(element.get('href', '')):
             yield parse_declaration(f'-weasy-link:"{href}"')
 
         if id_ := element.get('id'):

--- a/weasyprint/urls.py
+++ b/weasyprint/urls.py
@@ -22,6 +22,9 @@ from .logger import LOGGER
 UNICODE_SCHEME_RE = re.compile('^([a-zA-Z][a-zA-Z0-9.+-]+):')
 BYTES_SCHEME_RE = re.compile(b'^([a-zA-Z][a-zA-Z0-9.+-]+):')
 
+HTML_WHITESPACE = ' \t\n\f\r'
+URL_WHITESPACE_TRANSLATION = str.maketrans('', '', '\t\n\r')
+
 FILESYSTEM_ENCODING = sys.getfilesystemencoding()
 
 HTTP_HEADERS = {
@@ -97,6 +100,11 @@ def url_is_absolute(url):
     return bool(scheme.match(url))
 
 
+def normalize_url(url):
+    """Remove whitespace ignored in URLs parsed from HTML attributes."""
+    return url.strip(HTML_WHITESPACE).translate(URL_WHITESPACE_TRANSLATION)
+
+
 def get_url_attribute(element, attr_name, base_url, allow_relative=False):
     """Get the URI corresponding to the ``attr_name`` attribute.
 
@@ -109,7 +117,7 @@ def get_url_attribute(element, attr_name, base_url, allow_relative=False):
     Otherwise return an URI, absolute if possible.
 
     """
-    if value := element.get(attr_name, '').strip():
+    if value := normalize_url(element.get(attr_name, '')):
         context = f'<{element.tag} {attr_name}="{value}">'
         return url_join(base_url or '', value, allow_relative, context)
 


### PR DESCRIPTION
Fix #2851.

Normalize HTML URL attributes before resolution, stripping surrounding HTML whitespace and removing embedded ASCII tabs and newlines. The regression covers links and document base URLs.
