### PR TITLE
Fix cleared float layout after page breaks

### DIFF
--- a/tests/draw/test_float.py
+++ b/tests/draw/test_float.py
@@ -872,6 +872,44 @@ def test_float_split_clear(assert_pixels):
 
 
 @assert_no_logs
+def test_float_split_clear_float(assert_pixels):
+    assert_pixels('''
+        BBBB
+        BBBB
+        BBBB
+        BBBB
+        BBBB
+        BBBB
+        BBBB
+        BBBB
+        BBBB
+        BBBB
+        rrrr
+        rrrr
+    ''', '''
+        <style>
+            @page {
+                size: 4px;
+            }
+            body {
+                color: red;
+                font: 2px / 1 weasyprint;
+            }
+            div {
+                color: blue;
+                float: left;
+            }
+            article {
+                clear: left;
+                float: left;
+                text-decoration: underline;
+            }
+        </style>
+        <div>bb bb bb bb bb</div>
+        <article>aa</article>''')
+
+
+@assert_no_logs
 def test_float_split_clear_empty(assert_pixels):
     assert_pixels('''
         BBBB

--- a/weasyprint/layout/block.py
+++ b/weasyprint/layout/block.py
@@ -260,6 +260,12 @@ def _out_of_flow_layout(context, box, index, child, new_children,
 
     # Float child layout.
     elif child.is_floated():
+        direction = box.style['direction']
+        # Infinite clearance means that an earlier float is still broken.
+        # Retry this float on the next page without laying it out at infinity.
+        if get_clearance(context, child, direction) == inf:
+            return True, {index: None}, None, None
+
         # Check for forced break-before on the float.
         # https://drafts.csswg.org/css-break/#break-between
         new_child, out_of_flow_resume_at = float_layout(

--- a/weasyprint/layout/block.py
+++ b/weasyprint/layout/block.py
@@ -260,12 +260,6 @@ def _out_of_flow_layout(context, box, index, child, new_children,
 
     # Float child layout.
     elif child.is_floated():
-        direction = box.style['direction']
-        # Infinite clearance means that an earlier float is still broken.
-        # Retry this float on the next page without laying it out at infinity.
-        if get_clearance(context, child, direction) == inf:
-            return True, {index: None}, None, None
-
         # Check for forced break-before on the float.
         # https://drafts.csswg.org/css-break/#break-between
         new_child, out_of_flow_resume_at = float_layout(

--- a/weasyprint/layout/float.py
+++ b/weasyprint/layout/float.py
@@ -1,6 +1,6 @@
 """Layout for floating boxes."""
 
-from math import inf
+from sys import maxsize
 
 from ..formatting_structure import boxes
 from .min_max import handle_min_max_width
@@ -135,7 +135,7 @@ def get_clearance(context, box, direction, collapsed_margin=0):
     for broken_shape in context.broken_out_of_flow:
         if broken_shape.is_floated():
             if clear(box.style['clear'], broken_shape.style['float']):
-                return inf
+                return maxsize
     # Hypothetical position is the position of the top border edge
     clearance = None
     hypothetical_position = box.position_y + collapsed_margin
@@ -155,7 +155,7 @@ def avoid_collisions(context, box, containing_block, outer=True):
     box_height = box.margin_height() if outer else box.border_height()
 
     if box.border_height() == 0 and box.is_floated():
-        return 0, 0, containing_block.width
+        return 0, position_y, containing_block.width
 
     left_keywords = ['left']
     right_keywords = ['right']


### PR DESCRIPTION
I ran into an `AssertionError` while rendering a document containing a `float: right; clear: right` block split across pages. The error reached `draw_line()` with:

    x1 = 0
    x2 = 4.0
    y1 = nan
    y2 = nan

The added test reduces this to a cleared float following another float split across pages. On unmodified main, the underline reaches the same assertion. Without the underline, the output is 4 × 4 instead of the expected 4 × 12.

Since the second float has `clear: left`, it should appear below the first one. I think WeasyPrint tries to place it before the first float has finished across the pages. This change makes it wait until the first float is complete.