### PR TITLE
Add test for duplicated inline flex item borders

### DIFF
--- a/tests/draw/test_box.py
+++ b/tests/draw/test_box.py
@@ -154,6 +154,25 @@ def test_borders_box_sizing(assert_pixels):
 
 
 @assert_no_logs
+def test_inline_flex_item_border(assert_same_renderings):
+    source = '''
+      <style>
+        @page { size: 10px }
+        body { display: flex; margin: 0 }
+        div {
+          display: %s;
+          width: 4px;
+          height: 4px;
+          border: 1px solid red;
+        }
+        span { width: 2px; height: 2px; background: blue }
+      </style>
+      <div><span></span></div>
+    '''
+    assert_same_renderings(source % 'flex', source % 'inline-flex')
+
+
+@assert_no_logs
 def test_margin_boxes(assert_pixels):
     assert_pixels('''
         _______________


### PR DESCRIPTION
I ran into an issue where the border of an `inline-flex` element is drawn twice when the element is itself a flex item.

The added test compares otherwise identical `flex` and `inline-flex` items. It currently fails because a pixel that is blue in the flex version is red in the inline-flex version because of the extra border.

This PR only adds a small reproduction because I’m not sure what the correct fix should be.