### PR TITLE
Do not fill <line>: it has no interior

### DIFF
--- a/tests/draw/svg/test_shapes.py
+++ b/tests/draw/svg/test_shapes.py
@@ -458,3 +458,32 @@ def test_rect_fill_inherit(assert_pixels):
         <rect x="2" y="2" width="5" height="5" fill="inherit" />
       </svg>
     ''')
+
+
+@assert_no_logs
+def test_line_dash(assert_pixels):
+    # A line has no interior, so the default fill must not turn the paint
+    # operation into fill-and-stroke: when it did, the gaps between the
+    # dashes were not blank but joined by a continuous thread. Deliberately
+    # no fill="none" here -- that is the workaround this test makes
+    # unnecessary. Same geometry as test_line above, plus a dash pattern.
+    assert_pixels('''
+        _________
+        _________
+        _________
+        _________
+        RR__RR___
+        RR__RR___
+        _________
+        _________
+        _________
+    ''', '''
+      <style>
+        @page { size: 9px }
+        svg { display: block }
+      </style>
+      <svg width="9px" height="9px" xmlns="http://www.w3.org/2000/svg">
+        <line x1="0" y1="5" x2="6" y2="5"
+          stroke="red" stroke-width="2" stroke-dasharray="2"/>
+      </svg>
+    ''')

--- a/weasyprint/svg/__init__.py
+++ b/weasyprint/svg/__init__.py
@@ -726,8 +726,15 @@ class SVG:
 
     def set_graphical_state(self, node, font_size, context=None):
         """Set stroke and fill colors, gradients, patterns, and line options."""
-        # Get fill data
-        source, fill = node.get_paint('fill', context)
+        # Get fill data. A 'line' has no interior, so 'fill' cannot paint
+        # anything on it. Leaving the default fill in place makes fill_stroke()
+        # choose the fill-and-stroke painting operator instead of stroke-only,
+        # which changes the rendering: a dashed line comes out with a
+        # continuous thread running through the gaps between the dashes.
+        if node.tag == 'line':
+            source = fill = None
+        else:
+            source, fill = node.get_paint('fill', context)
         opacity = alpha_value(node.get('fill-opacity', 1))
         if gradient := self.gradients.get(source):
             fill = draw_gradient(self, node, gradient, font_size, opacity, stroke=False)


### PR DESCRIPTION
Fixes #2858.

`set_graphical_state()` resolves `fill` for every node, including `<line>`.
A line has no interior, so `fill` cannot paint anything on it — but a resolved
fill makes `fill_stroke()` take the `fill and stroke` branch, and WeasyPrint
emits the PDF `B` operator (fill *and* stroke) instead of `S` (stroke only).

On a solid line that is invisible. On a **dashed** line it is not: the gaps
between the dashes are joined by a continuous thread.

Straight from the generated PDF:

```
%% <line stroke-dasharray="6,4">        %% same line, fill="none"
0 0 0 rg      <- default fill            [6 4] 0 d
[6 4] 0 d                                150 10 m
60 10 m                                  150 90 l
60 90 l                                  S    <- stroke only
B             <- fill AND stroke
```

The change skips fill resolution for `line` only. Everything else is untouched.

**Test:** `test_line_dash`, written to exactly the geometry of the existing
`test_line` with a dash pattern added, and deliberately *without* `fill="none"`
— that attribute is the user-side workaround, and the point of the test is to
make it unnecessary.

**On verification.** I could not get a trustworthy run of the pixel suite
locally: I only have MiKTeX's Ghostscript as a stand-in for `gs`, and with it a
large number of tests fail on unmodified `main` — including `test_line` itself,
at the same pixel my new test reports. So I verified the fix three other ways:

1. the PDF content stream changes from `B` to `S` (above);
2. rasterising the minimal repro independently at 600 dpi, the most-covered
   column of the rule goes from **100 %** (continuous) to **60.6 %**, which is
   the exact duty cycle of a `6,4` pattern;
3. before the patch the new test fails at a pixel *inside a gap*; after it, it
   fails only at the same edge pixel where the pre-existing `test_line` fails in
   my environment.

CI will be the real check on point 3.
