### PR TITLE
Resolve math functions in color values

### DIFF
--- a/tests/css/test_math.py
+++ b/tests/css/test_math.py
@@ -30,6 +30,14 @@ from ..testing_utils import assert_no_logs, capture_logs, render_pages
     'min(100px)',
     'min(100%, 20em, 100px)',
     'calc(min(4, 2) * 50px)',
+    'calc(tan(min(45deg, 60deg)) * 100px)',
+    'calc(tan(max(45deg, 30deg)) * 100px)',
+    'clamp(50px, 100px, 200px)',
+    'clamp(100px, 250px, 50px)',
+    'calc(clamp(1, 2, 3) * 50px)',
+    'calc(clamp(1, 5, 2) * 50px)',
+    'calc(clamp(2, 5, 1) * 50px)',
+    'calc(tan(clamp(30deg, 45deg, 60deg)) * 100px)',
     'calc(sqrt(4) * 50px)',
     'calc(pow(2, 2) * 25px)',
     'calc(hypot(2) * 50px)',
@@ -327,7 +335,6 @@ def test_math_functions_gradient():
     ''')
 
 
-@pytest.mark.xfail
 @assert_no_logs
 def test_math_functions_color():
     render_pages('''
@@ -336,7 +343,6 @@ def test_math_functions_color():
     ''')
 
 
-@pytest.mark.xfail
 @assert_no_logs
 def test_math_functions_gradient_color():
     render_pages('''
@@ -344,6 +350,141 @@ def test_math_functions_gradient_color():
         rgba(10, 20, calc(30), calc(80%)) 10%,
         hsl(calc(10 + 10), 20%, 20%) 80%"></div>
     ''')
+
+
+COLOR_PROPERTIES = (
+    'color', 'background_color', 'border_top_color', 'border_right_color',
+    'border_bottom_color', 'border_left_color', 'column_rule_color',
+    'outline_color', 'text_decoration_color')
+
+
+def _computed_colors(declaration):
+    page, = render_pages(f'<div style="{declaration}">a</div>')
+    html, = page.children
+    body, = html.children
+    div, = body.children
+    return [str(div.style[name]) for name in COLOR_PROPERTIES]
+
+
+@assert_no_logs
+@pytest.mark.parametrize(('color', 'reference'), [
+    # Numbers, percentages and angles, in each channel of each color function.
+    ('rgb(calc(10 + 10), 20, 30)', 'rgb(20, 20, 30)'),
+    ('rgb(calc(10% * 2), 20%, 30%)', 'rgb(20%, 20%, 30%)'),
+    ('rgba(10, 20, 30, calc(0.25 * 2))', 'rgba(10, 20, 30, 0.5)'),
+    ('rgba(10, 20, calc(30), calc(80%))', 'rgba(10, 20, 30, 80%)'),
+    ('hsl(calc(10 + 10), 20%, 20%)', 'hsl(20, 20%, 20%)'),
+    ('hsl(calc(10deg + 10deg), 20%, 20%)', 'hsl(20deg, 20%, 20%)'),
+    ('hsl(20, calc(10% * 2), 20%)', 'hsl(20, 20%, 20%)'),
+    ('hsla(20, 20%, 20%, calc(0.5))', 'hsla(20, 20%, 20%, 0.5)'),
+    ('hwb(calc(10 + 10) 20% 30%)', 'hwb(20 20% 30%)'),
+    ('lab(calc(50%) 40 50)', 'lab(50% 40 50)'),
+    ('lch(calc(50%) 40 50)', 'lch(50% 40 50)'),
+    ('oklab(calc(0.5) 0.1 0.1)', 'oklab(0.5 0.1 0.1)'),
+    ('oklch(calc(0.5) 0.1 50)', 'oklch(0.5 0.1 50)'),
+    ('color(srgb calc(0.1 + 0.1) 0.2 0.3)', 'color(srgb 0.2 0.2 0.3)'),
+    ('device-cmyk(calc(0.1 + 0.1) 0.2 0.3 0.4)', 'device-cmyk(0.2 0.2 0.3 0.4)'),
+    # Every math function, not just calc().
+    ('rgb(min(20, 40), 20, 30)', 'rgb(20, 20, 30)'),
+    ('rgb(max(10, 20), 20, 30)', 'rgb(20, 20, 30)'),
+    ('rgb(clamp(10, 20, 30), 20, 30)', 'rgb(20, 20, 30)'),
+    ('rgb(clamp(20, 5, 30), 20, 30)', 'rgb(20, 20, 30)'),
+    ('rgb(clamp(1, 50, 20), 20, 30)', 'rgb(20, 20, 30)'),
+    ('rgb(clamp(10%, 20%, 30%), 20%, 30%)', 'rgb(20%, 20%, 30%)'),
+    ('hsl(min(20deg, 30deg), 20%, 20%)', 'hsl(20deg, 20%, 20%)'),
+    ('hsl(max(10deg, 20deg), 20%, 20%)', 'hsl(20deg, 20%, 20%)'),
+    ('hsl(clamp(10deg, 20deg, 30deg), 20%, 20%)', 'hsl(20deg, 20%, 20%)'),
+    ('rgb(round(19.6), 20, 30)', 'rgb(20, 20, 30)'),
+    ('rgb(mod(50, 30), 20, 30)', 'rgb(20, 20, 30)'),
+    ('rgb(abs(-20), 20, 30)', 'rgb(20, 20, 30)'),
+    ('rgb(sqrt(400), 20, 30)', 'rgb(20, 20, 30)'),
+    ('rgb(pow(2, 2), 20, 30)', 'rgb(4, 20, 30)'),
+    ('rgb(hypot(12, 16), 20, 30)', 'rgb(20, 20, 30)'),
+    ('rgb(calc(20 * exp(0)), 20, 30)', 'rgb(20, 20, 30)'),
+    ('rgb(calc(10 * log(100, 10)), 20, 30)', 'rgb(20, 20, 30)'),
+    ('rgb(calc(20 * sign(3)), 20, 30)', 'rgb(20, 20, 30)'),
+    ('rgb(calc(20 * sin(90deg)), 20, 30)', 'rgb(20, 20, 30)'),
+    ('rgb(calc(calc(10) + 10), 20, 30)', 'rgb(20, 20, 30)'),
+    ('rgb(calc(20 + pi * 0), 20, 30)', 'rgb(20, 20, 30)'),
+    ('light-dark(rgb(calc(10 + 10), 20, 30), blue)',
+     'light-dark(rgb(20, 20, 30), blue)'),
+])
+def test_math_functions_color_value(color, reference):
+    # A math function in a color must give the same result as the value it
+    # evaluates to, as required by CSS Values and Units 4.
+    assert _computed_colors(f'color: {color}') == (
+        _computed_colors(f'color: {reference}'))
+
+
+@assert_no_logs
+@pytest.mark.parametrize('css_property', [
+    'color', 'background-color', 'border-top-color', 'border-right-color',
+    'border-bottom-color', 'border-left-color', 'border-block-start-color',
+    'border-block-end-color', 'border-inline-start-color',
+    'border-inline-end-color', 'column-rule-color', 'outline-color',
+    'text-decoration-color',
+])
+def test_math_functions_color_property(css_property):
+    assert _computed_colors(f'{css_property}: rgb(calc(10 + 10), 20, 30)') == (
+        _computed_colors(f'{css_property}: rgb(20, 20, 30)'))
+
+
+@assert_no_logs
+@pytest.mark.parametrize(('shorthand', 'suffix'), [
+    ('background', ''),
+    ('border', '1px solid '),
+    ('border-top', '1px solid '),
+    ('outline', '1px solid '),
+    ('column-rule', '1px solid '),
+    ('text-decoration', 'underline '),
+])
+def test_math_functions_color_shorthand(shorthand, suffix):
+    assert _computed_colors(
+        f'{shorthand}: {suffix}rgb(calc(10 + 10), 20, 30)') == (
+            _computed_colors(f'{shorthand}: {suffix}rgb(20, 20, 30)'))
+
+
+@pytest.mark.parametrize('color', [
+    # Colors take no length, so these can never be resolved.
+    'rgb(calc(1em), 0, 0)',
+    'rgb(calc(10px), 0, 0)',
+    'rgb(calc(10px + 1em), 0, 0)',
+    'rgb(calc(100%), calc(1em), 0)',
+    'hsl(calc(1em), 20%, 20%)',
+    'rgb(min(1px, 2), 0, 0)',
+    'rgb(clamp(1px, 2, 3), 0, 0)',
+    # Resolving math must not make invalid syntax valid.
+    'rgb(calc(10, 20), 20, 30)',
+    'rgb(calc(10)% 20 30)',
+    'lab(calc(20 + 30)% 40 50)',
+    'notacolor(calc(20), 20, 30)',
+    'light-dark(calc(1em), red)',
+    'light-dark(calc(1em), red, red)',
+])
+def test_math_functions_color_error(color):
+    with capture_logs() as logs:
+        render_pages(f'<div style="color: {color}">a</div>')
+    assert len(logs) == 1
+
+
+@assert_no_logs
+@pytest.mark.parametrize(('stops', 'reference'), [
+    ('rgb(calc(10 + 10), 20, 30) 10%, blue 80%', 'rgb(20, 20, 30) 10%, blue 80%'),
+    ('rgb(calc(10 + 10), 20, 30), blue', 'rgb(20, 20, 30), blue'),
+    ('rgba(10, 20, calc(30), calc(80%)) 10%, hsl(calc(10 + 10), 20%, 20%) 80%',
+     'rgba(10, 20, 30, 80%) 10%, hsl(20, 20%, 20%) 80%'),
+])
+def test_math_functions_gradient_color_stops(stops, reference):
+    def gradient_colors(value):
+        page, = render_pages(
+            f'<div style="width: 10px; height: 10px;'
+            f' background: linear-gradient({value})">a</div>')
+        html, = page.children
+        body, = html.children
+        div, = body.children
+        (_, gradient), = div.style['background_image']
+        return [str(color) for color in gradient.colors]
+    assert gradient_colors(stops) == gradient_colors(reference)
 
 
 @assert_no_logs

--- a/weasyprint/css/__init__.py
+++ b/weasyprint/css/__init__.py
@@ -793,6 +793,30 @@ def _resolve_calc_value(computed, tokens):
                 return NAN
 
 
+def _resolve_math_argument(token, computed, property_name, refer_to, unit):
+    """Get the ``(unit, value, token)`` of a min(), max() or clamp() argument.
+
+    ``unit`` is the unit family of the previous arguments, as values of different
+    families can’t be compared. Return ``None`` for invalid arguments.
+
+    """
+    if token.type == 'percentage' and refer_to is not None:
+        token = tokenize(token.value / 100 * refer_to, unit='px')
+    if token.type == 'percentage':
+        argument_unit, value = '%', token.value
+    elif token.type == 'number':
+        argument_unit, value = '', token.value
+    elif token.unit.lower() in ANGLE_UNITS:
+        argument_unit, value = 'rad', to_radians(token)
+    else:
+        argument_unit, value = 'px', to_pixels(token, computed, property_name)
+    if unit not in (None, argument_unit):
+        if '%' in (unit, argument_unit):
+            raise PercentageInMath
+        return
+    return argument_unit, value, token
+
+
 def resolve_math(token, computed=None, property_name=None, refer_to=None):
     """Return token with resolved math functions.
 
@@ -833,33 +857,15 @@ def resolve_math(token, computed=None, property_name=None, refer_to=None):
             token = _resolve_calc_sum(computed, tokens, property_name, refer_to)
             if token is None:
                 return
-            if token.type == 'percentage':
-                if refer_to is None:
-                    if unit in ('px', ''):
-                        raise PercentageInMath
-                    unit = '%'
-                    value = token
-                else:
-                    unit = 'px'
-                    token = value = tokenize(token.value / 100 * refer_to, unit='px')
-            elif token.type == 'number':
-                if unit == '%':
-                    raise PercentageInMath
-                elif unit == 'px':
-                    return
-                unit = ''
-                value = tokenize(token.value, unit='px')
-            else:
-                if unit == '%':
-                    raise PercentageInMath
-                elif unit == '':
-                    return
-                unit = 'px'
-                value = tokenize(to_pixels(token, computed, property_name), unit='px')
+            resolved = _resolve_math_argument(
+                token, computed, property_name, refer_to, unit)
+            if resolved is None:
+                return
+            unit, value, token = resolved
             update_condition = (
                 target_value is None or
-                (function.name == 'min' and value.value < target_value.value) or
-                (function.name == 'max' and value.value > target_value.value))
+                (function.name == 'min' and value < target_value) or
+                (function.name == 'max' and value > target_value))
             if update_condition:
                 target_value, target_token = value, token
         return tokenize(target_token)
@@ -956,34 +962,23 @@ def resolve_math(token, computed=None, property_name=None, refer_to=None):
         return tokenize(math.atan2(y, x), unit='rad')
 
     elif function.name == 'clamp':
-        pixels_list = []
-        unit = None
+        values, tokens_list, unit = [], [], None
         for tokens in args:
             token = _resolve_calc_sum(computed, tokens, property_name, refer_to)
             if token is None:
                 return
-            if token.type == 'percentage':
-                if refer_to is None:
-                    if unit == 'px':
-                        raise PercentageInMath
-                    unit = '%'
-                    value = token
-                else:
-                    unit = 'px'
-                    token = tokenize(token.value / 100 * refer_to, unit='px')
-            else:
-                if unit == '%':
-                    raise PercentageInMath
-                unit = 'px'
-                pixels = to_pixels(token, computed, property_name)
-                value = tokenize(pixels, unit='px')
-            pixels_list.append(value)
-        min_token, token, max_token = pixels_list
-        if token.value < min_token.value:
-            token = min_token
-        if token.value > max_token.value:
-            token = max_token
-        return tokenize(token)
+            resolved = _resolve_math_argument(
+                token, computed, property_name, refer_to, unit)
+            if resolved is None:
+                return
+            unit, value, token = resolved
+            values.append(value)
+            tokens_list.append(token)
+        # clamp(min, value, max) is max(min, min(value, max)).
+        index = 1 if values[1] <= values[2] else 2
+        if values[index] < values[0]:
+            index = 0
+        return tokenize(tokens_list[index])
 
     elif function.name == 'pow':
         number_token, power_token = [

--- a/weasyprint/css/computed_values.py
+++ b/weasyprint/css/computed_values.py
@@ -3,13 +3,12 @@
 from functools import partial
 from math import pi
 
-from tinycss2.color5 import parse_color
-
 from ..logger import LOGGER
 from ..text.line_break import strut
 from ..urls import get_link
 from .functions import check_math
 from .properties import INITIAL_VALUES, ZERO_PIXELS, Dimension
+from .tokens import get_color
 from .units import LENGTH_UNITS, to_pixels
 
 # Value in pixels of font-size for <absolute-size> keywords: 12pt (16px) for
@@ -255,7 +254,7 @@ def image(style, name, image):
 @register_computer('outline-color')
 @register_computer('text-decoration-color')
 def color(style, name, values):
-    return parse_color(values, style['color_scheme'])
+    return get_color(values, style['color_scheme'])
 
 
 @register_computer('background-position')

--- a/weasyprint/css/tokens.py
+++ b/weasyprint/css/tokens.py
@@ -103,14 +103,14 @@ def parse_color_hint(tokens):
 
 def parse_color_stop(tokens):
     if len(tokens) == 1:
-        color = parse_color(tokens[0])
+        color = get_color(tokens[0])
         if color == 'currentcolor':
             # TODO: return the current color instead
             return parse_color('black'), None
         if color is not None:
             return color, None
     elif len(tokens) == 2:
-        color = parse_color(tokens[0])
+        color = get_color(tokens[0])
         position = get_length(tokens[1], negative=True, percentage=True)
         if color is not None and position is not None:
             return color, position
@@ -453,6 +453,20 @@ def get_resolution(token):
         factor = RESOLUTION_TO_DPPX.get(token.unit.lower())
         if factor is not None:
             return token.value * factor
+
+
+def get_color(token, color_schemes=None):
+    """Parse a <color> token, resolving math functions first."""
+    from . import resolve_math
+
+    if check_math(token):
+        try:
+            token = resolve_math(token) or token
+        except (PercentageInMath, RelativeLengthInMath):
+            # Colors take no length, so relative units and percentages that need a
+            # reference size are always invalid here.
+            return
+    return parse_color(token, color_schemes)
 
 
 def get_image(token, base_url):

--- a/weasyprint/css/validation/expanders.py
+++ b/weasyprint/css/validation/expanders.py
@@ -3,14 +3,13 @@
 import functools
 
 from tinycss2.ast import DimensionToken, IdentToken, NumberToken
-from tinycss2.color5 import parse_color
 
 from ..functions import check_var
 from ..properties import INITIAL_VALUES
 from .descriptors import expand_font_variant
 
 from ..tokens import (  # isort:skip
-    InvalidValues, Pending, get_keyword, get_single_keyword, split_on_comma)
+    InvalidValues, Pending, get_color, get_keyword, get_single_keyword, split_on_comma)
 from .properties import (  # isort:skip
     background_attachment, background_image, background_position, background_repeat,
     background_size, block_ellipsis, border_image_source, border_image_slice,
@@ -312,7 +311,7 @@ def expand_border_side(tokens, name):
 
     """
     for token in tokens:
-        if parse_color(token) is not None:
+        if get_color(token) is not None:
             suffix = '-color'
         elif border_width([token]) is not None:
             suffix = '-width'
@@ -578,7 +577,7 @@ def expand_text_decoration(tokens, name):
             if style:
                 raise InvalidValues
             style.append(token)
-        elif parse_color(token):
+        elif get_color(token):
             if color:
                 raise InvalidValues
             color.append(token)

--- a/weasyprint/css/validation/properties.py
+++ b/weasyprint/css/validation/properties.py
@@ -7,16 +7,15 @@ See https://www.w3.org/TR/CSS21/propidx.html and various CSS3 modules.
 from math import inf
 
 from tinycss2 import parse_component_value_list
-from tinycss2.color5 import parse_color
 
 from .. import computed_values
 from ..functions import Function, check_var
 from ..properties import KNOWN_PROPERTIES, ZERO_PIXELS, Dimension
 
 from ..tokens import (  # isort:skip
-    InvalidValues, Pending, comma_separated_list, get_angle, get_content_list,
-    get_content_list_token, get_custom_ident, get_image, get_keyword, get_length,
-    get_number, get_percentage, get_resolution, get_single_keyword, get_url,
+    InvalidValues, Pending, comma_separated_list, get_angle, get_color,
+    get_content_list, get_content_list_token, get_custom_ident, get_image, get_keyword,
+    get_length, get_number, get_percentage, get_resolution, get_single_keyword, get_url,
     parse_2d_position, parse_position, remove_whitespace, single_keyword, single_token)
 
 PREFIX = '-weasy-'
@@ -131,7 +130,7 @@ def background_attachment(keyword):
 @property('text-decoration-color')
 @single_token
 def other_colors(token):
-    if parse_color(token):
+    if get_color(token):
         return token
 
 
@@ -140,7 +139,7 @@ def other_colors(token):
 def outline_color(token):
     if get_keyword(token) == 'invert':
         return 'currentcolor'
-    elif parse_color(token):
+    elif get_color(token):
         return token
 
 
@@ -161,7 +160,7 @@ def empty_cells(keyword):
 @single_token
 def color(token):
     """``*-color`` and ``color`` properties validation."""
-    result = parse_color(token)
+    result = get_color(token)
     if result == 'currentcolor':
         return 'inherit'
     elif result:


### PR DESCRIPTION
`parse_color()` is the only value type in `css/tokens.py` that never runs the `check_math`/`resolve_math` prologue that `get_number`, `get_percentage`, `get_length` and `get_angle` all open with, so every `<color>`-valued property silently rejects `calc()` and friends:

```css
color: rgb(calc(10 + 10), 20, 30);          /* ignored */
background: rgba(10, 20, calc(30), calc(80%));
background-image: linear-gradient(hsl(calc(10 + 10), 20%, 20%), blue);
```

This adds the missing sibling wrapper, `get_color()`, and routes the validation-time call sites (`color`/`*-color` validators, the `border`/`outline`/`column-rule`/`text-decoration` expanders, gradient color stops, and the color computer) through it. It covers `color`, `background-color`, every `border-*`/`outline`/`column-rule`/`text-decoration` color, gradient stops and `light-dark()`. The 2 xfail tests you added in "Add more tests for math functions" now pass and are un-xfailed.

Colors carry their channels as numbers, percentages and angles, and auditing that surface turned up a second, pre-existing bug: `min()`/`max()`/`clamp()` assumed length arguments, so `clamp(1, 2, 3)`, `clamp(1deg, 2deg, 3deg)` and mixed-unit arguments raised an uncaught `AttributeError` and aborted the whole render (independent of colors, e.g. `width: clamp(1, 2, 3)`). The three branches are factored into one `_resolve_math_argument` helper that compares by unit family, so those cases resolve or are rejected cleanly.

`rgb(calc(1em), 0, 0)` and other length-in-color forms stay invalid, since colors take no lengths.

Tested: `tests/css/test_math.py` (un-xfailed + new parametrized coverage for the color functions, every math function in a color, the property family, gradient stops, and the negative cases); full non-`draw` suite green with no new failures.
