### PR TITLE
Add support of the box-shadow property

### DIFF
--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -572,26 +572,27 @@ background layers per box), including the ``background``, ``background-color``,
 ``background-position``, ``background-clip``, ``background-origin`` and
 ``background-size`` properties.
 
-WeasyPrint also supports the `rounded corners part`_ of this module, including
+WeasyPrint supports the `rounded corners part`_ of this module, including
 the ``border-radius`` property.
 
-WeasyPrint also supports the `border images part`_ of this module, including the
+WeasyPrint supports the `border images part`_ of this module, including the
 ``border-image``, ``border-image-source``, ``border-image-slice``,
 ``border-image-width``, ``border-image-outset`` and ``border-image-repeat``
 properties.
 
-WeasyPrint does **not** support the `box shadow part`_ of this module,
-including the ``box-shadow`` property. This feature has been implemented in a
-`git branch`_ that is not released, as it relies on raster implementation of
-shadows.
+WeasyPrint supports the `box shadow part`_ of this module, including the
+``box-shadow`` property. Blur should be avoided, as it is approximated using
+gradients, which may be rendered poorly by PDF readers, and are limited in
+some extreme situations (very large or uneven border radii, very large blur
+regions, etc.) Real Gaussian blur requires raster images that are not adapted
+to WeasyPrint’s vector PDF output.
 
 .. _CSS Backgrounds and Borders Level 3: https://www.w3.org/TR/css-backgrounds-3/
 .. _border part: https://www.w3.org/TR/css-backgrounds-3/#borders
 .. _background part: https://www.w3.org/TR/css-backgrounds-3/#backgrounds
 .. _rounded corners part: https://www.w3.org/TR/css-backgrounds-3/#corners
 .. _border images part: https://www.w3.org/TR/css-backgrounds-3/#border-images
-.. _box shadow part: https://www.w3.org/TR/css-backgrounds-3/#misc
-.. _git branch: https://github.com/Kozea/WeasyPrint/pull/149
+.. _box shadow part: https://www.w3.org/TR/css-backgrounds-3/#box-shadow
 
 CSS Image Values and Replaced Content Module Level 3 / 4
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/tests/css/test_validation.py
+++ b/tests/css/test_validation.py
@@ -5,6 +5,7 @@ from math import pi
 
 import pytest
 import tinycss2
+from tinycss2.color5 import parse_color
 
 from weasyprint.css import preprocess_declarations
 from weasyprint.css.validation.properties import PROPERTIES
@@ -1349,3 +1350,56 @@ def test_color_scheme(rule, value):
 ])
 def test_color_scheme_invalid(rule):
     assert_invalid(f'color-scheme: {rule}')
+
+
+@assert_no_logs
+@pytest.mark.parametrize(('rule', 'value'), [
+    ('none', ()),
+    ('1px 10px', (
+        ((1, 'px'), (10, 'px'), (0, 'px'), (0, 'px'), 'currentcolor', False),)),
+    ('1px 10px 0 3cm', (
+        ((1, 'px'), (10, 'px'), (0, None), (3, 'cm'), 'currentcolor', False),)),
+    ('1px 10px inset', (
+        ((1, 'px'), (10, 'px'), (0, 'px'), (0, 'px'), 'currentcolor', True),)),
+    ('1px 10px 2px 5cm inset', (
+        ((1, 'px'), (10, 'px'), (2, 'px'), (5, 'cm'), 'currentcolor', True),)),
+    ('black 1px 10px 2px 5cm', (
+        ((1, 'px'), (10, 'px'), (2, 'px'), (5, 'cm'), 'black', False),)),
+    ('red 1px 10px inset, blue 1px 10px inset', (
+        ((1, 'px'), (10, 'px'), (0, 'px'), (0, 'px'), 'red', True),
+        ((1, 'px'), (10, 'px'), (0, 'px'), (0, 'px'), 'blue', True))),
+    ('red 1px 10px 2px 5cm', (
+        ((1, 'px'), (10, 'px'), (2, 'px'), (5, 'cm'), 'red', False),)),
+    ('inset red 1px 10px 2px 5cm', (
+        ((1, 'px'), (10, 'px'), (2, 'px'), (5, 'cm'), 'red', True),)),
+    ('1px 10px 2px 5cm red inset', (
+        ((1, 'px'), (10, 'px'), (2, 'px'), (5, 'cm'), 'red', True),)),
+    ('1px 10px, 2px 4px #ff0000', (
+        ((1, 'px'), (10, 'px'), (0, 'px'), (0, 'px'), 'currentcolor', False),
+        ((2, 'px'), (4, 'px'), (0, 'px'), (0, 'px'), 'red', False))),
+])
+def test_box_shadow(rule, value):
+    result = get_value(f'box-shadow: {rule}')
+    for result_shadow, value_shadow in zip(result, value, strict=True):
+        assert result_shadow[:4] == value_shadow[:4]
+        assert result_shadow[5] == value_shadow[5]
+        assert parse_color(result_shadow[4]) == parse_color(result_shadow[4])
+
+
+@assert_no_logs
+@pytest.mark.parametrize('rule', [
+    '1px 10px,',
+    '1px 10px,,1px',
+    '1px red inset',
+    '1px 1px red blue inset',
+    'blue 1px 1px red',
+    'inset 1px 1px 1px blue inset',
+    '1px 10px red 3px',
+    '1px 10px inset 3px',
+    '1px 1px 1px inset inset',
+    '1px 0 0 3%',
+    '1px 0, none',
+    'none, none',
+])
+def test_box_shadow_invalid(rule):
+    assert_invalid(f'box-shadow: {rule}')

--- a/tests/draw/test_box.py
+++ b/tests/draw/test_box.py
@@ -773,3 +773,324 @@ def test_infinite_border_radius(assert_pixels):
       </style>
       <div></div>
     ''')
+
+
+@assert_no_logs
+def test_box_shadow_outset(assert_pixels):
+    assert_pixels('''
+        __________
+        _BBBBB____
+        _BBBBB____
+        _BBBBB____
+        _BBBBBrrr_
+        _BBBBBrrr_
+        ____rrrrr_
+        ____rrrrr_
+        ____rrrrr_
+        __________
+    ''', '''
+      <style>
+        @page { size: 10px; margin: 1px }
+        div { width: 5px; height: 5px; background: blue;
+              box-shadow: 3px 3px red }
+      </style>
+      <body><div>
+    ''')
+
+
+@assert_no_logs
+def test_box_shadow_outset_spread(assert_pixels):
+    assert_pixels('''
+        __________
+        _BBB______
+        _BBBrrrrr_
+        _BBBrrrrr_
+        __rrrrrrr_
+        __rrrrrrr_
+        __rrrrrrr_
+        __rrrrrrr_
+        __rrrrrrr_
+        __________
+    ''', '''
+      <style>
+        @page { size: 10px; margin: 1px }
+        div { width: 3px; height: 3px; background: blue;
+              box-shadow: 3px 3px 0 2px red }
+      </style>
+      <body><div>
+    ''')
+
+
+@assert_no_logs
+def test_box_shadow_outset_negative_spread(assert_pixels):
+    assert_pixels('''
+        __________
+        _BBB______
+        _BBB______
+        _BBB______
+        __________
+        _____r____
+        __________
+        __________
+        __________
+        __________
+    ''', '''
+      <style>
+        @page { size: 10px; margin: 1px }
+        div { width: 3px; height: 3px; background: blue;
+              box-shadow: 3px 3px 0 -1px red }
+      </style>
+      <body><div>
+    ''')
+
+
+@assert_no_logs
+def test_box_shadow_outset_big_negative_spread(assert_pixels):
+    assert_pixels('''
+        __________
+        _BBB______
+        _BBB______
+        _BBB______
+        __________
+        __________
+        __________
+        __________
+        __________
+        __________
+    ''', '''
+      <style>
+        @page { size: 10px; margin: 1px }
+        div { width: 3px; height: 3px; background: blue;
+              box-shadow: 3px 3px 0 -2px red }
+      </style>
+      <body><div>
+    ''')
+
+
+@assert_no_logs
+def test_box_shadow_inset(assert_pixels):
+    assert_pixels('''
+        __________
+        _rrrrrrrr_
+        _rrrrrrrr_
+        _rrrrrrrr_
+        _rrrBBBBB_
+        _rrrBBBBB_
+        _rrrBBBBB_
+        _rrrBBBBB_
+        _rrrBBBBB_
+        __________
+    ''', '''
+      <style>
+        @page { size: 10px; margin: 1px }
+        div { width: 8px; height: 8px; background: blue;
+              box-shadow: 3px 3px red inset }
+      </style>
+      <body><div>
+    ''')
+
+
+@assert_no_logs
+def test_box_shadow_inset_spread(assert_pixels):
+    assert_pixels('''
+        __________
+        _rrrrrrrr_
+        _rrrrrrrr_
+        _rrrrrrrr_
+        _rrrrrrrr_
+        _rrrrBBBB_
+        _rrrrBBBB_
+        _rrrrBBBB_
+        _rrrrBBBB_
+        __________
+    ''', '''
+      <style>
+        @page { size: 10px; margin: 1px }
+        div { width: 8px; height: 8px; background: blue;
+              box-shadow: 3px 3px 0 1px red inset }
+      </style>
+      <body><div>
+    ''')
+
+
+@assert_no_logs
+def test_box_shadow_inset_negative_spread(assert_pixels):
+    assert_pixels('''
+        __________
+        _rrrrrrrr_
+        _rrrrrrrr_
+        _rrrrrrrr_
+        _BBBBBBBr_
+        _BBBBBBBr_
+        _BBBBBBBr_
+        _BBBBBBBr_
+        _BBBBBBBr_
+        __________
+    ''', '''
+      <style>
+        @page { size: 10px; margin: 1px }
+        div { width: 8px; height: 8px; background: blue;
+              box-shadow: -2px 4px 0 -1px red inset }
+      </style>
+      <body><div>
+    ''')
+
+
+@assert_no_logs
+def test_box_shadow_inset_big_negative_spread(assert_pixels):
+    assert_pixels('''
+        __________
+        _BBBBBBBB_
+        _BBBBBBBB_
+        _BBBBBBBB_
+        _BBBBBBBB_
+        _BBBBBBBB_
+        _BBBBBBBB_
+        _BBBBBBBB_
+        _BBBBBBBB_
+        __________
+    ''', '''
+      <style>
+        @page { size: 10px; margin: 1px }
+        div { width: 8px; height: 8px; background: blue;
+              box-shadow: -2px 4px 0 -5px red inset }
+      </style>
+      <body><div>
+    ''')
+
+
+@assert_no_logs
+def test_box_shadow_transparent_background(assert_pixels):
+    assert_pixels('''
+        __________
+        __________
+        __________
+        __________
+        ______rrr_
+        ______rrr_
+        ____rrrrr_
+        ____rrrrr_
+        ____rrrrr_
+        __________
+    ''', '''
+      <style>
+        @page { size: 10px; margin: 1px }
+        div { width: 5px; height: 5px; box-shadow: 3px 3px red }
+      </style>
+      <body><div>
+    ''')
+
+
+@assert_no_logs
+def test_box_shadow_inset_outset(assert_pixels):
+    assert_pixels('''
+        rrrrrrrr__
+        rgggggggg_
+        rgBBBBBBB_
+        rgBBBBBBB_
+        rgBBBBBBB_
+        rgBBBBBBB_
+        rgBBBBBBB_
+        rgBBBBBBB_
+        _gBBBBBBB_
+        __________
+    ''', '''
+      <style>
+        @page { size: 10px; margin: 1px }
+        div { width: 8px; height: 8px; background: blue;
+              box-shadow: -1px -1px red, 1px 1px green inset }
+      </style>
+      <body><div>
+    ''')
+
+
+@assert_no_logs
+def test_box_shadow_multiple_outset(assert_pixels):
+    assert_pixels('''
+        __________
+        _BBBBB____
+        _BBBBBr___
+        _BBBBBrg__
+        _BBBBBrg__
+        _BBBBBrg__
+        __rrrrrg__
+        ___ggggg__
+        __________
+        __________
+    ''', '''
+      <style>
+        @page { size: 10px; margin: 1px }
+        div { width: 5px; height: 5px; background: blue;
+              box-shadow: 1px 1px red, 2px 2px green }
+      </style>
+      <body><div>
+    ''')
+
+
+@assert_no_logs
+def test_box_shadow_multiple_inset(assert_pixels):
+    assert_pixels('''
+        __________
+        _rrrrrrrr_
+        _rrrrrrrr_
+        _rrrrrrrr_
+        _rrrBBBBg_
+        _rrrBBBBg_
+        _rrrBBBBg_
+        _rrrBBBBg_
+        _rrrggggg_
+        __________
+    ''', '''
+      <style>
+        @page { size: 10px; margin: 1px }
+        div { width: 8px; height: 8px; background: blue;
+              box-shadow: 3px 3px red inset, -1px -1px green inset }
+      </style>
+      <body><div>
+    ''')
+
+
+@assert_no_logs
+def test_box_shadow_outset_radius(assert_pixels):
+    assert_pixels('''
+        __________
+        __zzBB____
+        _zzzBB____
+        _zzBzz____
+        _BBzzzzrr_
+        _BBzzzzrr_
+        ____zzrzz_
+        ____rrzzz_
+        ____rrzz__
+        __________
+    ''', '''
+      <style>
+        @page { size: 10px; margin: 1px }
+        div { width: 5px; height: 5px; background: blue;
+              box-shadow: 3px 3px red; border-radius: 4px 0 4px 0 }
+      </style>
+      <body><div>
+    ''')
+
+
+@assert_no_logs
+def test_box_shadow_inset_radius(assert_pixels):
+    assert_pixels('''
+        __________
+        __zzzrrrr_
+        _zzzzrrrr_
+        _zzzzrrrr_
+        _zzzrzzzB_
+        _rrrzzzzB_
+        _rrrzzzzB_
+        _rrrzzzBB_
+        _rrrBBBBB_
+        __________
+    ''', '''
+      <style>
+        @page { size: 10px; margin: 1px }
+        div { width: 8px; height: 8px; background: blue;
+              box-shadow: 3px 3px red inset; border-radius: 4px 0 0 0 }
+      </style>
+      <body><div>
+    ''')

--- a/weasyprint/css/computed_values.py
+++ b/weasyprint/css/computed_values.py
@@ -258,6 +258,15 @@ def color(style, name, values):
     return parse_color(values, style['color_scheme'])
 
 
+@register_computer('box-shadow')
+def box_shadow(style, name, values):
+    return tuple((
+        length(style, name, x), length(style, name, y),
+        length(style, name, blur), length(style, name, spread),
+        parse_color(color, style['color_scheme']), inset,
+    ) for x, y, blur, spread, color, inset in values)
+
+
 @register_computer('background-position')
 @register_computer('object-position')
 def compute_position(style, name, values):

--- a/weasyprint/css/properties.py
+++ b/weasyprint/css/properties.py
@@ -77,6 +77,7 @@ INITIAL_VALUES = {
         Dimension(0, None), Dimension(0, None),
         Dimension(0, None), Dimension(0, None)),
     'border_image_repeat': ('stretch', 'stretch'),
+    'box_shadow': (),
     'mask_border_source': ('none', None),
     'mask_border_slice': (
         Dimension(100, '%'), Dimension(100, '%'),

--- a/weasyprint/css/validation/properties.py
+++ b/weasyprint/css/validation/properties.py
@@ -310,6 +310,44 @@ def border_style(keyword):
                        'inset', 'outset', 'groove', 'ridge', 'solid')
 
 
+@property('box-shadow')
+def box_shadow(tokens):
+    """`box-shadow` property validation."""
+    if get_single_keyword(tokens) == 'none':
+        return ()
+    shadows = []
+    while tokens := list(tokens):
+        lengths = []
+        color = None
+        inset = False
+        last_length = False
+        while tokens:
+            token = tokens.pop(0)
+            if token.type == 'literal' and token.value == ',' and tokens:
+                break
+            elif token.type == 'ident' and token.value == 'inset' and not inset:
+                inset = True
+                last_length = False
+            elif (length := get_length(token)) and not (lengths and not last_length):
+                lengths.append(length)
+                last_length = True
+            elif not color and parse_color(token):
+                color = token
+                last_length = False
+            else:
+                return
+        if not (2 <= len(lengths) <= 4):
+            return
+        x, y = lengths.pop(0), lengths.pop(0)
+        blur = lengths.pop(0) if lengths else ZERO_PIXELS
+        if blur.value < 0:
+            return
+        spread = lengths.pop(0) if lengths else ZERO_PIXELS
+        color = color or 'currentcolor'
+        shadows.append((x, y, blur, spread, color, inset))
+    return tuple(shadows)
+
+
 @property('break-before')
 @property('break-after')
 @single_keyword

--- a/weasyprint/draw/__init__.py
+++ b/weasyprint/draw/__init__.py
@@ -1,11 +1,12 @@
 """Take an "after layout" box tree and draw it onto a pydyf stream."""
 
 import operator
-from math import floor
+from math import floor, pi
 from xml.etree import ElementTree
 
+from ..css.properties import Dimension
 from ..formatting_structure import boxes
-from ..images import SVGImage
+from ..images import LinearGradient, RadialGradient, SVGImage
 from ..layout import replaced
 from ..layout.background import BackgroundLayer
 from ..matrix import Matrix
@@ -136,28 +137,144 @@ def draw_stacking_context(stream, stacking_context):
                 stream.draw_x_object(group_id)
 
 
-def draw_background(stream, bg, clip_box=True, bleed=None, marks=()):
+def _spread_box(box, spread, tx, ty):
+    if not any((spread, tx, ty)):
+        return box
+
+    # Update coordinates.
+    x = box[0] + tx - spread
+    y = box[1] + ty - spread
+    width = max(0, box[2] + 2 * spread)
+    height = max(0, box[3] + 2 * spread)
+
+    # Update radii.
+    radii = [
+        [r[0] + spread, r[1] + spread] if r[0] >= -spread and r[1] >= -spread and all(r)
+        else [0, 0] for r in box[4:]]
+
+    return x, y, width, height, *radii
+
+
+def _draw_box_shadow(stream, box, style, tx, ty, blur, spread, color, inset):
+    stream.set_color(color)
+
+    # Original rounded box values.
+    shadow_box = _spread_box(box, spread, tx, ty)
+    inner_box = _spread_box(box, spread - blur, tx, ty)
+    outer_box = _spread_box(box, spread + blur, tx, ty)
+
+    # Mask original box.
+    if not inset:
+        rounded_box(stream, outer_box)
+    rounded_box(stream, box)
+    stream.clip(even_odd=True)
+    stream.end()
+
+    # No blur: we render the rounded box with spread applied.
+    if not blur:
+        if inset:
+            rounded_box(stream, box)
+        rounded_box(stream, shadow_box)
+        stream.fill(even_odd=True)
+        return
+
+    # Fill the outer rectangle if inset, the plain rectangle if outset.
+    if inset:
+        rounded_box(stream, box)
+        rounded_box(stream, outer_box)
+        stream.fill(even_odd=True)
+    else:
+        rounded_box(stream, inner_box)
+        stream.fill()
+
+    # Variables for blur: linear gradient sides and corners.
+    transparent = color.to(color.space)
+    transparent.alpha = 0
+    repeat = False
+    shape = 'ellipse'
+    x, y, w, h = inner_box[:4]
+    (tlcx, tlcy), (trcx, trcy), (brcx, brcy), (blcx, blcy) = inner_box[4:]
+    sides = (
+        (0, x + tlcx, y - 2 * blur, w - tlcx - trcx, 2 * blur),
+        (pi / 2, x + w, y + trcy, 2 * blur, h - trcy - brcy),
+        (pi, x + blcx, y + h, w - blcx - brcx, 2 * blur),
+        (3 * pi / 2, x - 2 * blur, y + tlcy, 2 * blur, h - tlcy - blcy))
+    corners = (
+        (100, 100, x - 2 * blur, y - 2 * blur, tlcx, tlcy),
+        (0, 100, x + w - trcx, y - 2 * blur, trcx, trcy),
+        (0, 0, x + w - brcx, y + h - brcy, brcx, brcy),
+        (100, 0, x - 2 * blur, y + h - blcy, blcx, blcy))
+    in_color, out_color = (transparent, color) if inset else (color, transparent)
+
+    # Draw sides.
+    stops = [(in_color, None), (out_color, None)]
+    hints = [Dimension(blur * 1.25, 'px')]
+    for angle, e, f, width, height in sides:
+        gradient = LinearGradient(stops, ('angle', angle), repeat, hints)
+        with stream.stacked():
+            stream.transform(e=e, f=f)
+            gradient.draw(stream, width, height, style)
+
+    # Draw corners.
+    with stream.stacked():
+        rounded_box(stream, inner_box)
+        rounded_box(stream, outer_box)
+        stream.clip(even_odd=True)
+        stream.end()
+        for left, top, e, f, cx, cy in corners:
+            width, height = 2 * blur + cx, 2 * blur + cy
+            size = ('explicit', (Dimension(width, 'px'), Dimension(height, 'px')))
+            stops = [(in_color, Dimension(cx, 'px')), (out_color, None)]
+            hints = [Dimension(cx + blur * 1.25, 'px')]
+            center = ('left', Dimension(left, '%'), 'top', Dimension(top, '%'))
+            gradient = RadialGradient(stops, shape, size, center, repeat, hints)
+            with stream.stacked():
+                stream.transform(e=e, f=f)
+                gradient.draw(stream, width, height, style)
+
+
+def draw_box_shadows(stream, boxes, style, inset):
+    """Draw box shadows."""
+    for x, y, blur, spread, color, shadow_inset in reversed(style['box_shadow']):
+        # Only draw inset or outset shadows.
+        if inset != shadow_inset:
+            continue
+
+        tx, ty, blur = x.value, y.value, blur.value
+        spread = -spread.value if inset else spread.value
+        color = style['color'] if color == 'currentcolor' else color
+
+        for box in boxes:
+            with stream.stacked():
+                _draw_box_shadow(stream, box, style, tx, ty, blur, spread, color, inset)
+
+
+def draw_background(stream, background, clip_box=True, bleed=None, marks=()):
     """Draw the background color and image to a ``pdf.stream.Stream``.
 
     If ``clip_box`` is set to ``False``, the background is not clipped to the
     border box of the background, but only to the painting area.
 
     """
-    if bg is None:
+    if background is None or not background.layers:
         return
+
+    clipped_boxes = background.layers[-1].clipped_boxes
+    painting_area = background.layers[-1].painting_area
+
+    draw_box_shadows(stream, clipped_boxes, background.style, inset=False)
 
     with stream.stacked():
         if clip_box:
-            for box in bg.layers[-1].clipped_boxes:
+            for box in clipped_boxes:
                 rounded_box(stream, box)
             stream.clip()
             stream.end()
 
         # Draw background color.
-        if bg.color.alpha > 0:
+        if background.color.alpha > 0:
             with stream.artifact(), stream.stacked():
-                stream.set_color(bg.color)
-                painting_area = bg.layers[-1].painting_area
+                stream.set_color(background.color)
                 stream.rectangle(*painting_area)
                 stream.clip()
                 stream.end()
@@ -166,7 +283,7 @@ def draw_background(stream, bg, clip_box=True, bleed=None, marks=()):
 
         # Draw crop marks and crosses.
         if bleed and marks:
-            x, y, width, height = bg.layers[-1].painting_area
+            x, y, width, height = painting_area
             half_bleed = {key: value * 0.5 for key, value in bleed.items()}
             svg = f'''
               <svg height="{height}" width="{width}"
@@ -229,10 +346,12 @@ def draw_background(stream, bg, clip_box=True, bleed=None, marks=()):
             layer = BackgroundLayer(
                 image, size, position, repeat, unbounded, painting_area,
                 positioning_area, clipped_boxes)
-            bg.layers.insert(0, layer)
+            background.layers.insert(0, layer)
         # Paint in reversed order: first layer is "closest" to the viewer.
-        for layer in reversed(bg.layers):
-            draw_background_image(stream, layer, bg.style)
+        for layer in reversed(background.layers):
+            draw_background_image(stream, layer, background.style)
+
+    draw_box_shadows(stream, clipped_boxes, background.style, inset=True)
 
 
 def draw_background_image(stream, layer, style):

--- a/weasyprint/layout/background.py
+++ b/weasyprint/layout/background.py
@@ -74,7 +74,7 @@ def layout_box_backgrounds(page, box, get_image_from_uri, layout_children=True,
             for type_, value in style['background_image']]
         color = get_color(style, 'background_color')
 
-    if color.alpha == 0 and not any(images):
+    if color.alpha == 0 and not any(images) and not style['box_shadow']:
         if box != page:  # Pages need a background for bleed box
             box.background = None
             return


### PR DESCRIPTION
Related to #13.

The current code should work correctly for sharp shadows.

Blur is approximated using gradients, which give a pretty good results when the shadow is light, but is not a Gaussian blur as required by the specification. Gaussian blur requires rasterization, and we don’t want that in PDF.

Known limitations with blur are:

- poor PDF rendering, including artifacts because of rounding errors,
- large or dark shadows, where the difference with Gaussian blur is very visible,
- different x/y values of border radii are not correctly approximated by radial gradients,
- with very large border radii, radial gradients are not cropped correctly.

We don’t want to fix these limitations now, and will only fix them in the future if the changes are small and easy to maintain. Blurred shadows are pretty rare in printed documents, and usually very subtle, so they should be rendered quite correctly with the current code.