### PR TITLE
Preserve the original HTML metadata name case for custom metadata keys

### DIFF
--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -9,7 +9,7 @@ from .testing_utils import BASE_URL, assert_no_logs
 from weasyprint.html import (  # isort:skip
     map_to_dimension_property, map_to_dimension_property_ignoring_zero,
     map_to_pixel_length, parse_dimension_value, parse_integer,
-    parse_non_negative_integer, parse_string, parse_url)
+    parse_non_negative_integer, parse_string, parse_url, get_html_metadata)
 
 
 PH_TESTING_CSS = CSS(string='''
@@ -302,6 +302,47 @@ def test_ph_embedded():
     assert img.width == 10
     assert img.height == 20
 
+
+@assert_no_logs
+def test_custom_metadata_preserve_case():
+    metadata = get_html_metadata(HTML(string='''
+      <meta name="SomeExampleAttribute" content="Hello World">
+    '''))
+
+    assert metadata['custom'] == {
+        'SomeExampleAttribute': 'Hello World'
+    }
+
+@assert_no_logs
+def test_custom_metadata_duplicate_key():
+    # The first value encountered should be preserved.
+    metadata = get_html_metadata(HTML(string='''
+      <meta name="SomeExampleAttribute" content="Hello World">
+      <meta name="someEXAMPLEattribute" content="Hello World">
+    '''))
+
+    assert metadata['custom'] == {
+        'SomeExampleAttribute': 'Hello World'
+    }
+
+@assert_no_logs
+def test_standard_metadata_is_lowercased():
+    metadata = get_html_metadata(HTML(string='''
+      <meta name="DesCRIPTION" content="Hello World">
+    '''))
+
+    assert metadata['description'] == 'Hello World'
+
+@assert_no_logs
+def test_standard_metadata_not_also_in_custom():
+    # desCRIPTION ("Hello World 2") should not appear in the custom metadata dict.
+    metadata = get_html_metadata(HTML(string='''
+      <meta name="description" content="Hello World 1">
+      <meta name="desCRIPTION" content="Hello World 2">
+    '''))
+
+    assert metadata['description'] == 'Hello World 1'
+    assert metadata['custom'] == dict()
 
 @pytest.mark.parametrize(('string', 'expected'), [
     ('42', 42),

--- a/weasyprint/html.py
+++ b/weasyprint/html.py
@@ -355,35 +355,58 @@ def get_html_metadata(html):
     created = None
     modified = None
     attachments = []
+
+    # Custom metadata stored with original case.
     custom = {}
+    # Used to detect equivalent custom names differing only by case.
+    custom_metadata_names = set()
+
     lang = html.etree_element.attrib.get('lang', None)
     for element in html.wrapper_element.query_all('title', 'meta', 'link'):
         element = element.etree_element
         if element.tag == 'title' and title is None:
             title = get_child_text(element)
         elif element.tag == 'meta':
-            name = ascii_lower(element.get('name', ''))
+            name_original = element.get('name', '')
+            name_lower = ascii_lower(name_original)
             content = element.get('content', '')
-            if name == 'keywords':
+            if name_lower == 'keywords':
                 for keyword in map(strip_whitespace, content.split(',')):
                     if keyword not in keywords:
                         keywords.append(keyword)
-            elif name == 'author':
+            elif name_lower == 'author':
                 authors.append(content)
-            elif name == 'description':
+            elif name_lower == 'description':
                 if description is None:
                     description = content
-            elif name == 'generator':
+            elif name_lower == 'generator':
                 if generator is None:
                     generator = content
-            elif name == 'dcterms.created':
+
+            elif name_lower == 'dcterms.created':
                 if created is None:
-                    created = parse_w3c_date(name, content)
-            elif name == 'dcterms.modified':
+                    created = parse_w3c_date(name_lower, content)
+
+            elif name_lower == 'dcterms.modified':
                 if modified is None:
-                    modified = parse_w3c_date(name, content)
-            elif name and name not in custom:
-                custom[name] = content
+                    modified = parse_w3c_date(name_lower, content)
+
+            elif name_lower:
+                # For custom metadata names, we preserve original case.
+                # Example:
+                #   <meta name="CamelCase" ...>
+                # stays:
+                #   /CamelCase
+                #
+                # If both:
+                #   CamelCase
+                #   camelcase
+                # are present, only the first one is kept ("first occurrence wins" behavior)
+
+                if name_lower not in custom_metadata_names:
+                    custom[name_original] = content
+                    custom_metadata_names.add(name_lower)
+
         elif element.tag == 'link' and element_has_link_type(
                 element, 'attachment'):
             url = get_url_attribute(element, 'href', html.base_url)


### PR DESCRIPTION
Preserve the original metadata name case for custom metadata keys while continuing to compare names using ascii_lower(). Standard metadata names retain current behavior (converted to lowercase).

Unit tests are added to validate this change.

Fixes #2860