### PR TITLE
Document automatic PDF regeneration on source changes

### DIFF
--- a/docs/common_use_cases.rst
+++ b/docs/common_use_cases.rst
@@ -2,6 +2,49 @@ Common Use Cases
 ================
 
 
+Regenerate PDFs Automatically
+-----------------------------
+
+During development, you can automatically regenerate a PDF whenever an HTML or
+CSS file changes. On Linux, install ``inotify-tools`` and save the following
+script as ``watch.sh``:
+
+.. code-block:: sh
+
+  #!/bin/sh
+
+  input=${1:-document.html}
+  output=${2:-${input%.*}.pdf}
+
+  render() {
+      if ! weasyprint "$input" "$output"; then
+          printf 'PDF generation failed\n' >&2
+      fi
+  }
+
+  render
+  while inotifywait \
+      --quiet \
+      --recursive \
+      --event close_write,create,delete,move \
+      --include '\.(html|css)$' \
+      .; do
+      render
+  done
+
+Make the script executable and give it the paths of the input and output
+files:
+
+.. code-block:: sh
+
+  $ chmod +x watch.sh
+  $ ./watch.sh document.html document.pdf
+
+The script watches the current directory and its subdirectories. Change the
+final ``.`` passed to ``inotifywait`` if the files to watch are stored
+elsewhere.
+
+
 Include in Web Applications
 ---------------------------
 

--- a/docs/common_use_cases.rst
+++ b/docs/common_use_cases.rst
@@ -6,19 +6,20 @@ Regenerate PDFs Automatically
 -----------------------------
 
 During development, you can automatically regenerate a PDF whenever an HTML or
-CSS file changes. On Linux, install ``inotify-tools`` and run:
+CSS file changes. On Linux, macOS and Windows, install watchexec_.
 
-.. code-block:: sh
-
-  while inotifywait -e modify document.html style.css; do
-      python -m weasyprint document.html document.pdf
-  done
-
-On macOS and Windows, install watchexec_ and run:
+To watch specific files, run:
 
 .. code-block:: sh
 
   watchexec --watch document.html --watch style.css -- python -m weasyprint document.html document.pdf
+
+To watch all HTML and CSS files in the current directory and its subdirectories,
+use an extension filter:
+
+.. code-block:: sh
+
+  watchexec -e html,css -- python -m weasyprint document.html document.pdf
 
 Replace the filenames in these examples with your own HTML, CSS and PDF paths.
 

--- a/docs/common_use_cases.rst
+++ b/docs/common_use_cases.rst
@@ -6,43 +6,23 @@ Regenerate PDFs Automatically
 -----------------------------
 
 During development, you can automatically regenerate a PDF whenever an HTML or
-CSS file changes. On Linux, install ``inotify-tools`` and save the following
-script as ``watch.sh``:
+CSS file changes. On Linux, install ``inotify-tools`` and run:
 
 .. code-block:: sh
 
-  #!/bin/sh
-
-  input=${1:-document.html}
-  output=${2:-${input%.*}.pdf}
-
-  render() {
-      if ! weasyprint "$input" "$output"; then
-          printf 'PDF generation failed\n' >&2
-      fi
-  }
-
-  render
-  while inotifywait \
-      --quiet \
-      --recursive \
-      --event close_write,create,delete,move \
-      --include '\.(html|css)$' \
-      .; do
-      render
+  while inotifywait -e modify document.html style.css; do
+      python -m weasyprint document.html document.pdf
   done
 
-Make the script executable and give it the paths of the input and output
-files:
+On macOS and Windows, install watchexec_ and run:
 
 .. code-block:: sh
 
-  $ chmod +x watch.sh
-  $ ./watch.sh document.html document.pdf
+  watchexec --watch document.html --watch style.css -- python -m weasyprint document.html document.pdf
 
-The script watches the current directory and its subdirectories. Change the
-final ``.`` passed to ``inotifywait`` if the files to watch are stored
-elsewhere.
+Replace the filenames in these examples with your own HTML, CSS and PDF paths.
+
+.. _watchexec: https://watchexec.github.io/
 
 
 Include in Web Applications


### PR DESCRIPTION
## Summary

- document a cross-platform workflow for regenerating PDFs with `watchexec`
- include an example for watching specific HTML and CSS files
- include an extension-filter example for watching HTML and CSS files recursively

## Motivation

This gives developers a concise workflow for automatically rebuilding a PDF while editing its HTML and CSS sources on Linux, macOS and Windows.

Closes #1360.

## Validation

- built the complete Sphinx documentation with warnings treated as errors
- tested the specific-file and extension-filter modes with Watchexec 2.5.1 on Windows
- verified that HTML and CSS changes rerun the configured command
