### PR TITLE
Give every (glyph, text) pair its own ToUnicode identity (#2841)

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -674,6 +674,59 @@ def test_to_unicode_rtl():
 
 
 @assert_no_logs
+def test_to_unicode_cluster_glyphs(tmp_path):
+    # Regression test for #2841.
+    # A font whose GSUB draws one character as two glyphs, shared between
+    # characters — the shape of Noto Sans Arabic, where a dotted letter is a
+    # skeleton glyph plus a dots glyph. 'b' and 'c' share their dots glyph;
+    # 'q' and 'r' share their skeleton glyph. Each character must keep exactly
+    # one ToUnicode entry of its own, whether its private glyph is real
+    # ('b', 'c', 'q') or a substitute id had to be made ('r').
+    from fontTools.feaLib.builder import addOpenTypeFeaturesFromString
+    from fontTools.fontBuilder import FontBuilder
+    from fontTools.pens.ttGlyphPen import TTGlyphPen
+
+    from weasyprint.text.fonts import FontConfiguration
+
+    pen = TTGlyphPen(None)
+    pen.moveTo((50, 0))
+    pen.lineTo((50, 700))
+    pen.lineTo((550, 700))
+    pen.lineTo((550, 0))
+    pen.closePath()
+    box = pen.glyph()
+    builder = FontBuilder(1000, isTTF=True)
+    names = [
+        '.notdef', 'b', 'c', 'q', 'r', 'b.skel', 'c.skel', 'qr.skel', 'dots']
+    builder.setupGlyphOrder(names)
+    builder.setupCharacterMap({ord(letter): letter for letter in 'bcqr'})
+    builder.setupGlyf({name: box for name in names})
+    builder.setupHorizontalMetrics({name: (600, 50) for name in names})
+    builder.setupHorizontalHeader(ascent=800, descent=-200)
+    builder.setupNameTable({'familyName': 'cluster', 'styleName': 'Regular'})
+    builder.setupOS2()
+    builder.setupPost()
+    addOpenTypeFeaturesFromString(builder.font, '''
+        feature ccmp {
+            sub b by b.skel dots;
+            sub c by c.skel dots;
+            sub q by qr.skel dots;
+            sub r by qr.skel dots;
+        } ccmp;''')
+    builder.save(str(tmp_path / 'cluster.ttf'))
+
+    font_config = FontConfiguration()
+    pdf = FakeHTML(string='''
+      <style>
+        @font-face { font-family: cluster; src: url(cluster.ttf) }
+        body { font-family: cluster }
+      </style>bcqr''', base_url=str(tmp_path / 'index.html')).write_pdf(
+        uncompressed_pdf=True, font_config=font_config)
+    for letter in 'bcqr':
+        assert pdf.count(b' <%04x>' % ord(letter)) == 1, letter
+
+
+@assert_no_logs
 def test_no_redirect():
     with http_server() as root_url:
         _run(f'--no-http-redirect {root_url}/gzip -')

--- a/weasyprint/draw/text.py
+++ b/weasyprint/draw/text.py
@@ -175,10 +175,26 @@ def draw_first_line(stream, textbox, text_overflow, block_ellipsis, matrix):
             string = ''
             stream.set_font_size(font.hash, 1 if font.bitmap else font_size)
         string += '<'
+        # The codepoints of each cluster, found before drawing: the first shown
+        # glyph of a cluster carries them all in ToUnicode, the other glyphs of
+        # the cluster carry none — glyphs shared between clusters, like the
+        # dots of Arabic letters, must not carry any one letter’s codepoints.
+        cluster_texts = {}
+        start = 0
+        for i in range(1, number_of_glyphs + 1):
+            if i == number_of_glyphs or clusters[i] != clusters[start]:
+                utf8_slice = slice(*sorted(
+                    (utf8_positions[start], utf8_positions[i])))
+                cluster_texts[start] = (
+                    utf8_text[utf8_slice].decode(), i - start > 1)
+                start = i
+        text, in_cluster = '', False
         for i in range(number_of_glyphs):
             glyph_info = glyphs_info[i]
             glyph_id = glyph_info.glyph
             width = glyph_info.geometry.width
+            if i in cluster_texts:
+                text, in_cluster = cluster_texts[i]
 
             # Display zero-width empty glyph.
             if glyph_id == pango.PANGO_GLYPH_EMPTY:
@@ -199,10 +215,12 @@ def draw_first_line(stream, textbox, text_overflow, block_ellipsis, matrix):
                     # want to keep Pango’s layout for next glyphs.
                     font.widths[0] = font.widths[glyph_id]
 
-            # Create mapping between glyphs and Unicode codepoints.
-            if glyph_id not in font.to_unicode:
-                utf8_slice = slice(*sorted(utf8_positions[i:i+2]))
-                font.to_unicode[glyph_id] = utf8_text[utf8_slice].decode()
+            # Give the glyph its ToUnicode identity, possibly through a
+            # substitute glyph id when this glyph already carries other
+            # codepoints (see Font.resolve_glyph).
+            outline_glyph_id = glyph_id
+            glyph_id = font.resolve_glyph(glyph_id, text, in_cluster)
+            text = ''
 
             # Set horizontal and vertical offsets.
             offset = glyph_info.geometry.x_offset / font_size
@@ -232,7 +250,8 @@ def draw_first_line(stream, textbox, text_overflow, block_ellipsis, matrix):
                 logical_width = font.widths[glyph_id]
             else:
                 pango.pango_font_get_glyph_extents(
-                    pango_font, glyph_id, stream.ink_rect, stream.logical_rect)
+                    pango_font, outline_glyph_id, stream.ink_rect,
+                    stream.logical_rect)
                 logical_width = font.widths[glyph_id] = round(
                     stream.logical_rect.width * 1000 * FROM_UNITS / font_size)
 

--- a/weasyprint/pdf/fonts.py
+++ b/weasyprint/pdf/fonts.py
@@ -17,7 +17,7 @@ from ..text.fonts import get_hb_object_data, get_pango_font_hb_face
 
 
 class Font:
-    def __init__(self, pango_font, description, font_size):
+    def __init__(self, pango_font, description, font_size, fonts=None):
         self.hb_font = pango.pango_font_get_hb_font(pango_font)
         self.hb_face = get_pango_font_hb_face(pango_font)
         self.file_content = get_hb_object_data(self.hb_face)
@@ -102,7 +102,19 @@ class Font:
         self.stemh = 80
         self.widths = {}
         self.to_unicode = {}
-        self.missing = {}
+        # Substitute and missing glyph ids extend the FILE's glyph space, and
+        # one file can back several Font instances (used at several sizes, or
+        # in forms — synthesized small caps draw one file at two sizes), so
+        # instances sharing a file share one id registry: ids allocated by any
+        # instance stay unique, and the one embedded file gets them all.
+        for other in (fonts or {}).values():
+            if other.hash == self.hash:
+                self.aliases = other.aliases
+                self.missing = other.missing
+                break
+        else:
+            self.aliases = {}
+            self.missing = {}
         self.used_in_forms = False
 
         # Set font flags.
@@ -112,10 +124,103 @@ class Font:
         if b'Serif' in name.split(b' '):
             self.flags += 2 ** (2 - 1)  # Serif
 
+    def resolve_glyph(self, glyph, text, in_cluster):
+        """The glyph id to show for this text — a substitute id if needed.
+
+        Text extraction concatenates the ToUnicode values of the glyphs that
+        were shown, so it is only right when each shown glyph id carries
+        exactly the codepoints it was drawn for — including none: the extra
+        glyphs of a multi-glyph cluster, like the shared dots of a decomposed
+        Arabic letter, get ``text == ''``. A glyph id can only carry ONE value,
+        and complex fonts reuse glyphs across clusters (Noto Sans Arabic draws
+        ق and ة as different skeletons plus the same two-dots glyph, and ب and
+        ت as the same skeleton plus different dots), so the first text a glyph
+        is drawn with keeps the real id and any other text gets a substitute
+        id, drawn as a component of the real glyph (see _embed_aliases).
+
+        A single-glyph cluster never steals a glyph that already reads back
+        as other text: deliberate double mappings (U+00A0 reading back as the
+        space it shares a glyph with, synthesized small caps reading back as
+        the capital they scale) keep reading back as they always have, and
+        renderers may rasterize the same outline differently under another id
+        at very small sizes, so identity only changes where extraction is
+        otherwise wrong. A glyph that reads back as NOTHING does get a
+        substitute even alone — it was claimed as the silent extra of an
+        earlier cluster, and bare س would otherwise vanish from every document
+        where ش came first. No substitute can be made for bitmap or CFF
+        fonts, emoji fonts whose color tables are looked up by id, or a full
+        16-bit glyph space: the cluster then reads back as the text its
+        glyphs already carry, never as an invented longer string.
+        """
+        current = self.to_unicode.get(glyph)
+        if current is None or current == text:
+            self.to_unicode[glyph] = text
+            return glyph
+        if not (in_cluster or current == ''):
+            return glyph
+        if self.bitmap or self.png or self.svg or self.type == 'otf':
+            return glyph
+        key = (glyph, text)
+        if key not in self.aliases:
+            alias = self.glyph_count + len(self.missing) + len(self.aliases)
+            if alias > 2 ** 16 - 1:
+                return glyph
+            self.aliases[key] = alias
+            self.to_unicode[alias] = text
+            if glyph in self.widths:
+                self.widths[alias] = self.widths[glyph]
+        return self.aliases[key]
+
+    def _embed_aliases(self):
+        """Copy each substitute glyph's outline into the font file.
+
+        Substitute ids (see resolve_glyph) are shown by the page's content
+        streams and mapped by ToUnicode, so the embedded font must draw them:
+        each gets a copy of its real glyph. Ids reserved for missing glyphs
+        (see get_unused_glyph_id) share the id space above glyph_count and get
+        a copy of .notdef, so every id up to the highest substitute exists.
+        """
+        from fontTools.ttLib.tables._g_l_y_f import (
+            Glyph,
+            GlyphComponent,
+            GlyphCoordinates,
+        )
+
+        sources = {alias: glyph for (glyph, _), alias in self.aliases.items()}
+        full_font = io.BytesIO(self.file_content)
+        ttfont = TTFont(full_font, fontNumber=self.index)
+        glyph_order = ttfont.getGlyphOrder()
+        glyf, hmtx = ttfont['glyf'], ttfont['hmtx']
+        for alias in range(len(glyph_order), max(sources) + 1):
+            source = glyph_order[sources.get(alias, 0)]
+            name = f'alias{alias}'
+            # A composite pointing at the real glyph, not a copy of its
+            # outline: renderers rasterize it through the component, so the
+            # substitute paints pixel-identically to the glyph it stands for.
+            component = GlyphComponent()
+            component.glyphName = source
+            component.x = component.y = 0
+            component.flags = 0x0204    # ARGS_ARE_XY_VALUES | USE_MY_METRICS
+            composite = Glyph()
+            composite.numberOfContours = -1
+            composite.components = [component]
+            composite.coordinates = GlyphCoordinates()
+            glyf.glyphs[name] = composite
+            hmtx.metrics[name] = hmtx.metrics[source]
+            glyph_order.append(name)
+        ttfont.setGlyphOrder(glyph_order)
+        glyf.glyphOrder = glyph_order
+        ttfont['maxp'].numGlyphs = len(glyph_order)
+        ttfont['post'].formatType = 3.0    # no glyph names to keep consistent
+        optimized_font = io.BytesIO()
+        ttfont.save(optimized_font)
+        self.file_content = optimized_font.getvalue()
+
     def get_unused_glyph_id(self, codepoint):
         """Get a glyph id that’s not used in the font, for given Unicode codepoint."""
         if codepoint not in self.missing:
-            next_unused_glyph_id = self.glyph_count + len(self.missing)
+            next_unused_glyph_id = (
+                self.glyph_count + len(self.missing) + len(self.aliases))
             if next_unused_glyph_id > 2 ** 16 - 1:
                 LOGGER.warning(
                     'Too many glyphs missing from "%s", '
@@ -126,6 +231,11 @@ class Font:
 
     def clean(self, to_unicode, hinting):
         """Remove useless data from font."""
+
+        # Draw the substitute glyphs the content streams show, whether the
+        # font is then subset or embedded whole.
+        if self.aliases:
+            self._embed_aliases()
 
         # Subset font.
         self.subset(to_unicode, hinting)
@@ -194,8 +304,12 @@ class Font:
         if not to_unicode:
             return
 
-        if harfbuzz_subset and harfbuzz.hb_version_atleast(4, 1, 0):
-            # 4.1.0 is required for hb_set_add_sorted_array.
+        if (not self.aliases and harfbuzz_subset and
+                harfbuzz.hb_version_atleast(4, 1, 0)):
+            # 4.1.0 is required for hb_set_add_sorted_array. HarfBuzz subsets
+            # hb_face, read from the original file: it cannot see the
+            # substitute glyphs _embed_aliases added, so Fonttools — which
+            # reads the updated file content — subsets those fonts.
             self._harfbuzz_subset(to_unicode, hinting)
         else:
             self._fonttools_subset(to_unicode, hinting)
@@ -350,6 +464,11 @@ def build_fonts_dictionary(pdf, fonts, compress, subset, options):
             b'<0000> <ffff>',
             b'endcodespacerange'], compress=compress)
         to_unicode_stream = to_unicode_object.stream
+        # Glyphs with no text of their own (the extra glyphs of a multi-glyph
+        # cluster, see Font.resolve_glyph) map to the empty string on purpose:
+        # an absent entry makes extractors fall back to garbage — pypdf emits
+        # chr(glyph_id), pdfminer emits (cid:N) — while <gid> <> reads back as
+        # exactly nothing in both.
         to_unicode_length = len(to_unicode)
         to_unicode_items = tuple(to_unicode.items())
         for i in range(ceil(to_unicode_length / 100)):

--- a/weasyprint/pdf/stream.py
+++ b/weasyprint/pdf/stream.py
@@ -184,7 +184,8 @@ class Stream(pydyf.Stream):
     def add_font(self, pango_font):
         key, description, font_size = get_pango_font_key(pango_font)
         if key not in self._fonts:
-            self._fonts[key] = Font(pango_font, description, font_size)
+            self._fonts[key] = Font(
+                pango_font, description, font_size, self._fonts)
         return self._fonts[key], font_size
 
     def add_group(self, x, y, width, height):


### PR DESCRIPTION
Fixes #2841 — the mapping half; c9f2626 covered the standalone empty strings. *(Force-pushed once: the first version only redistributed existing glyph ids and could not recover letters whose every glyph is shared; this version makes every mapping exact.)*

## The defect

`draw_first_line` maps each glyph from a per-glyph utf-8 slice, first come first served. When GSUB draws one character as several glyphs (Noto Sans Arabic draws a dotted letter as a skeleton plus a *shared* dots glyph) two things go wrong:

- inside a multi-glyph cluster the slice `utf8_positions[i:i+2]` gives the whole character to one glyph and the **empty string** to the others — the empty bfchar entries in the issue title;
- a **shared** glyph keeps whichever character it was first drawn with and carries it into every other cluster that reuses it: `الطاقة` extracts as `الطاةة`, a different real word, silently.

## The change

1. Cluster codepoints are found before drawing; the first shown glyph of each cluster carries them, the other glyphs of the cluster carry none.
2. `Font.resolve_glyph` keeps the map exact: the first text a glyph is drawn with keeps the real glyph id, and any *other* text gets a **substitute glyph id**. `Font._embed_aliases` adds each substitute to the font file before subsetting (or whole embedding) as a **composite glyph pointing at the real glyph** — a component, not a copy, so renderers rasterize it through the glyph it stands for. Instances of one file share the id registry, so a file used at several sizes or in forms stays consistent.
3. A single-glyph cluster never steals a glyph that already reads back as other *text* — U+00A0 keeps reading back as the space it shares a glyph with, synthesized small caps keep reading back as their capital, and none of their rendering changes (that constraint came from the draw tests: renderers can rasterize the same outline differently under another id at tiny sizes). But a glyph that reads back as *nothing* does get a substitute even alone, or bare س would vanish from every document where ش came first.
4. The silent extra glyphs of a cluster keep an **explicitly empty** CMap entry (`<gid> <>`), deliberately. Measured:

| non-carrier glyph | pypdf | pdfminer.six |
|---|---|---|
| absent from CMap | falls back to `chr(glyph_id)` mojibake (`ğ`), and that stray LTR letter then derails its bidi reordering, losing *other* letters | `(cid:N)` inside words |
| mapped to `<>` | reads back as nothing | reads back as nothing |

5. Fonts where a substitute cannot be drawn (CFF, bitmap, color fonts whose tables are looked up by id, a full 16-bit glyph space) keep the first text and degrade exactly as before — never as an invented longer string.

## Measured effect (Noto Sans Arabic 2.013, static)

| text | main | this branch |
|---|---|---|
| `الطاقة`, pypdf | `الطاةة` (a different word) | `الطاقة` exact |
| 48-word wrapped paragraph, words findable, pypdf | 13/48 | **48/48** |
| a second 26-word paragraph, words findable | 8/26 | **26/26** |

Rendering is unchanged: Ghostscript renders of the same paragraph on main and on this branch differ by 10 antialiasing pixels on a 1240×1754 page, letterforms identical; the full draw suite passes.

## On c9f2626

Since it was asked in the issue: with c9f2626 in, no standalone empty string is shown anymore; empty `<>` elements still occur *inside* TJ arrays (`[<>103<0055>0] TJ`) — measured harmless to both extractors above.

## Tests

`test_to_unicode_cluster_glyphs` builds a nine-glyph TTF with fontTools (already a dependency) whose `ccmp` decomposes four characters over a shared dots glyph and a shared skeleton glyph — the Noto shape without shipping a font. On main, three of the four characters never reach the CMap; with this change each has exactly one entry, one of them through a substitute id. Full suite: 4264 passed, 40 xfailed (draw tests included), ruff clean.
