### PR TITLE
Fix IndexError when absolute content overflows a margin box

### DIFF
--- a/tests/layout/test_page.py
+++ b/tests/layout/test_page.py
@@ -1793,3 +1793,32 @@ def test_running_float():
         Hello!
       </footer>
     ''')
+
+
+@assert_no_logs
+def test_running_absolute_overflow():
+    # Regression test for #2857.
+    paragraphs = '\n'.join(f'<p>Paragraph {i}.</p>' for i in range(30))
+    render_pages(f'''
+      <style>
+        header {{
+          position: running(header);
+        }}
+        div {{
+          position: absolute;
+          top: 0;
+          left: 0;
+          right: 0;
+        }}
+        @page {{
+          size: 100px;
+          margin: 60px 10px 10px;
+          @top-center {{
+            content: element(header);
+            width: 100%;
+          }}
+        }}
+      </style>
+      <header><div>{paragraphs}</div></header>
+      <p>Text</p>
+    ''')

--- a/weasyprint/layout/__init__.py
+++ b/weasyprint/layout/__init__.py
@@ -289,8 +289,14 @@ class LayoutContext:
         self.finish_block_formatting_context(root_box)
 
     def add_broken_out_of_flow(self, new_box, box, containing_block, resume_at):
+        # Margin boxes are laid out outside of any block formatting context, so
+        # the stack of root boxes may be empty. ``None`` is already handled as
+        # "no formatting context" when the broken box is laid out again.
+        root_box = (
+            self._excluded_shapes_root_boxes[-1]
+            if self._excluded_shapes_root_boxes else None)
         self.broken_out_of_flow[new_box] = (
-            box, containing_block, self._excluded_shapes_root_boxes[-1], resume_at)
+            box, containing_block, root_box, resume_at)
 
     def get_string_set_for(self, page, name, keyword='first'):
         """Resolve value of string function."""


### PR DESCRIPTION
Fixes #2857.

Margin boxes are laid out outside of any block formatting context, so `_excluded_shapes_root_boxes` is empty while their content is laid out. When an absolutely positioned box inside a running element overflowed the margin box, `absolute_layout()` called `add_broken_out_of_flow()`, which indexed that empty list and raised `IndexError` instead of rendering. It now falls back to `None`, which `make_page()` already handles as "no formatting context" when the broken box is laid out again.

The new `test_running_absolute_overflow` in `tests/layout/test_page.py` fails with `IndexError` without the fix and passes with it.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
