### PR TITLE
Write explicit color-space objects for shading and transparency-group…

### DIFF
--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -768,6 +768,20 @@ def test_custom_rdf_metadata():
 
 
 @assert_no_logs
+def test_color_spaces_with_icc_output_intent():
+    shading_pdf = FakeHTML(string='''
+      <style>html { background: linear-gradient(red, blue) }</style>
+    ''').write_pdf(output_intent='srgb')
+    group_pdf = FakeHTML(string='''
+      <div style="width: 1px; height: 1px; background: red; opacity: .5"></div>
+    ''').write_pdf(output_intent='srgb')
+
+    profile = rb'\[/ICCBased \d+ 0 R\]'
+    assert re.search(rb'/ShadingType 2/ColorSpace ' + profile, shading_pdf)
+    assert re.search(rb'/Group <<[^>]+/CS ' + profile, group_pdf)
+
+
+@assert_no_logs
 def test_font_descent_ascent():
     pdf = FakeHTML(string='''
       <html style="font-family: weasyprint">abc

--- a/weasyprint/pdf/stream.py
+++ b/weasyprint/pdf/stream.py
@@ -205,7 +205,7 @@ class Stream(pydyf.Stream):
                 'Type': '/Group',
                 'S': '/Transparency',
                 'I': 'true',
-                'CS': f'/{self._default_color_space}',
+                'CS': self._default_color_space,
             }),
         })
         group = self.clone(resources=resources, extra=extra)
@@ -258,7 +258,8 @@ class Stream(pydyf.Stream):
                     color_space=None):
         shading = pydyf.Dictionary({
             'ShadingType': shading_type,
-            'ColorSpace': f'/{color_space or self._default_color_space}',
+            'ColorSpace': (
+                f'/{color_space}' if color_space else self._default_color_space),
             'Domain': pydyf.Array(domain),
             'Coords': pydyf.Array(coords),
             'Function': function,
@@ -326,12 +327,13 @@ class Stream(pydyf.Stream):
     @property
     def _default_color_space(self):
         if self._output_intent in self._color_profiles:
-            return self._output_intent
+            profile = self._color_profiles[self._output_intent]
         elif self._output_intent == 'device-cmyk':
-            return 'DeviceCMYK'
+            return '/DeviceCMYK'
         elif 'device-cmyk' in self._color_profiles:
-            return 'DeviceCMYK'
+            return '/DeviceCMYK'
         elif self._color_profiles:
-            return next(iter(self._color_profiles))
+            profile = next(iter(self._color_profiles.values()))
         else:
-            return 'DeviceRGB'
+            return '/DeviceRGB'
+        return pydyf.Array(('/ICCBased', profile.pdf_reference))


### PR DESCRIPTION
# Named ICC output intent writes invalid color spaces for gradients

WeasyPrint 69.0 and current `main` write ICC resource keys where PDF shading and
transparency-group dictionaries require explicit color-space objects. At least Poppler and Adobe Acrobat therefore has issues rendering affected gradients.


## Reproduction

```python
from weasyprint import HTML

HTML(string='''
<style>
  @page{size:100mm 100mm}
  div{width:60mm; height:60mm; background:linear-gradient(red,blue) }
</style>
<div></div>
''').write_pdf('out.pdf', output_intent='srgb')
```

```bash
# Render to png (ends up white)
$ pdftoppm -png -r 100 out.pdf image
Syntax Warning: Bad color space 'srgb'
Syntax Warning: Bad color space 'srgb'
Syntax Warning: Bad color space in shading dictionary
```

Every PDF/A variant triggers the same bug because they set the sRGB output intent automatically.

The generated form contains:

```text
/Group << /S /Transparency /CS /srgb >>
/Shading << /ShadingType 2 /ColorSpace /srgb ... >>
```

Poppler reports `Bad color space in shading dictionary` and does not paint the
gradient. WeasyPrint 68.1 emits `/DeviceRGB` and renders correctly.

`/srgb` is a resource key and can be resolved as a `cs`/`CS` operand inside a
content stream. These dictionary entries are themselves color-space objects,
so they must instead contain `/DeviceRGB` or `[/ICCBased <profile-reference>]`.
Both `Stream.add_shading()` and `Stream.add_group()` need the explicit form.
The group defect also occurs without gradients, for example on solid content
with `opacity: .5`.


## Example files

[srgb.pdf](https://github.com/user-attachments/files/30659194/srgb.pdf)
[device.pdf](https://github.com/user-attachments/files/30659195/device.pdf)


## References

- [ISO 32000-1:2008, §8.6.3, pp. 139–142](https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf) — Distinguishes resource names from explicit color-space objects.
- [ISO 32000-1:2008, §8.7.4.3, Table 78, p. 183](https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf) — Defines a shading's `ColorSpace` entry.
- [ISO 32000-1:2008, §11.6.6, Table 147, pp. 349–350](https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf) — Defines a transparency group's `CS` entry.
