### PR TITLE
Support display: contents;

### DIFF
--- a/tests/css/test_counters.py
+++ b/tests/css/test_counters.py
@@ -641,3 +641,43 @@ def test_counter_multiple_extends():
     assert li_6.children[0].children[0].children[0].text == '6. '
     assert li_7.children[0].children[0].children[0].text == '7. '
     assert li_8.children[0].children[0].children[0].text == '8. '
+
+
+@assert_no_logs
+def test_counter_display_contents():
+    page, = render_pages('''
+      <style>
+        section { counter-reset: c }
+        p { counter-increment: c }
+        p::before { content: counter(c) }
+      </style>
+      <section><p>a</p><div style="display: contents"><p>b</p><p>c</p></div>
+      <p>d</p></section>
+    ''')
+    html, = page.children
+    body, = html.children
+    section, = body.children
+    values = [
+        p.children[0].children[0].children[0].text for p in section.children]
+    assert values == ['1', '2', '3', '4']
+
+
+@assert_no_logs
+@pytest.mark.parametrize(('display', 'value'), [
+    ('none', '0'),
+    ('contents', '1'),
+    ('block', '1'),
+])
+def test_counter_increment_display(display, value):
+    page, = render_pages(f'''
+      <style>
+        body {{ counter-reset: c }}
+        x {{ counter-increment: c; display: {display} }}
+        p::before {{ content: counter(c) }}
+      </style>
+      <x></x><p>y</p>
+    ''')
+    html, = page.children
+    body, = html.children
+    p = body.children[-1]
+    assert p.children[0].children[0].children[0].text == value

--- a/tests/css/test_target.py
+++ b/tests/css/test_target.py
@@ -1,6 +1,6 @@
 """Test the CSS cross references using target-*() functions."""
 
-from ..testing_utils import assert_no_logs, render_pages
+from ..testing_utils import assert_no_logs, capture_logs, render_pages
 
 
 @assert_no_logs
@@ -224,3 +224,48 @@ def test_target_absolute_non_root():
     text_box, after = inline.children
     assert text_box.text == 'link'
     assert after.children[0].text == '1'
+
+
+def test_target_counter_display_contents():
+    # Regression test for #2210. A display:contents element generates no box, so
+    # it cannot be a target-*() anchor: the reference resolves to the usual
+    # undefined-anchor error and its content is discarded, rather than being
+    # papered over with a stand-in descendant box. Links to the element still
+    # resolve, see test_links_display_contents_target.
+    with capture_logs() as logs:
+        page, = render_pages('''
+          <style> a::after { content: target-counter(url(#t), page) } </style>
+          <p><a>ref</a></p>
+          <div id="t" style="display: contents">T</div>
+        ''')
+    html, = page.children
+    body, = html.children
+    a = body.children[0].children[0].children[0]
+    text, after = a.children
+    assert text.text == 'ref'
+    assert not after.children
+    assert len(logs) == 1
+    assert 'undefined anchor' in logs[0]
+
+
+@assert_no_logs
+def test_target_counter_display_contents_child():
+    # Targeting a child of a display:contents wrapper is unaffected: the child
+    # keeps its own box and id, so target-counter() resolves normally.
+    page1, page2 = render_pages('''
+      <style>
+        @page { size: 10px 6px }
+        body { font-family: weasyprint; font-size: 2px; line-height: 1 }
+        a::after { content: target-counter(url(#child), page) }
+      </style>
+      <p><a>ref</a></p><p>x</p><p>x</p><p>x</p>
+      <div style="display: contents"><span id="child">T</span></div>
+    ''')
+    html, = page1.children
+    body, = html.children
+    p_a = body.children[0]
+    line, = p_a.children
+    a, = line.children
+    text, after = a.children
+    assert text.text == 'ref'
+    assert after.children[0].text == '2'

--- a/tests/layout/test_flex.py
+++ b/tests/layout/test_flex.py
@@ -2123,6 +2123,36 @@ def test_flex_inline_grid():
 
 
 @assert_no_logs
+def test_flex_order_display_contents():
+    # Regression test for #2210.
+    # Element children of a display:contents wrapper become flex items,
+    # interleaved with a direct (non-wrapped) sibling and ordered by `order`.
+    page, = render_pages('''
+      <style>
+        @page { size: 50px 10px }
+        body { font: 2px/1 weasyprint }
+        article { display: flex }
+        span { width: 10px }
+      </style>
+      <article>
+        <div style="display: contents"><span style="order: 2">A</span
+          ><span style="order: 4">B</span></div><span style="order: 0">E</span
+          ><div style="display: contents"><span style="order: 1">C</span
+          ><span style="order: 3">D</span></div>
+      </article>
+    ''')
+    html, = page.children
+    body, = html.children
+    article, = body.children
+    items = article.children
+    position = {
+        item.children[0].children[0].text: item.position_x for item in items}
+    assert set(position) == {'A', 'B', 'C', 'D', 'E'}
+    assert (position['E'] < position['C'] < position['A']
+            < position['D'] < position['B'])
+
+
+@assert_no_logs
 def test_flex_display_none():
     # Text around a display:none element is one contiguous run, so it forms a
     # single anonymous flex item.
@@ -2139,3 +2169,79 @@ def test_flex_display_none():
     article, = body.children
     item, = article.children
     assert item.children[0].children[0].text == 'AB'
+
+
+@assert_no_logs
+def test_flex_display_contents_text():
+    # Bare text from adjacent display:contents elements is one contiguous run,
+    # so it forms a single anonymous flex item, each keeping its own style. A's
+    # red is inline (overriding the matching span rule) and B's blue comes from
+    # the selector, so both inline and selector styling survive unboxing.
+    page, = render_pages('''
+      <style>
+        @page { size: 40px 10px }
+        body { font: 2px/1 weasyprint }
+        article { display: flex }
+        span { color: blue }
+      </style>
+      <article><span style="display: contents; color: red">A</span
+        ><span style="display: contents">B</span></article>
+    ''')
+    html, = page.children
+    body, = html.children
+    article, = body.children
+    item, = article.children
+    line, = item.children
+    a, b = line.children
+    assert a.text == 'A'
+    assert a.style['color'] == (1, 0, 0, 1)
+    assert b.text == 'B'
+    assert b.style['color'] == (0, 0, 1, 1)
+
+
+@assert_no_logs
+@pytest.mark.parametrize(('fragment', 'items'), [
+    # Whitespace inside a contiguous run is kept.
+    ('<span style="display: contents">A </span>'
+     '<span style="display: contents">B</span>', ['A B']),
+    # Whitespace-only boxes at a run's edges are trimmed.
+    ('<span style="display: contents"> </span>'
+     '<span style="display: contents">A</span>'
+     '<span style="display: contents">B</span>'
+     '<span style="display: contents"> </span>', ['AB']),
+    # A whitespace-only run between two items generates no item of its own.
+    ('<span>X</span><span style="display: contents"> </span>'
+     '<span>Y</span>', ['X', 'Y']),
+])
+def test_flex_display_contents_whitespace(fragment, items):
+    page, = render_pages(
+        '<style>@page{size:40px 10px}body{font:2px/1 weasyprint}'
+        'article{display:flex}</style>'
+        f'<article>{fragment}</article>')
+    html, = page.children
+    body, = html.children
+    article, = body.children
+    texts = [
+        ''.join(box.text for line in item.children for box in line.children)
+        for item in article.children]
+    assert texts == items
+
+
+@assert_no_logs
+def test_flex_display_contents_item_style():
+    # The anonymous item wrapping a run of unboxed text inherits from the flex
+    # container, not from the display:contents element the text came from.
+    page, = render_pages('''
+      <style>
+        @page { size: 40px 10px }
+        body { font: 2px/1 weasyprint }
+        article { display: flex; text-align: right }
+      </style>
+      <article><span style="display: contents; text-align: left">A</span
+        ><span style="display: contents">B</span></article>
+    ''')
+    html, = page.children
+    body, = html.children
+    article, = body.children
+    item, = article.children
+    assert item.style['text_align_all'] == 'right'

--- a/tests/layout/test_flex.py
+++ b/tests/layout/test_flex.py
@@ -2120,3 +2120,22 @@ def test_flex_inline_grid():
     span, = div.children
     assert span.position_x == 2
     assert span.position_y == 2
+
+
+@assert_no_logs
+def test_flex_display_none():
+    # Text around a display:none element is one contiguous run, so it forms a
+    # single anonymous flex item.
+    page, = render_pages('''
+      <style>
+        @page { size: 40px 10px }
+        body { font: 2px/1 weasyprint }
+        article { display: flex }
+      </style>
+      <article>A<span style="display: none"></span>B</article>
+    ''')
+    html, = page.children
+    body, = html.children
+    article, = body.children
+    item, = article.children
+    assert item.children[0].children[0].text == 'AB'

--- a/tests/layout/test_footnotes.py
+++ b/tests/layout/test_footnotes.py
@@ -987,3 +987,65 @@ def test_footnotes_column_converge():
     column1, column2 = div.children
     assert column1.height == column2.height == p.height == 2
     assert footnote_area.height == 2
+
+
+@assert_no_logs
+def test_footnote_display_contents():
+    # Regression test for #2210.
+    page, = render_pages('''
+      <style>
+        @page { size: 20px }
+        body { font-family: weasyprint; font-size: 2px; line-height: 1 }
+        span { float: footnote; display: contents }
+      </style>
+      <div>a<span>b</span></div>
+    ''')
+    html, footnote_area = page.children
+    body, = html.children
+    div, = body.children
+    footnote, = footnote_area.children
+    assert footnote.children[0].children[-1].text == 'b'
+
+
+@assert_no_logs
+def test_footnote_call_display_contents():
+    # Regression test for #2210.
+    page, = render_pages('''
+      <style>
+        @page { size: 20px }
+        body { font-family: weasyprint; font-size: 2px; line-height: 1 }
+        span { float: footnote }
+        span::footnote-call { display: contents }
+        span::footnote-marker { display: contents }
+      </style>
+      <div>a<span>b</span></div>
+    ''')
+    html, footnote_area = page.children
+    footnote, = footnote_area.children
+    assert footnote.children[0].children[-1].text == 'b'
+
+
+@assert_no_logs
+def test_footnote_call_display_contents_keeps_footnote():
+    # display:contents on the footnote-call pseudo keeps a placeholder box
+    # instead of unboxing: that box carries the footnote reference, so unboxing
+    # it would drop the footnote entirely.
+    page, = render_pages('''
+      <style>
+        @page { size: 20px }
+        body { font-family: weasyprint; font-size: 2px; line-height: 1 }
+        span { float: footnote }
+        span::footnote-call { display: contents }
+      </style>
+      <div>a<span>b</span></div>
+    ''')
+    html, footnote_area = page.children
+    div, = html.children[0].children
+    line, = div.children
+    # The call marker still renders inline in the text...
+    assert ''.join(
+        box.text for box in line.descendants()
+        if getattr(box, 'text', None)) == 'a1'
+    # ...and the footnote is preserved.
+    footnote, = footnote_area.children
+    assert footnote.children[0].children[-1].text == 'b'

--- a/tests/layout/test_grid.py
+++ b/tests/layout/test_grid.py
@@ -1939,3 +1939,22 @@ def test_grid_in_columns_with_break():
     section2, section3 = grid.children
     assert section2.position_y == 0
     assert section3.position_y == 4
+
+
+@assert_no_logs
+def test_grid_display_none():
+    # Text around a display:none element is one contiguous run, so it forms a
+    # single anonymous grid item.
+    page, = render_pages('''
+      <style>
+        @page { size: 40px 10px }
+        body { font: 2px/1 weasyprint }
+        article { display: grid; grid-template-columns: 40px }
+      </style>
+      <article>A<span style="display: none"></span>B</article>
+    ''')
+    html, = page.children
+    body, = html.children
+    article, = body.children
+    item, = article.children
+    assert item.children[0].children[0].text == 'AB'

--- a/tests/layout/test_grid.py
+++ b/tests/layout/test_grid.py
@@ -1942,6 +1942,36 @@ def test_grid_in_columns_with_break():
 
 
 @assert_no_logs
+def test_grid_order_display_contents():
+    # Regression test for #2210.
+    # Element children of a display:contents wrapper become grid items,
+    # interleaved with a direct (non-wrapped) sibling and ordered by `order`.
+    page, = render_pages('''
+      <style>
+        @page { size: 50px 10px }
+        body { font: 2px/1 weasyprint }
+        article {
+          display: grid; grid-template-columns: 10px 10px 10px 10px 10px }
+      </style>
+      <article>
+        <div style="display: contents"><span style="order: 2">A</span
+          ><span style="order: 4">B</span></div><span style="order: 0">E</span
+          ><div style="display: contents"><span style="order: 1">C</span
+          ><span style="order: 3">D</span></div>
+      </article>
+    ''')
+    html, = page.children
+    body, = html.children
+    article, = body.children
+    items = article.children
+    position = {
+        item.children[0].children[0].text: item.position_x for item in items}
+    assert set(position) == {'A', 'B', 'C', 'D', 'E'}
+    assert (position['E'] < position['C'] < position['A']
+            < position['D'] < position['B'])
+
+
+@assert_no_logs
 def test_grid_display_none():
     # Text around a display:none element is one contiguous run, so it forms a
     # single anonymous grid item.
@@ -1958,3 +1988,55 @@ def test_grid_display_none():
     article, = body.children
     item, = article.children
     assert item.children[0].children[0].text == 'AB'
+
+
+@assert_no_logs
+def test_grid_display_contents_text():
+    # Bare text from adjacent display:contents elements is one contiguous run,
+    # so it forms a single anonymous grid item, each keeping its own style. A's
+    # red is inline (overriding the matching span rule) and B's blue comes from
+    # the selector, so both inline and selector styling survive unboxing.
+    page, = render_pages('''
+      <style>
+        @page { size: 40px 10px }
+        body { font: 2px/1 weasyprint }
+        article { display: grid; grid-template-columns: 40px }
+        span { color: blue }
+      </style>
+      <article><span style="display: contents; color: red">A</span
+        ><span style="display: contents">B</span></article>
+    ''')
+    html, = page.children
+    body, = html.children
+    article, = body.children
+    item, = article.children
+    line, = item.children
+    a, b = line.children
+    assert a.text == 'A'
+    assert a.style['color'] == (1, 0, 0, 1)
+    assert b.text == 'B'
+    assert b.style['color'] == (0, 0, 1, 1)
+
+
+@assert_no_logs
+def test_grid_display_contents_item_style():
+    # The anonymous item wrapping a run of unboxed text inherits from the grid
+    # container, not from the display:contents element the text came from.
+    page, = render_pages('''
+      <style>
+        @page { size: 40px 10px }
+        body { font: 2px/1 weasyprint }
+        article {
+          display: grid;
+          grid-template-columns: 40px;
+          text-align: right;
+        }
+      </style>
+      <article><span style="display: contents; text-align: left">A</span
+        ><span style="display: contents">B</span></article>
+    ''')
+    html, = page.children
+    body, = html.children
+    article, = body.children
+    item, = article.children
+    assert item.style['text_align_all'] == 'right'

--- a/tests/layout/test_list.py
+++ b/tests/layout/test_list.py
@@ -129,3 +129,19 @@ def test_lists_page_break_margin():
             assert (
                 li.children[0].position_y ==
                 li.children[1].children[0].position_y)
+
+
+@assert_no_logs
+def test_list_marker_display_none():
+    # Regression test: display:none on a marker used to raise a KeyError in
+    # make_box, which has no ('none',) entry in BOX_TYPE_FROM_DISPLAY.
+    page, = render_pages('''
+      <style>li::marker { display: none }</style>
+      <ul><li>a</li></ul>
+    ''')
+    html, = page.children
+    body, = html.children
+    ul, = body.children
+    li, = ul.children
+    line, = li.children
+    assert line.children[0].text == 'a'

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1585,3 +1585,12 @@ def test_unknown_document_write_pdf_option():
     assert len(logs) == 1
     assert logs[0].startswith('ERROR')
     assert 'bogus_option' in logs[0]
+
+
+@pytest.mark.parametrize('html', [
+    b'<input style="display: contents">',
+    b'<textarea style="display: contents">x</textarea>',
+    b'<select style="display: contents"><option>x</option></select>',
+])
+def test_pdf_forms_display_contents(html):
+    assert b'AcroForm' not in _run('--pdf-forms --uncompressed-pdf - -', html)

--- a/tests/test_boxes.py
+++ b/tests/test_boxes.py
@@ -961,6 +961,24 @@ def test_margin_box_string_set_1():
     assert text_box.text == 'first assignment'
 
 
+@pytest.mark.xfail
+@assert_no_logs
+def test_margin_box_string_set_display_contents():
+    # TODO: string-set on a display:contents element is dropped
+    # (set_content_lists is skipped on the unbox path), so string() is empty.
+    page, = render_pages('''
+      <style>
+        @page { @top-center { content: string(header) } }
+        div { string-set: header content() }
+      </style>
+      <div style="display: contents">Title</div>
+    ''')
+    html, top_center = page.children
+    line_box, = top_center.children
+    text_box, = line_box.children
+    assert text_box.text == 'Title'
+
+
 @assert_no_logs
 def test_margin_box_string_set_2():
     def simple_string_set_test(content_val, extra_style=''):

--- a/tests/test_boxes.py
+++ b/tests/test_boxes.py
@@ -1256,3 +1256,288 @@ def test_display_none_root(html):
     box = parse_all(html)
     assert box.style['display'] == ('block', 'flow')
     assert not box.children
+
+
+@assert_no_logs
+def test_display_contents_inline():
+    assert_tree(parse_all(
+        '<p><span style="display: contents">x<em>b</em></span></p>'), [
+            ('p', 'Block', [
+                ('p', 'Line', [
+                    ('span', 'Text', 'x'),
+                    ('em', 'Inline', [
+                        ('em', 'Text', 'b')])])])])
+
+
+@assert_no_logs
+def test_display_contents_block_children():
+    assert_tree(parse_all(
+        '<div><section style="display: contents">'
+        '<p>a</p><p>b</p></section></div>'), [
+            ('div', 'Block', [
+                ('p', 'Block', [('p', 'Line', [('p', 'Text', 'a')])]),
+                ('p', 'Block', [('p', 'Line', [('p', 'Text', 'b')])])])])
+
+
+@assert_no_logs
+def test_display_contents_siblings():
+    # A contents element's children become siblings of its own siblings, not
+    # children nested inside a box standing in for the element.
+    assert_tree(parse_all(
+        '<div><section style="display: contents"><h1>a</h1></section>'
+        '<p>b</p></div>'), [
+            ('div', 'Block', [
+                ('h1', 'Block', [('h1', 'Line', [('h1', 'Text', 'a')])]),
+                ('p', 'Block', [('p', 'Line', [('p', 'Text', 'b')])])])])
+
+
+@assert_no_logs
+def test_display_contents_before_after():
+    assert_tree(parse_all(
+        '<style>span::before { content: "B" }'
+        ' span::after { content: "A" }</style>'
+        '<div><span style="display: contents">x</span></div>'), [
+            ('div', 'Block', [
+                ('div', 'Line', [
+                    ('span::before', 'Inline', [
+                        ('span::before', 'Text', 'B')]),
+                    ('span', 'Text', 'x'),
+                    ('span::after', 'Inline', [
+                        ('span::after', 'Text', 'A')])])])])
+
+
+@assert_no_logs
+def test_display_contents_inheritance():
+    box = parse_all(
+        '<div><span style="display: contents; color: red">'
+        '<em>b</em></span></div>')
+    body, = box.children
+    div, = body.children
+    line, = div.children
+    em, = line.children
+    assert em.style['color'] == (1, 0, 0, 1)
+
+
+@assert_no_logs
+@pytest.mark.parametrize('css', ['float: left', 'position: absolute'])
+def test_display_contents_out_of_flow(css):
+    assert_tree(parse_all(
+        f'<div><span style="display: contents; {css}">'
+        f'<em>b</em></span>x</div>'), [
+            ('div', 'Block', [
+                ('div', 'Line', [
+                    ('em', 'Inline', [('em', 'Text', 'b')]),
+                    ('div', 'Text', 'x')])])])
+
+
+@assert_no_logs
+def test_display_contents_nested():
+    assert_tree(parse_all(
+        '<div><span style="display: contents">'
+        '<i style="display: contents"><em>b</em></i></span></div>'), [
+            ('div', 'Block', [
+                ('div', 'Line', [
+                    ('em', 'Inline', [
+                        ('em', 'Text', 'b')])])])])
+
+
+@assert_no_logs
+@pytest.mark.parametrize('html', [
+    '<html style="display: contents">',
+    '<html style="display: contents"><p>abc',
+])
+def test_display_contents_root(html):
+    box = parse_all(html)
+    assert box.element_tag == 'html'
+    assert box.style['display'] == ('block', 'flow')
+
+
+@assert_no_logs
+@pytest.mark.parametrize('child', [
+    '<img src="pattern.png" style="display: contents">',
+    '<svg style="display: contents"><rect/></svg>',
+    '<textarea style="display: contents">x</textarea>',
+    '<select style="display: contents"><option>x</option></select>',
+    '<br style="display: contents">',
+    '<canvas style="display: contents">x</canvas>',
+    '<iframe style="display: contents">x</iframe>',
+    '<video style="display: contents">x</video>',
+    '<audio style="display: contents">x</audio>',
+    '<meter style="display: contents">x</meter>',
+    '<progress style="display: contents">x</progress>',
+])
+def test_display_contents_none(child):
+    assert_tree(parse_all(f'<div>{child}</div>'), [('div', 'Block', [])])
+
+
+@assert_no_logs
+def test_display_contents_table():
+    # A display:contents table unboxes: its rows move into the parent and a
+    # whole anonymous table regenerates around them. Indented markup must not
+    # leak the table's whitespace as spurious rows.
+    assert_tree(parse_all(
+        '<div>\n'
+        '  <table style="display: contents">\n'
+        '    <tr><td>a</td></tr>\n'
+        '  </table>\n'
+        '</div>'), [
+            ('div', 'Block', [
+                ('div', 'Block', [
+                    ('div', 'Table', [
+                        ('tbody', 'TableRowGroup', [
+                            ('tr', 'TableRow', [
+                                ('td', 'TableCell', [
+                                    ('td', 'Line', [
+                                        ('td', 'Text', 'a')])])])])])])])])
+
+
+@assert_no_logs
+def test_display_contents_row_group():
+    # A display:contents row group (thead/tbody/tfoot) unboxes: its rows are
+    # re-wrapped in a single anonymous row group. Indented markup must not leak
+    # whitespace as spurious rows.
+    assert_tree(parse_all(
+        '<table>\n'
+        '  <thead style="display: contents">\n'
+        '    <tr><th>h</th></tr>\n'
+        '  </thead>\n'
+        '  <tbody style="display: contents">\n'
+        '    <tr><td>a</td></tr>\n'
+        '  </tbody>\n'
+        '  <tfoot style="display: contents">\n'
+        '    <tr><td>f</td></tr>\n'
+        '  </tfoot>\n'
+        '</table>'), [
+            ('table', 'Block', [
+                ('table', 'Table', [
+                    ('table', 'TableRowGroup', [
+                        ('tr', 'TableRow', [
+                            ('th', 'TableCell', [
+                                ('th', 'Line', [('th', 'Text', 'h')])])]),
+                        ('tr', 'TableRow', [
+                            ('td', 'TableCell', [
+                                ('td', 'Line', [('td', 'Text', 'a')])])]),
+                        ('tr', 'TableRow', [
+                            ('td', 'TableCell', [
+                                ('td', 'Line', [
+                                    ('td', 'Text', 'f')])])])])])])])
+
+
+@assert_no_logs
+def test_display_contents_row():
+    # A display:contents table row unboxes: its cells are re-wrapped in a
+    # single anonymous row. Indented markup must not leak whitespace as spurious
+    # cells.
+    assert_tree(parse_all(
+        '<table><tbody>\n'
+        '  <tr style="display: contents">\n'
+        '    <td>a</td><td>b</td>\n'
+        '  </tr>\n'
+        '</tbody></table>'), [
+            ('table', 'Block', [
+                ('table', 'Table', [
+                    ('tbody', 'TableRowGroup', [
+                        ('tbody', 'TableRow', [
+                            ('td', 'TableCell', [
+                                ('td', 'Line', [('td', 'Text', 'a')])]),
+                            ('td', 'TableCell', [
+                                ('td', 'Line', [
+                                    ('td', 'Text', 'b')])])])])])])])
+
+
+@assert_no_logs
+def test_display_contents_cell():
+    # display:contents table cells (td/th) unbox: their content is re-wrapped
+    # in one anonymous cell, the inter-cell whitespace surviving as inline text
+    # rather than a spurious cell.
+    assert_tree(parse_all(
+        '<table><tbody><tr>\n'
+        '  <th style="display: contents">h</th>\n'
+        '  <td style="display: contents">a</td>\n'
+        '</tr></tbody></table>'), [
+            ('table', 'Block', [
+                ('table', 'Table', [
+                    ('tbody', 'TableRowGroup', [
+                        ('tr', 'TableRow', [
+                            ('tr', 'TableCell', [
+                                ('tr', 'Line', [
+                                    ('th', 'Text', 'h'),
+                                    ('tr', 'Text', ' '),
+                                    ('td', 'Text', 'a'),
+                                    ('tr', 'Text', ' ')])])])])])])])
+
+
+@assert_no_logs
+def test_display_contents_button():
+    assert_tree(parse_all(
+        '<div><button style="display: contents">x</button></div>'), [
+            ('div', 'Block', [
+                ('div', 'Line', [
+                    ('button', 'Text', 'x')])])])
+
+
+@assert_no_logs
+def test_display_contents_tail():
+    assert_tree(parse_all(
+        '<div><span style="display: contents">a</span>bc</div>'), [
+            ('div', 'Block', [
+                ('div', 'Line', [
+                    ('span', 'Text', 'a'),
+                    ('div', 'Text', 'bc')])])])
+
+
+@assert_no_logs
+def test_display_contents_pseudo():
+    assert_tree(parse_all(
+        '<style>p::before { content: "X"; display: contents }</style>'
+        '<p>y</p>'), [
+            ('p', 'Block', [
+                ('p', 'Line', [
+                    ('p::before', 'Text', 'X'),
+                    ('p', 'Text', 'y')])])])
+
+
+@assert_no_logs
+def test_display_contents_marker():
+    assert_tree(parse_all(
+        '<style>li::marker { content: "M"; display: contents }</style>'
+        '<ul><li>x</li></ul>'), [
+            ('ul', 'Block', [
+                ('li', 'Block', [
+                    ('li', 'Line', [
+                        ('li::marker', 'Text', 'M'),
+                        ('li', 'Text', 'x')])])])])
+
+
+@assert_no_logs
+def test_display_contents_colgroup():
+    # A colgroup is not in Appendix B's display:contents none-list, so it unboxes
+    # like any other element: the group disappears while its columns survive
+    # (matching browsers). Indented markup must not leak its whitespace as
+    # spurious anonymous rows.
+    box = parse_all(
+        '<table>\n  <colgroup style="display: contents">\n'
+        '    <col><col>\n  </colgroup>\n'
+        '  <tr><td>a</td><td>b</td></tr>\n</table>')
+    table, = (child for child in box.descendants()
+              if isinstance(child, boxes.TableBox))
+    columns = [col for group in table.column_groups for col in group.children]
+    assert len(columns) == 2
+    rows = [row for group in table.children
+            if isinstance(group, boxes.TableRowGroupBox)
+            for row in group.children]
+    assert len(rows) == 1
+
+
+@assert_no_logs
+def test_display_contents_col():
+    # A <col> is void, so display:contents unboxes it to nothing: the column it
+    # would define disappears, the same effect as display:none (matching
+    # browsers). The sibling col still defines its own column.
+    box = parse_all(
+        '<table><colgroup><col style="display: contents"><col></colgroup>'
+        '<tr><td>a</td></tr></table>')
+    table, = (child for child in box.descendants()
+              if isinstance(child, boxes.TableBox))
+    columns = [col for group in table.column_groups for col in group.children]
+    assert len(columns) == 1

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -47,6 +47,17 @@ def test_bookmarks_1():
         b'a', b'b', b'c', b'd', b'e']
 
 
+@pytest.mark.xfail
+@assert_no_logs
+def test_bookmark_display_contents():
+    # TODO: bookmark-label/level on a display:contents element are dropped
+    # (set_content_lists is skipped on the unbox path), so no outline entry.
+    pdf = FakeHTML(string=(
+        '<style>div { bookmark-level: 1; bookmark-label: content() }</style>'
+        '<div style="display: contents">a</div><p>b</p>')).write_pdf()
+    assert b'/Title (a)' in pdf
+
+
 @assert_no_logs
 def test_bookmarks_2():
     pdf = FakeHTML(string='<body>').write_pdf()

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -307,6 +307,62 @@ def test_links_none():
 
 
 @assert_no_logs
+def test_links_display_contents():
+    # A display:contents link keeps its link: a wrapped child box inherits it.
+    pdf = FakeHTML(string=(
+        '<a href="https://weasyprint.org" style="display: contents">'
+        '<span>link</span></a>')).write_pdf()
+    assert b'/URI (https://weasyprint.org)' in pdf
+
+
+@assert_no_logs
+def test_links_display_contents_text():
+    # display:contents keeps document-tree semantics (CSS Display 3), so a link
+    # survives even with bare-text content: the unboxed text carries the link,
+    # and gather_anchors honors it when no ancestor box registered it.
+    pdf = FakeHTML(string=(
+        '<a href="https://weasyprint.org" style="display: contents">'
+        'link</a>')).write_pdf()
+    assert b'/URI (https://weasyprint.org)' in pdf
+
+
+@assert_no_logs
+def test_links_display_contents_target():
+    # An id on a display:contents element stays a live link target, because the
+    # element is still rendered: the anchor moves to the first box it unboxes
+    # to (unlike display:none, which would drop it and dangle the reference).
+    pdf = FakeHTML(string=(
+        '<a href="#tgt">ref</a>'
+        '<h1 id="tgt" style="display: contents">Target</h1>')).write_pdf()
+    assert b'/Dest (tgt)' in pdf
+
+
+@assert_no_logs
+def test_links_display_contents_nested_id():
+    # The contents element and its first child both carry an id; the box-level
+    # anchors list lets that box hold both, so both #ids resolve.
+    pdf = FakeHTML(string=(
+        '<a href="#outer">a</a><a href="#inner">b</a>'
+        '<div id="outer" style="display: contents">'
+        '<h1 id="inner">T</h1></div>')).write_pdf()
+    assert b'/Dest (outer)' in pdf
+    assert b'/Dest (inner)' in pdf
+
+
+def test_links_display_contents_empty():
+    # An empty display:contents element renders nothing, so there is no box for
+    # its id to point at: the link is dropped, as for display:none, and the
+    # 'No anchor' warning is expected.
+    with capture_logs() as logs:
+        pdf = FakeHTML(string=(
+            '<a href="#tgt">ref</a>'
+            '<div id="tgt" style="display: contents"></div>')).write_pdf()
+    assert b'/Dest (tgt)' not in pdf
+    assert len(logs) == 1
+    assert 'No anchor #tgt for internal URI reference' in logs[0]
+
+
+@assert_no_logs
 def test_links():
     pdf = FakeHTML(string='''
       <style>

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -1556,6 +1556,30 @@ def test_first_letter_nested():
 
 
 @assert_no_logs
+def test_first_letter_display_contents():
+    # ::first-letter styles a block container's own box. A display:contents
+    # element generates none, so its own ::first-letter has no effect, while an
+    # ancestor's still reaches the content (CSS Display 3, Pseudo-4).
+    page, = render_pages('''
+      <style>
+        p::first-letter { font-weight: 700 }
+        span::first-letter { font-style: italic }
+      </style>
+      <p><span style="display: contents">abc</span></p>
+    ''')
+    html, = page.children
+    body, = html.children
+    p, = body.children
+    line, = p.children
+    first_letter, next_text = line.children
+    first_letter_text, = first_letter.children
+    # The paragraph's ::first-letter reaches the content...
+    assert first_letter_text.style['font_weight'] == 700
+    # ...but the display:contents span's own ::first-letter does not apply.
+    assert first_letter_text.style['font_style'] == 'normal'
+
+
+@assert_no_logs
 def test_first_line_line_height():
     page, = render_pages('''
       <style>

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -225,6 +225,10 @@ def _sanity_checks(box):
     - Line boxes and inline boxes can only contain inline-level boxes.
 
     """
+    # A display:contents element generates no box, so build.py must unbox it:
+    # no box may reach the tree still claiming that display.
+    assert box.style['display'] != ('contents',), box
+
     if not isinstance(box, boxes.ParentBox):
         return
 

--- a/weasyprint/anchors.py
+++ b/weasyprint/anchors.py
@@ -28,7 +28,7 @@ def rectangle_aabb(matrix, pos_x, pos_y, width, height):
 
 
 def gather_anchors(box, anchors, links, bookmarks, forms, parent_matrix=None,
-                   parent_form=None):
+                   parent_form=None, parent_link=None):
     """Gather anchors and other data related to specific positions in PDF.
 
     Currently finds anchors, links, bookmarks and forms.
@@ -82,12 +82,19 @@ def gather_anchors(box, anchors, links, bookmarks, forms, parent_matrix=None,
         bookmark_level = box.style['bookmark_level']
     state = box.style['bookmark_state']
     link = box.style['link']
-    anchor_name = box.style['anchor']
+    # A display:contents element donates its anchor to a descendant through a
+    # box-level list, so register those alongside the box's own style anchor.
+    anchor_names = [box.style['anchor']] if box.style['anchor'] else []
+    anchor_names += box.anchors
     has_bookmark = bookmark_label and bookmark_level
-    # 'link' is inherited but redundant on text boxes
-    has_link = link and not isinstance(box, (boxes.TextBox, boxes.LineBox))
+    # 'link' is inherited, so it's redundant on a text box whose link an
+    # ancestor box already registered (normally the <a>). An unboxed
+    # display:contents link leaves no such ancestor, so keep it on the text.
+    has_link = link and (
+        not isinstance(box, (boxes.TextBox, boxes.LineBox))
+        or link != parent_link)
     # In case of duplicate IDs, only the first is an anchor.
-    has_anchor = anchor_name and anchor_name not in anchors
+    has_anchor = any(name not in anchors for name in anchor_names)
     is_input = box.is_input()
 
     if box.is_form():
@@ -104,9 +111,9 @@ def gather_anchors(box, anchors, links, bookmarks, forms, parent_matrix=None,
         if has_link or is_input:
             rectangle = rectangle_aabb(matrix, pos_x, pos_y, width, height)
         if has_link:
-            token_type, link = link
+            token_type, url = link
             assert token_type == 'url'
-            link_type, target = link
+            link_type, target = url
             assert isinstance(target, str)
             if link_type == 'external' and box.is_attachment():
                 link_type = 'attachment'
@@ -123,10 +130,14 @@ def gather_anchors(box, anchors, links, bookmarks, forms, parent_matrix=None,
             if matrix:
                 pos_x1, pos_y1 = matrix.transform_point(pos_x1, pos_y1)
                 pos_x2, pos_y2 = matrix.transform_point(pos_x2, pos_y2)
-            anchors[anchor_name] = (pos_x1, pos_y1, pos_x2, pos_y2)
+            for name in anchor_names:
+                if name not in anchors:
+                    anchors[name] = (pos_x1, pos_y1, pos_x2, pos_y2)
 
+    child_link = link if has_link else parent_link
     for child in box.all_children():
-        gather_anchors(child, anchors, links, bookmarks, forms, matrix, parent_form)
+        gather_anchors(child, anchors, links, bookmarks, forms, matrix,
+                       parent_form, child_link)
 
 
 def make_page_bookmark_tree(page, skipped_levels, last_by_depth,

--- a/weasyprint/css/__init__.py
+++ b/weasyprint/css/__init__.py
@@ -198,7 +198,12 @@ class StyleFor:
         computed = computed_styles[element, pseudo_type] = ComputedStyle(
             parent_style, cascaded, pseudo_type, root_style, base_url,
             self.font_config, self.initial_page_sizes)
-        if target_collector and computed['anchor']:
+        if target_collector and computed['anchor'] and (
+                computed['display'] != ('contents',)):
+            # A display:contents element generates no box, so it cannot be a
+            # target-*() anchor: leave it uncollected so target-*() hits the
+            # undefined-anchor error. Its #id still resolves for links, via
+            # gather_anchors.
             target_collector.collect_anchor(computed['anchor'])
 
     def add_page_declarations(self, page_type):

--- a/weasyprint/css/computed_values.py
+++ b/weasyprint/css/computed_values.py
@@ -535,6 +535,9 @@ def display(style, name, value):
     # See https://www.w3.org/TR/CSS21/visuren.html#dis-pos-flo.
     float_ = style.specified['float']
     position = style.specified['position']
+    if value == ('contents',) and style.is_root_element:
+        # display:contents computes to block on the root element.
+        return ('block', 'flow')
     if position in ('absolute', 'fixed') or float_ != 'none' or style.is_root_element:
         if value == ('inline-table',):
             return ('block', 'table')

--- a/weasyprint/css/validation/properties.py
+++ b/weasyprint/css/validation/properties.py
@@ -753,9 +753,9 @@ def display(tokens):
     if len(tokens) == 1:
         value = tokens[0].value
         if value in (
-                'none', 'table-caption', 'table-row-group', 'table-cell',
-                'table-header-group', 'table-footer-group', 'table-row',
-                'table-column-group', 'table-column'):
+                'none', 'contents', 'table-caption', 'table-row-group',
+                'table-cell', 'table-header-group', 'table-footer-group',
+                'table-row', 'table-column-group', 'table-column'):
             return (value,)
         elif value in ('inline-table', 'inline-flex', 'inline-grid'):
             return tuple(value.split('-'))

--- a/weasyprint/formatting_structure/boxes.py
+++ b/weasyprint/formatting_structure/boxes.py
@@ -82,6 +82,9 @@ class Box:
     missing_link = None
     link_annotation = None
     force_fragmentation = False
+    # Anchor names a display:contents element donates to this box (its own
+    # -weasy-anchor is separate); see element_to_box. Empty tuple by default.
+    anchors = ()
 
     # Default, overriden on some subclasses
     def all_children(self):

--- a/weasyprint/formatting_structure/build.py
+++ b/weasyprint/formatting_structure/build.py
@@ -41,6 +41,17 @@ BOX_TYPE_FROM_DISPLAY = {
     ('table-caption',): boxes.TableCaptionBox,
 }
 
+# Elements on which display:contents computes to none.
+# https://drafts.csswg.org/css-display-3/#unbox-html
+DISPLAY_CONTENTS_NONE = frozenset((
+    'audio', 'br', 'canvas', 'embed', 'frame', 'frameset', 'iframe', 'img',
+    'input', 'meter', 'object', 'progress', 'select', 'textarea', 'video',
+    'wbr',
+    # Not in the Appendix B list, but boxless here: <svg> is re-parsed by its
+    # handler, and a void <col> unboxes to nothing (like display:none, matching
+    # browsers). <colgroup> is absent: it unboxes and its columns survive.
+    'col', '{http://www.w3.org/2000/svg}svg'))
+
 # https://stackoverflow.com/questions/16317534/
 ASCII_TO_WIDE = {i: chr(i + 0xfee0) for i in range(0x21, 0x7f)}
 ASCII_TO_WIDE.update({0x20: '\u3000', 0x2D: '\u2212'})
@@ -95,6 +106,11 @@ def build_formatting_structure(element_tree, style_for, get_image_from_uri,
 
 
 def make_box(element_tag, style, content, element):
+    if style['display'] == ('contents',):
+        # No principal box: return a throwaway inline box carrying the style so
+        # the caller can build children against it and then unbox it, returning
+        # the children in its place. The box itself is always discarded.
+        return boxes.InlineBox(element_tag, style, element, content)
     return BOX_TYPE_FROM_DISPLAY[style['display'][:2]](
         element_tag, style, element, content)
 
@@ -133,19 +149,30 @@ def element_to_box(element, style_for, get_image_from_uri, base_url,
     # TODO: should be the used value. When does the used value for `display`
     # differ from the computer value?
     display = style['display']
-    if display == ('none',):
+    if display == ('none',) or (
+            display == ('contents',) and element.tag in DISPLAY_CONTENTS_NONE):
+        # display:contents computes to none on replaced elements, form controls
+        # and other unusual elements (CSS Display 3 Appendix B).
         return []
 
     if style['float'] == 'footnote':
+        # A footnote is a box moved to the footnote area, so display:contents
+        # (which would generate no box) cannot apply: the footnote wins.
         if style['footnote_display'] == 'block':
             style['display'] = ('block', 'flow')
         else:
             # TODO: handle compact footnotes
             style['display'] = ('inline', 'flow')
 
+    unboxed = style['display'] == ('contents',)
     box = make_box(element.tag, style, [], element)
-    box.first_letter_style = style_for(element, 'first-letter')
-    box.first_line_style = style_for(element, 'first-line')
+    if not unboxed:
+        # ::first-letter and ::first-line style a block container's own box. A
+        # display:contents element generates none, so per spec its own have no
+        # effect (an ancestor's still reach the content). Skip the lookup: this
+        # box is discarded anyway.
+        box.first_letter_style = style_for(element, 'first-letter')
+        box.first_line_style = style_for(element, 'first-line')
 
     if state is None:
         # use a list to have a shared mutable object
@@ -181,7 +208,7 @@ def element_to_box(element, style_for, get_image_from_uri, base_url,
     # collect anchor's counter_values, maybe it's a target.
     # to get the spec-conform counter_values we must do it here,
     # after the ::before is parsed and before the ::after is
-    if style['anchor']:
+    if style['anchor'] and not unboxed:
         target_collector.store_target(style['anchor'], counter_values, box)
 
     text = element.text
@@ -199,6 +226,11 @@ def element_to_box(element, style_for, get_image_from_uri, base_url,
             footnote.style['float'] = 'none'
             footnotes.append(footnote)
             call_style = style_for(footnote.element, 'footnote-call')
+            if call_style['display'] == ('contents',):
+                # The call anchors the footnote and must generate a box, so
+                # display:contents falls back to inline rather than unboxing.
+                call_style = call_style.copy()
+                call_style['display'] = ('inline', 'flow')
             footnote_call = make_box(
                 f'{footnote.element.tag}::footnote-call', call_style, [],
                 footnote.element)
@@ -212,7 +244,10 @@ def element_to_box(element, style_for, get_image_from_uri, base_url,
         text = child_element.tail
         if text:
             text_box = boxes.TextBox.anonymous_from(box, text)
-            if children and isinstance(children[-1], boxes.TextBox):
+            if (children and isinstance(children[-1], boxes.TextBox) and
+                    children[-1].style is text_box.style):
+                # Only merge into this element's own anonymous text, not into
+                # text unboxed from a display:contents child (different style).
                 children[-1].text += text_box.text
             else:
                 children.append(text_box)
@@ -228,6 +263,11 @@ def element_to_box(element, style_for, get_image_from_uri, base_url,
             counter_values.pop(name)
 
     box.children = children
+
+    if unboxed:
+        # display:contents generates no box; its children take its place.
+        return children
+
     set_content_lists(
         element, box, style, counter_values, target_collector, counter_style)
 
@@ -249,6 +289,10 @@ def element_to_box(element, style_for, get_image_from_uri, base_url,
     if style['float'] == 'footnote':
         counter_values['footnote'][-1] += 1
         marker_style = style_for(element, 'footnote-marker')
+        if marker_style['display'] == ('contents',):
+            # Like the call, the marker must generate a box.
+            marker_style = marker_style.copy()
+            marker_style['display'] = ('inline', 'flow')
         marker = make_box(
             f'{element.tag}::footnote-marker', marker_style, [], element)
         marker.children = content_to_boxes(
@@ -296,6 +340,10 @@ def before_after_to_box(element, pseudo_type, state, style_for,
         target_collector, counter_style))
 
     box.children = children
+
+    if display == ('contents',):
+        # Unbox the pseudo, returning its generated content and no box.
+        return children
 
     # calculate the bookmark-label
     if style['bookmark_level'] != 'none':
@@ -352,6 +400,11 @@ def marker_to_box(element, state, parent_style, style_for, get_image_from_uri,
                 children.append(box)
 
     if not children:
+        return
+
+    if style['display'] == ('contents',):
+        # display:contents: unbox the marker, yielding its content and no box.
+        yield from children
         return
 
     if parent_style['list_style_position'] == 'outside':
@@ -782,6 +835,18 @@ def table_boxes_children(box, children):
             children = [boxes.TableColumnBox.anonymous_from(box, [])
                         for _ in range(span)]
 
+    # Unboxing a table-internal element (a colgroup, tbody, tr...) can leave its
+    # insignificant whitespace beside the container's own. Rules 1.3 and 1.4
+    # below each strip only a single whitespace box, so collapse each run to one
+    # first (a no-op for normal, non-unboxed tables).
+    if box.tabular_container:
+        deduped = []
+        for child in children:
+            if is_whitespace(child) and deduped and is_whitespace(deduped[-1]):
+                continue
+            deduped.append(child)
+        children = deduped
+
     # rule 1.3
     if box.tabular_container and len(children) >= 2:
         # TODO: Maybe only remove text if internal is also
@@ -1012,6 +1077,49 @@ def blockify(box, layout):
     return anonymous
 
 
+def wrap_text_run(container, text_run):
+    """Wrap a contiguous run of text boxes in a single anonymous block.
+
+    The block is anonymous from ``container`` so it inherits from the flex or
+    grid container, not from a display:contents element the text came from.
+    Leading and trailing whitespace-only boxes are dropped; a whitespace-only
+    run generates no box (returns None).
+
+    """
+    start, end = 0, len(text_run)
+    while start < end and not text_run[start].text.strip(' '):
+        start += 1
+    while end > start and not text_run[end - 1].text.strip(' '):
+        end -= 1
+    text_run = text_run[start:end]
+    if not text_run:
+        return None
+    return boxes.BlockBox.anonymous_from(container, text_run)
+
+
+def coalesce_text(container, children):
+    """Wrap each contiguous run of text in a single anonymous block.
+
+    A flex or grid container turns each contiguous run of text directly inside
+    it into one item; a run of only whitespace generates none.
+    https://www.w3.org/TR/css-flexbox-1/#flex-items
+
+    """
+    coalesced = []
+    text_run = []
+    for child in children:
+        if isinstance(child, boxes.TextBox):
+            text_run.append(child)
+            continue
+        if box := wrap_text_run(container, text_run):
+            coalesced.append(box)
+        text_run = []
+        coalesced.append(child)
+    if box := wrap_text_run(container, text_run):
+        coalesced.append(box)
+    return coalesced
+
+
 def flex_boxes(box):
     """Remove and add boxes according to the flex model.
 
@@ -1032,15 +1140,10 @@ def flex_boxes(box):
 def flex_children(box, children):
     if isinstance(box, boxes.FlexContainerBox):
         flex_children = []
-        for child in children:
+        for child in coalesce_text(box, children):
             child.is_floated = lambda: False
             if child.is_in_normal_flow():
                 child.is_flex_item = True
-            if isinstance(child, boxes.TextBox) and not child.text.strip(' '):
-                # TODO: ignore texts only containing "characters that can be
-                # affected by the white-space property"
-                # https://www.w3.org/TR/css-flexbox-1/#flex-items
-                continue
             flex_children.append(blockify(child, 'flex'))
         return flex_children
     else:
@@ -1067,14 +1170,9 @@ def grid_boxes(box):
 def grid_children(box, children):
     if isinstance(box, boxes.GridContainerBox):
         grid_children = []
-        for child in children:
+        for child in coalesce_text(box, children):
             if child.is_in_normal_flow():
                 child.is_grid_item = True
-            if isinstance(child, boxes.TextBox) and not child.text.strip(' '):
-                # TODO: ignore texts only containing "characters that can be
-                # affected by the white-space property"
-                # https://drafts.csswg.org/css-grid-2/#grid-item
-                continue
             grid_children.append(blockify(child, 'grid'))
         return grid_children
     else:

--- a/weasyprint/formatting_structure/build.py
+++ b/weasyprint/formatting_structure/build.py
@@ -265,7 +265,18 @@ def element_to_box(element, style_for, get_image_from_uri, base_url,
     box.children = children
 
     if unboxed:
-        # display:contents generates no box; its children take its place.
+        # No box to carry the anchor, so donate it to the first durable
+        # (non-whitespace) descendant via a box-level list, which lets that
+        # descendant keep its own anchor too. Enough for #id links to resolve;
+        # target-*() and string-set/bookmark stay unsupported (no stand-in box).
+        if style['anchor']:
+            target = next(
+                (child for child in children if not (
+                    isinstance(child, boxes.TextBox)
+                    and not child.text.strip())),
+                None)
+            if target is not None:
+                target.anchors = [*target.anchors, style['anchor']]
         return children
 
     set_content_lists(

--- a/weasyprint/formatting_structure/build.py
+++ b/weasyprint/formatting_structure/build.py
@@ -322,10 +322,10 @@ def marker_to_box(element, state, parent_style, style_for, get_image_from_uri,
     # `content` where 'normal' computes as 'inhibit' for pseudo elements.
     quote_depth, counter_values, _counter_scopes, _page_groups = state
 
-    box = make_box(f'{element.tag}::marker', style, children, element)
-
     if style['display'] == ('none',):
         return
+
+    box = make_box(f'{element.tag}::marker', style, children, element)
 
     image_type, image = style['list_style_image']
 


### PR DESCRIPTION
This is an attempt to implement `display: contents;` robustly. See issue #2210. I looked at #2746 and your review comments, but this PR is entirely from scratch.

Thanks for all your work on Weasyprint. Long time user and sponsor, first attempt at contributing to the codebase. I've organised this PR into multiple commits in case you want to cherrypick, but most of it is interdependent. This PR was human-written and human-reviewed, AI was used only in a supporting role.

I've tried to keep the implementation as simple as possible (though sadly, nowhere near as simple as I'd hoped it would be based on your comment). I considered whether we could partially support `display:contents` and document the limitations, but in the end it was hard to actually carve much out. The main issue that I've run into is that Weasyprint makes various assumptions about boxes and about text that would have been completely fine before `display: contents;` existed (I'm pretty sure there were no layout transparent elements before that) - I think it's right to keep those assumptions and so have worked around them.

I've taken a test driven approach, starting with the requirements of the spec and I've also tested some common contents cases for sanity.

Most of the implementation is completely to spec, but there are some places where the spec was ambiguous or where strict compliance would have made the implementation messy:
- If an element has `display: contents;` IDs as anchors for internal hyperlinks are pushed down to a rendered child if possible, because there is no representation of the contents box to target. I did not do this for similar print-centric features like target-counter because of complexity - and I think it's reasonable that the user should change their markup/CSS to avoid the issue altogether. The children of a `display: contents;` element work normally for all features - the quirk is only around elements that have both `display: contents;` and an ID that something else targets.
- `float: footnote;`, `::footnote-call`, `::footnote-marker` - ignore any display: contents; setting because it makes no sense and breaks
- I've made no attempt to support `string-set` and `bookmark-*` on elements with `display: contents;` Again, those will work fine on children of a `display: contents;` element.
- Some elements are evaluated to `display: none;` - most of this is exactly as specified by Appendix B, and some of this is for convenience because of how Weasyprint handles the element (e.g. `svg`) - I can't see this causing a problem for users in the real world.

I believe everything else handled is to spec:
- Children that are unboxed due to display: contents; still inherit from it (e.g. `display: contents; color: blue;` should result in blue text)
- The above is achieved by a box that is used as the parent, but never put into the render tree (we assert this with `_sanity_check`).
- Multiple text fragments that end up with different styles, despite ending up in the same box are supported. Where those text fragments find themselves in a flex/grid container, we shove them into a shared box when computing the flex/grid layout (previously unnecessary because all would have been same style and merged earlier into single text node). This also handles tail text.
- `a[href]` with `display: contents` becomes a text node and I've handled linking that up. 
- `::first-letter` and `::first-line` directly on a `display: contents` element have no effect
- Contents is properly handled and tested on table/thead/tbody/tfoot/tr/td/th/colgroup/col.

Everything I could think of is tested and I have included xfails for the things that I've deliberately left unsupported. In addition to the automated tests committed, I also visually compared a "kitchen sink" example page before and after adding support and against Firefox/Chromium (for non-print features).

Apologies for submitting such a big PR as my first - I thought this was going to be a lot smaller when I started ha ha.