### PR TITLE
Keep absolutely positioned flex children in document order

### DIFF
--- a/tests/layout/test_position.py
+++ b/tests/layout/test_position.py
@@ -494,9 +494,7 @@ def test_grid_relative_positioning():
 
 
 @assert_no_logs
-@pytest.mark.xfail
 def test_flex_absolute_positioning():
-    """TODO: Order is not kept when out-of-flow and in-flow children are mixed."""
     page, = render_pages('''
       <style>
         @page { size: 100px 100px }
@@ -512,9 +510,9 @@ def test_flex_absolute_positioning():
     html, = page.children
     body, = html.children
     article, = body.children
-    # That’s currently div2, div1
     div1, div2 = article.children
 
+    assert (div1.position_x, div1.position_y) == (0, 0)
     assert (div2.position_x, div2.position_y) == (10, 10)
 
 

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -796,6 +796,21 @@ def test_pdf_tags_split_table_with_caption():
 
 
 @assert_no_logs
+def test_pdf_tags_absolute_in_flex():
+    # The structure tree is built from the box tree, so an absolutely
+    # positioned flex child listed first would be read out first too.
+    pdf = FakeHTML(string='''
+      <html lang="en">
+        <div style="display: flex; position: relative">
+          <h1>heading</h1>
+          <ul style="position: absolute"><li>item</li></ul>
+        </div>
+    ''').write_pdf(pdf_tags=True, uncompressed_pdf=True)
+    tags = re.findall(rb'/S (/\w+)', pdf)
+    assert tags.index(b'/H1') < tags.index(b'/L')
+
+
+@assert_no_logs
 def test_pdf_ua_2_namespace_type():
     # Regression test for #2786.
     pdf = FakeHTML(string='<html lang="en"><body>abc').write_pdf(

--- a/weasyprint/layout/flex.py
+++ b/weasyprint/layout/flex.py
@@ -900,8 +900,13 @@ def flex_layout(context, box, bottom_space, skip_stack, containing_block, page_i
                 cross_translate += extra_cross_size / (len(flex_lines) + 1)
 
     # Now we are no longer in the flex algorithm.
-    box = box.copy_with_children(
-        [child for child in children if child.is_absolutely_positioned()])
+    # Absolutely positioned children are put back below, once the flex items
+    # are laid out, at the index they have in the document. The children list
+    # is what the PDF structure tree is built from, so listing them first
+    # would give assistive technologies a wrong reading order.
+    absolute_children = [
+        child for child in children if child.is_absolutely_positioned()]
+    box = box.copy_with_children([])
     child_skip_stack = skip_stack
     for line in flex_lines:
         for index, child in line:
@@ -936,6 +941,12 @@ def flex_layout(context, box, bottom_space, skip_stack, containing_block, page_i
             child_skip_stack = None
         if resume_at:
             break
+
+    # Absolutely positioned children back into document order. They are sorted
+    # among themselves already, and only the flex items that fit on this page
+    # are in the list, hence the clamp.
+    for child in absolute_children:
+        box.children.insert(min(child.index, len(box.children)), child)
 
     if original_box_height != 'auto':
         # Don’t resume if flex items overflow flex container bottom.


### PR DESCRIPTION
Absolutely positioned children of a flex container are collected at the front of the children list `flex_layout` passes on, whatever their position in the document:

```python
box = box.copy_with_children(
    [child for child in children if child.is_absolutely_positioned()])
```

`pdf/tags.py` builds the PDF structure tree from that list, so a tagged PDF hands assistive technologies a reading order in which, say, a logo positioned into a corner comes before the heading it belongs to. Block containers keep the order. This is what `test_flex_absolute_positioning` is marked `xfail` for ("Order is not kept when out-of-flow and in-flow children are mixed").

The placeholders already record their index (`placeholder.index`), so this puts them back at it once the flex items are laid out. Absolutely positioned boxes are painted from the stacking context, so painting is unaffected — no layout changes, the previously xfailing test now asserts both children's positions.

Tests: `pytest` and `ruff check` on macOS/Python 3.14. Same 7 failures as on unpatched `main` here (`font-variant-caps`, `font-stretch`, `acid2` — missing fonts locally), no new ones, and the `xfail` above turns green.

One related thing I did **not** touch: when a flex container is fragmented, its absolutely positioned children are laid out again for every fragment, so they are painted — and tagged — on every page the container spans. The loop at `flex.py:132` does not honour the `skip_stack`, unlike its counterpart in `block.py`. Repro:

```html
<style>
  @page { size: 300px 200px; margin: 5px }
  section { position: relative; display: flex; flex-direction: column }
  a { position: absolute; right: 0; bottom: 0 }
  p { margin: 0 0 60px }
</style>
<section>
  <div><p>one</p><p>two</p><p>three</p><p>four</p></div>
  <a href="https://example.com/">LOGO</a>
</section>
```

`LOGO` appears on all three pages. Happy to open a separate issue for it.