### PR TITLE
Remove fontTools subsetter

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,9 +19,9 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install Ghostscript (Ubuntu)
+      - name: Install Ghostscript and HarfBuzz-Subset (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get update -y && sudo apt-get install ghostscript -y
+        run: sudo apt-get update -y && sudo apt-get install ghostscript libharfbuzz-subset0 -y
       - name: Install DejaVu, Pango and Ghostscript (MacOS)
         if: matrix.os == 'macos-latest'
         run: |

--- a/docs/first_steps.rst
+++ b/docs/first_steps.rst
@@ -107,7 +107,7 @@ following packages::
   pacman -S python-pip pango gcc libjpeg-turbo openjpeg2
 
 
-Debian ≥ 11
+Debian ≥ 12
 +++++++++++
 
 To install WeasyPrint using your distribution’s package::
@@ -143,7 +143,7 @@ following packages::
   dnf install python3-pip pango gcc python3-devel gcc-c++ zlib-devel libjpeg-devel openjpeg2-devel libffi-devel
 
 
-Ubuntu ≥ 20.04
+Ubuntu ≥ 24.04
 ++++++++++++++
 
 To install WeasyPrint using your distribution’s package::
@@ -153,12 +153,12 @@ To install WeasyPrint using your distribution’s package::
 To install WeasyPrint inside a virtualenv using wheels (if possible), you need
 the following packages::
 
-  apt install python3-pip libpango-1.0-0 libharfbuzz0b libpangoft2-1.0-0 libharfbuzz-subset0
+  apt install python3-pip libpango-1.0-0 libpangoft2-1.0-0 libharfbuzz-subset0
 
 To install WeasyPrint inside a virtualenv without using wheels, you need the
 following packages::
 
-  apt install python3-pip libpango-1.0-0 libharfbuzz0b libpangoft2-1.0-0 libharfbuzz-subset0 libffi-dev libjpeg-dev libopenjp2-7-dev
+  apt install python3-pip libpango-1.0-0 libpangoft2-1.0-0 libharfbuzz-subset0 libffi-dev libjpeg-dev libopenjp2-7-dev
 
 
 macOS

--- a/weasyprint/pdf/fonts.py
+++ b/weasyprint/pdf/fonts.py
@@ -6,7 +6,6 @@ from hashlib import md5
 from math import ceil
 
 import pydyf
-from fontTools import subset
 from fontTools.ttLib import TTFont, TTLibError, ttFont
 from fontTools.varLib.instancer import instantiateVariableFont
 
@@ -194,22 +193,19 @@ class Font:
         if not to_unicode:
             return
 
-        if harfbuzz_subset and harfbuzz.hb_version_atleast(4, 1, 0):
-            # 4.1.0 is required for hb_set_add_sorted_array.
-            self._harfbuzz_subset(to_unicode, hinting)
-        else:
-            self._fonttools_subset(to_unicode, hinting)
+        if not harfbuzz_subset:
+            LOGGER.warning(
+                'Harfbuzz-Subset must be installed to subset fonts, '
+                'generated PDFs will be larger than expected.')
+            return
 
-    def _harfbuzz_subset(self, to_unicode, hinting):
-        """Subset font using Harfbuzz."""
         hb_subset = ffi.gc(
             harfbuzz_subset.hb_subset_input_create_or_fail(),
             harfbuzz_subset.hb_subset_input_destroy)
 
         # Only keep used glyphs.
         gid_set = harfbuzz_subset.hb_subset_input_glyph_set(hb_subset)
-        gid_array = ffi.new(f'hb_codepoint_t[{len(to_unicode)}]', sorted(to_unicode))
-        harfbuzz.hb_set_add_sorted_array(gid_set, gid_array, len(to_unicode))
+        self.hb_set_add_array(gid_set, sorted(to_unicode))
 
         # Set flags.
         flags = (
@@ -226,8 +222,7 @@ class Font:
         drop_tables = tuple(harfbuzz.hb_tag_from_string(name, -1) for name in (
             b'BASE', b'DSIG', b'EBDT', b'EBLC', b'EBSC', b'GPOS', b'GSUB', b'JSTF',
             b'LTSH', b'PCLT', b'SVG '))
-        drop_tables_array = ffi.new(f'hb_codepoint_t[{len(drop_tables)}]', drop_tables)
-        harfbuzz.hb_set_add_sorted_array(drop_set, drop_tables_array, len(drop_tables))
+        self.hb_set_add_array(drop_set, drop_tables)
 
         # Subset font.
         hb_face = ffi.gc(
@@ -237,8 +232,7 @@ class Font:
         # Drop empty glyphs after last one used.
         gid_set = harfbuzz_subset.hb_subset_input_glyph_set(hb_subset)
         keep = tuple(range(max(to_unicode) + 1))
-        gid_array = ffi.new(f'hb_codepoint_t[{len(keep)}]', keep)
-        harfbuzz.hb_set_add_sorted_array(gid_set, gid_array, len(keep))
+        self.hb_set_add_array(gid_set, keep)
 
         # Set flags.
         flags = (
@@ -264,29 +258,14 @@ class Font:
 
         LOGGER.warning('Unable to subset "%s" with HarfBuzz', self.family)
 
-    def _fonttools_subset(self, to_unicode, hinting):
-        """Subset font using Fonttools."""
-        full_font = io.BytesIO(self.file_content)
-
-        # Set subset options.
-        options = subset.Options(
-            retain_gids=True, passthrough_tables=True, ignore_missing_glyphs=True,
-            hinting=hinting, desubroutinize=True, notdef_outline=bool(self.missing))
-        options.drop_tables += ['GSUB', 'GPOS', 'SVG']
-        subsetter = subset.Subsetter(options)
-        subsetter.populate(gids=to_unicode)
-
-        # Subset font.
-        try:
-            ttfont = TTFont(full_font, fontNumber=self.index)
-            subsetter.subset(ttfont)
-        except TTLibError as exception:
-            LOGGER.warning('Unable to subset "%s" with fontTools', self.family)
-            LOGGER.debug('Original exception:', exc_info=exception)
+    @staticmethod
+    def hb_set_add_array(gid_set, codepoints):
+        if harfbuzz.hb_version_atleast(4, 1, 0):
+            gid_array = ffi.new(f'hb_codepoint_t[{len(codepoints)}]', codepoints)
+            harfbuzz.hb_set_add_sorted_array(gid_set, gid_array, len(codepoints))
         else:
-            optimized_font = io.BytesIO()
-            ttfont.save(optimized_font)
-            self.file_content = optimized_font.getvalue()
+            for codepoint in codepoints:
+                harfbuzz.hb_set_add(gid_set, codepoint)
 
 
 def build_fonts_dictionary(pdf, fonts, compress, subset, options):

--- a/weasyprint/text/ffi.py
+++ b/weasyprint/text/ffi.py
@@ -72,6 +72,7 @@ ffi.cdef('''
     hb_subset_input_t * hb_subset_input_create_or_fail (void);
     void hb_subset_input_destroy (hb_subset_input_t *input);
     hb_set_t * hb_subset_input_glyph_set (hb_subset_input_t *input);
+    void hb_set_add (hb_set_t *set, hb_codepoint_t codepoint);
     void hb_set_add_sorted_array (
         hb_set_t *set, const hb_codepoint_t *sorted_codepoints,
         unsigned int num_codepoints);


### PR DESCRIPTION
Ubuntu 22.04 (supported until April 2027) and Debian 11 (supported until August 2026) don’t seem to package Harfbuzz-Subset. Wait until April 2027 before merging!