### PR TITLE
Transform running elements into relatively-positioned boxes

### DIFF
--- a/tests/layout/test_page.py
+++ b/tests/layout/test_page.py
@@ -1754,6 +1754,45 @@ def test_running_absolute():
 
 
 @assert_no_logs
+def test_running_absolute_overflow():
+    # Regression test for #2857.
+    render_pages('''
+      <style>
+        header {
+          position: running(header);
+        }
+        p {
+          font: 2px/1 weasyprint;
+          position: absolute;
+        }
+        div {
+          break-before: page;
+        }
+        @page {
+          size: 10px;
+          margin: 2px;
+          @top-center {
+            content: element(header);
+          }
+        }
+      </style>
+      <header>
+        <p>
+          abc<br>
+          abc<br>
+          abc<br>
+          abc<br>
+          abc<br>
+        </p>
+      </header>
+      <div>a</div>
+      <div>a</div>
+      <div>a</div>
+      <div>a</div>
+    ''')
+
+
+@assert_no_logs
 def test_running_flex():
     # Regression test.
     render_pages('''

--- a/weasyprint/formatting_structure/build.py
+++ b/weasyprint/formatting_structure/build.py
@@ -526,7 +526,7 @@ def compute_content_list(content_list, parent_box, counter_values, css_token,
             if new_box is None:
                 continue
             new_box = new_box.deepcopy()
-            new_box.style['position'] = 'static'
+            new_box.style['position'] = 'relative'
             for child in new_box.descendants():
                 if child.style['content'] in ('normal', 'none'):
                     continue


### PR DESCRIPTION
Running elements are positioned boxes. Instead of considering them as static boxes, we can use relative boxes that will take care of absolute children.

Fix #2857.