### PR TITLE
Handle whitespaces and newlines in URLs

### DIFF
--- a/tests/css/test_common.py
+++ b/tests/css/test_common.py
@@ -5,9 +5,10 @@ from math import isclose
 import pytest
 
 from weasyprint import CSS
-from weasyprint.css import find_stylesheets, get_all_computed_styles
 from weasyprint.urls import URLFetcher, path2url
 
+from weasyprint.css import (  # isort:skip
+    find_stylesheets, get_all_computed_styles, string_to_css, url_to_css)
 from ..testing_utils import (  # isort:skip
     BASE_URL, FakeHTML, assert_no_logs, capture_logs, resource_path)
 
@@ -261,3 +262,25 @@ def test_media_queries(media, width, warning):
     html, = page._page_box.children
     assert html.width == width
     assert (logs if warning else not logs)
+
+
+@pytest.mark.parametrize(('string', 'expected'), [
+    ('a', '"a"'),
+    ('a\nb', '"a\\Ab"'),
+    ('a\rb', '"a\\Db"'),
+    ('\n\na', '"\\A\\Aa"'),
+    ('a"b', '"a\\"b"'),
+])
+def test_string_to_css(string, expected):
+    assert string_to_css(string) == expected
+
+
+@pytest.mark.parametrize(('string', 'expected'), [
+    ('a', 'url("a")'),
+    ('a\nb', 'url("a\\Ab")'),
+    ('a\rb', 'url("a\\Db")'),
+    ('\n\na', 'url("\\A\\Aa")'),
+    ('a"b', 'url("a\\"b")'),
+])
+def test_url_to_css(string, expected):
+    assert url_to_css(string) == expected

--- a/tests/resources/doc1.html
+++ b/tests/resources/doc1.html
@@ -41,8 +41,7 @@
 </head>
 <body style="font-size: 20px">
     <h1 style="font-size: 2em">WeasyPrint test document (with Ünicōde)</h1>
-    <p style="color: blue; font-size: x-large;
-              -weasy-link: '#none'  /* no such target */">Hello</p>
+    <p style="color: blue; font-size: x-large">Hello</p>
     <ul style="font-family: weasyprint; font-size: 1.25ex">
         <li style="font-size: 6pt; font-weight: bold">
             <a href=home.html

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1125,8 +1125,7 @@ def test_links_3():
     assert_links(
         '''
             <body style="width: 200px">
-            <div style="display: block; margin: 10px 5px;
-                        -weasy-link: url(../lipsum/é_%E9)">
+            <a href="../lipsum/é_%E9" style="display: block; margin: 10px 5px">
         ''', [[('external', 'https://weasyprint.org/foo/lipsum/%C3%A9_%E9',
                 (5, 10, 195, 10))]],
         [{}], [([('external', 'https://weasyprint.org/foo/lipsum/%C3%A9_%E9',
@@ -1144,19 +1143,6 @@ def test_links_4():
         ''', [[('external', '../lipsum', (5, 10, 195, 10))]], [{}],
         [([('external', '../lipsum', (5, 10, 195, 10))], [])],
         base_url=None)
-
-
-@assert_no_logs
-def test_links_5():
-    # Relative URI reference without a base URI: not supported for -weasy-link
-    assert_links(
-        '''
-            <body style="width: 200px">
-            <div style="-weasy-link: url(../lipsum);
-                        display: block; margin: 10px 5px">
-        ''', [[]], [{}], [([], [])], base_url=None, warnings=[
-            'WARNING: Ignored `-weasy-link: url(../lipsum)` at 1:1, '
-            'Relative URI reference without a base URI'])
 
 
 @assert_no_logs
@@ -1183,8 +1169,7 @@ def test_links_7():
     assert_links(
         '''
             <body style="width: 200px">
-            <div style="-weasy-link: url(#lipsum);
-                        margin: 10px 5px" id="lipsum">
+            <a href="#lipsum" style="display: block; margin: 10px 5px" id="lipsum">
         ''',
         [[('internal', 'lipsum', (5, 10, 195, 10))]],
         [{'lipsum': (5, 10, 195, 10)}],

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -9,7 +9,7 @@ from .testing_utils import BASE_URL, assert_no_logs
 from weasyprint.html import (  # isort:skip
     map_to_dimension_property, map_to_dimension_property_ignoring_zero,
     map_to_pixel_length, parse_dimension_value, parse_integer,
-    parse_non_negative_integer, parse_string, parse_url)
+    parse_non_negative_integer)
 
 
 PH_TESTING_CSS = CSS(string='''
@@ -523,25 +523,3 @@ def test_map_to_dimension_property_ignoring_zero(string, expected):
 ])
 def test_map_to_dimension_property_ignoring_zero_invalid(string):
     assert map_to_dimension_property_ignoring_zero(string) is None
-
-
-@pytest.mark.parametrize(('string', 'expected'), [
-    ('a', '"a"'),
-    ('a\nb', '"a\\Ab"'),
-    ('a\rb', '"a\\Db"'),
-    ('\n\na', '"\\A\\Aa"'),
-    ('a"b', '"a\\"b"'),
-])
-def test_parse_string(string, expected):
-    assert parse_string(string) == expected
-
-
-@pytest.mark.parametrize(('string', 'expected'), [
-    ('a', 'url("a")'),
-    ('a\nb', 'url("a\\Ab")'),
-    ('a\rb', 'url("a\\Db")'),
-    ('\n\na', 'url("\\A\\Aa")'),
-    ('a"b', 'url("a\\"b")'),
-])
-def test_parse_url(string, expected):
-    assert parse_url(string) == expected

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -314,7 +314,7 @@ def test_links():
         p { display: block; height: 90pt; margin: 0 0 10pt 0 }
         img { width: 30pt; vertical-align: top }
       </style>
-      <p><a href="https://weasyprint.org"><img src=pattern.png></a></p>
+      <p><a href=" https://weasy\nprint.org\t"><img src=pattern.png></a></p>
       <p style="padding: 0 10pt"><a
          href="#lipsum"><img style="border: solid 1pt"
                              src=pattern.png></a></p>

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -400,19 +400,6 @@ def test_relative_links_missing_base():
 
 
 @assert_no_logs
-def test_relative_links_missing_base_link():
-    # Relative URI reference without a base URI: not supported for -weasy-link
-    with capture_logs() as logs:
-        pdf = FakeHTML(
-            string='<div style="-weasy-link: url(../lipsum)">',
-            base_url=None).write_pdf()
-    assert b'/Annots' not in pdf
-    assert len(logs) == 1
-    assert 'WARNING: Ignored `-weasy-link: url(../lipsum)`' in logs[0]
-    assert 'Relative URI reference without a base URI' in logs[0]
-
-
-@assert_no_logs
 def test_relative_links_internal():
     # Internal URI reference without a base URI: OK
     pdf = FakeHTML(
@@ -432,7 +419,7 @@ def test_relative_links_internal():
 @assert_no_logs
 def test_relative_links_anchors():
     pdf = FakeHTML(
-        string='<div style="-weasy-link: url(#lipsum)" id="lipsum"></div>a',
+        string='<a href="#lipsum" id="lipsum" style="display: block"></a>a',
         base_url=None).write_pdf()
     assert b'/Dest (lipsum)' in pdf
     link = re.search(

--- a/weasyprint/anchors.py
+++ b/weasyprint/anchors.py
@@ -28,7 +28,7 @@ def rectangle_aabb(matrix, pos_x, pos_y, width, height):
 
 
 def gather_anchors(box, anchors, links, bookmarks, forms, parent_matrix=None,
-                   parent_form=None):
+                   parent_form=None, parent_link=None):
     """Gather anchors and other data related to specific positions in PDF.
 
     Currently finds anchors, links, bookmarks and forms.
@@ -81,7 +81,7 @@ def gather_anchors(box, anchors, links, bookmarks, forms, parent_matrix=None,
     else:
         bookmark_level = box.style['bookmark_level']
     state = box.style['bookmark_state']
-    link = box.style['link']
+    link = box.link or parent_link
     anchor_name = box.style['anchor']
     has_bookmark = bookmark_label and bookmark_level
     # 'link' is inherited but redundant on text boxes
@@ -104,9 +104,9 @@ def gather_anchors(box, anchors, links, bookmarks, forms, parent_matrix=None,
         if has_link or is_input:
             rectangle = rectangle_aabb(matrix, pos_x, pos_y, width, height)
         if has_link:
-            token_type, link = link
+            token_type, token_link = link
             assert token_type == 'url'
-            link_type, target = link
+            link_type, target = token_link
             assert isinstance(target, str)
             if link_type == 'external' and box.is_attachment():
                 link_type = 'attachment'
@@ -126,7 +126,8 @@ def gather_anchors(box, anchors, links, bookmarks, forms, parent_matrix=None,
             anchors[anchor_name] = (pos_x1, pos_y1, pos_x2, pos_y2)
 
     for child in box.all_children():
-        gather_anchors(child, anchors, links, bookmarks, forms, matrix, parent_form)
+        gather_anchors(
+            child, anchors, links, bookmarks, forms, matrix, parent_form, link)
 
 
 def make_page_bookmark_tree(page, skipped_levels, last_by_depth,

--- a/weasyprint/css/__init__.py
+++ b/weasyprint/css/__init__.py
@@ -377,10 +377,6 @@ def find_style_attributes(tree, presentational_hints=False, base_url=None):
             yield parse_declaration(f'-weasy-anchor:"{id_}"')
 
         if element.tag == 'a':
-            href = html.parse_url(
-                element.get('href'), base_url, allow_relative=True)
-            if href:
-                yield parse_declaration(f'-weasy-link:"{href}"')
             if name := element.get('name'):
                 yield parse_declaration(f'-weasy-anchor:"{name}"')
 

--- a/weasyprint/css/__init__.py
+++ b/weasyprint/css/__init__.py
@@ -253,6 +253,23 @@ class StyleFor:
         return True
 
 
+def string_to_css(string):
+    """Transform a string to CSS-escaped string, including quotes."""
+    string = (
+        string
+        .replace('\\', '\\\\')
+        .replace('"', '\\"')
+        .replace('\n', '\\A')
+        .replace('\r', '\\D')
+        .replace('\f', '\\C'))
+    return f'"{string}"'
+
+
+def url_to_css(string):
+    """Transform a URL to url() string."""
+    return f'url({string_to_css(string)})'
+
+
 def get_child_text(element):
     """Return the text directly in the element, not descendants."""
     content = [element.text] if element.text else []
@@ -288,7 +305,7 @@ def find_stylesheets(wrapper_element, device_media_type, url_fetcher, base_url,
     The output order is the same as the source order.
 
     """
-    from ..html import element_has_link_type, get_url_attribute
+    from ..html import element_has_link_type, parse_url
 
     for wrapper in wrapper_element.query_all('style', 'link'):
         element = wrapper.etree_element
@@ -316,7 +333,7 @@ def find_stylesheets(wrapper_element, device_media_type, url_fetcher, base_url,
             if not element_has_link_type(element, 'stylesheet') or \
                     element_has_link_type(element, 'alternate'):
                 continue
-            href = get_url_attribute(element, 'href', base_url)
+            href = parse_url(element.get('href'), base_url)
             if href is not None:
                 try:
                     yield CSS(
@@ -360,8 +377,8 @@ def find_style_attributes(tree, presentational_hints=False, base_url=None):
             yield parse_declaration(f'-weasy-anchor:"{id_}"')
 
         if element.tag == 'a':
-            href = html.get_url_attribute(
-                element, 'href', base_url, allow_relative=True)
+            href = html.parse_url(
+                element.get('href'), base_url, allow_relative=True)
             if href:
                 yield parse_declaration(f'-weasy-link:"{href}"')
             if name := element.get('name'):
@@ -395,8 +412,8 @@ def find_style_attributes(tree, presentational_hints=False, base_url=None):
                     yield parse_declaration(f'margin-left:{value}')
                     yield parse_declaration(f'margin-right:{value}')
                     break
-            if background := element.get('background'):
-                url = html.parse_url(background)
+            if background := html.parse_url(element.get('background'), base_url):
+                url = url_to_css(background)
                 style_attribute = f'background-image:{url}'
                 yield parse_declaration(style_attribute)
             if bgcolor := element.get('bgcolor'):
@@ -421,7 +438,7 @@ def find_style_attributes(tree, presentational_hints=False, base_url=None):
                 color = html.parse_legacy_color(color)
                 yield parse_declaration(f'color:{color}')
             if face := element.get('face'):
-                face = html.parse_string(face)
+                face = string_to_css(face)
                 yield parse_declaration(f'font-family:{face}')
             if size := element.get('size'):
                 size = size.strip(html.WHITESPACE)
@@ -466,8 +483,8 @@ def find_style_attributes(tree, presentational_hints=False, base_url=None):
                 value = html.map_to_dimension_property(height)
                 if value is not None:
                     yield parse_declaration(f'height:{value}')
-            if background := element.get('background'):
-                url = html.parse_url(background)
+            if background := html.parse_url(element.get('background'), base_url):
+                url = url_to_css(background)
                 style_attribute = (f'background-image:{url}')
                 yield parse_declaration(style_attribute)
             if bgcolor := element.get('bgcolor'):
@@ -489,8 +506,8 @@ def find_style_attributes(tree, presentational_hints=False, base_url=None):
                 yield parse_declaration('text-align:center')
             elif align in ('center', 'left', 'right', 'justify'):
                 yield parse_declaration(f'text-align:{align}')
-            if background := element.get('background'):
-                url = html.parse_url(background)
+            if background := html.parse_url(element.get('background'), base_url):
+                url = url_to_css(background)
                 style_attribute = f'background-image:{url}'
                 yield parse_declaration(style_attribute)
             if bgcolor := element.get('bgcolor'):

--- a/weasyprint/css/__init__.py
+++ b/weasyprint/css/__init__.py
@@ -28,7 +28,7 @@ from PIL.ImageCms import ImageCmsProfile
 from .. import CSS
 from ..logger import LOGGER, PROGRESS_LOGGER
 from ..text.fonts import FontConfiguration
-from ..urls import URLFetchingError, fetch, get_url_attribute, url_join
+from ..urls import URLFetchingError, fetch, url_join
 from . import counters, media_queries
 from .computed_values import COMPUTER_FUNCTIONS, PHYSICAL_FUNCTIONS
 from .functions import Function, check_math, check_var
@@ -288,7 +288,7 @@ def find_stylesheets(wrapper_element, device_media_type, url_fetcher, base_url,
     The output order is the same as the source order.
 
     """
-    from ..html import element_has_link_type
+    from ..html import element_has_link_type, get_url_attribute
 
     for wrapper in wrapper_element.query_all('style', 'link'):
         element = wrapper.etree_element
@@ -356,13 +356,14 @@ def find_style_attributes(tree, presentational_hints=False, base_url=None):
         if lang := element.get('lang'):
             yield parse_declaration(f'-weasy-lang:"{lang}"')
 
-        if href := element.get('href', '').strip(html.WHITESPACE):
-            yield parse_declaration(f'-weasy-link:"{href}"')
-
         if id_ := element.get('id'):
             yield parse_declaration(f'-weasy-anchor:"{id_}"')
 
         if element.tag == 'a':
+            href = html.get_url_attribute(
+                element, 'href', base_url, allow_relative=True)
+            if href:
+                yield parse_declaration(f'-weasy-link:"{href}"')
             if name := element.get('name'):
                 yield parse_declaration(f'-weasy-anchor:"{name}"')
 

--- a/weasyprint/css/computed_values.py
+++ b/weasyprint/css/computed_values.py
@@ -7,7 +7,6 @@ from tinycss2.color5 import parse_color
 
 from ..logger import LOGGER
 from ..text.line_break import strut
-from ..urls import get_link
 from .functions import check_math
 from .properties import INITIAL_VALUES, ZERO_PIXELS, Dimension
 from .units import LENGTH_UNITS, to_pixels
@@ -690,16 +689,6 @@ def line_height(style, name, value):
         return Dimension(pixels, 'px')
     else:
         return length(style, name, value)
-
-
-@register_computer('link')
-def link(style, name, values):
-    """Compute the ``link`` property."""
-    name, value = values
-    if name == 'string':
-        return get_link(value, style.base_url)
-    elif name == 'url':
-        return values
 
 
 @register_computer('lang')

--- a/weasyprint/css/properties.py
+++ b/weasyprint/css/properties.py
@@ -290,7 +290,6 @@ INITIAL_VALUES = {
 
     # Proprietary
     'anchor': None,  # computed value of 'none'
-    'link': None,  # computed value of 'none'
     'lang': None,  # computed value of 'none'
 }
 
@@ -340,7 +339,6 @@ INHERITED = {
     'lang',
     'letter_spacing',
     'line_height',
-    'link',
     'list_style_image',
     'list_style_position',
     'list_style_type',

--- a/weasyprint/css/validation/properties.py
+++ b/weasyprint/css/validation/properties.py
@@ -1922,16 +1922,6 @@ def anchor(token):
         return token.value
 
 
-@property(proprietary=True, wants_base_url=True)
-@single_token
-def link(token, base_url):
-    """Validation for ``link``."""
-    if token.type == 'url':
-        return get_url(token, base_url)
-    elif token.type == 'string':
-        return ('string', token.value)
-
-
 @property()
 @single_token
 def tab_size(token):

--- a/weasyprint/formatting_structure/boxes.py
+++ b/weasyprint/formatting_structure/boxes.py
@@ -82,6 +82,7 @@ class Box:
     string_set = None
     footnote = None
     cached_counter_values = None
+    link = None
     missing_link = None
     link_annotation = None
     widget_annotation = None

--- a/weasyprint/html.py
+++ b/weasyprint/html.py
@@ -36,8 +36,8 @@ INTEGER_RE = re.compile(f'^[{WHITESPACE}]*([+-]?)([0-9]+)')
 DIMENSION_RE = re.compile(f'^[{WHITESPACE}]*([0-9]+([.][0-9]*)?)(%)?')
 
 
-def get_url_attribute(element, attr_name, base_url, allow_relative=False):
-    """Get the URI corresponding to the ``attr_name`` attribute.
+def parse_url(string, base_url, allow_relative=False):
+    """Parse a valid URL potentially surrounded by spaces.
 
     Return ``None`` if:
 
@@ -48,14 +48,15 @@ def get_url_attribute(element, attr_name, base_url, allow_relative=False):
     Otherwise return an URI, absolute if possible.
 
     """
-    value = element.get(attr_name, '')
-    value = value.strip(WHITESPACE)
-    for character in TAB_OR_NEWLINE:
-        value = value.replace(character, '')
+    if not string:
+        return
 
-    if value:
-        context = f'<{element.tag} {attr_name}="{value}">'
-        return url_join(base_url or '', value, allow_relative, context)
+    string = string.strip(WHITESPACE)
+    for character in TAB_OR_NEWLINE:
+        string = string.replace(character, '')
+
+    if string:
+        return url_join(base_url or '', string, allow_relative, string)
 
 
 def parse_integer(string):
@@ -109,31 +110,6 @@ def parse_legacy_color(string):
     green = round(max(0, min(1, color.green)) * 255)
     blue = round(max(0, min(1, color.blue)) * 255)
     return f'#{red:02x}{green:02x}{blue:02x}'
-
-
-def parse_string(string):
-    """Parse a URL from an HTML attribute value.
-
-    Return a CSS-escaped string, including quotes.
-
-    """
-    string = (
-        string
-        .replace('\\', '\\\\')
-        .replace('"', '\\"')
-        .replace('\n', '\\A')
-        .replace('\r', '\\D')
-        .replace('\f', '\\C'))
-    return f'"{string}"'
-
-
-def parse_url(string):
-    """Parse a URL from an HTML attribute value.
-
-    Return a url() string.
-
-    """
-    return f'url({parse_string(string)})'
 
 
 def map_to_pixel_length(string):
@@ -242,7 +218,7 @@ def make_replaced_box(element, box, image):
 def handle_img(element, box, get_image_from_uri, base_url):
     """Handle ``<img>`` elements, return either an image or the alt-text."""
     # See: https://www.w3.org/TR/html5/embedded-content-1.html#the-img-element.
-    if src := get_url_attribute(element, 'src', base_url):
+    if src := parse_url(element.get('src'), base_url):
         orientation = box.style['image_orientation']
         if image := get_image_from_uri(url=src, orientation=orientation):
             return [make_replaced_box(element, box, image)]
@@ -258,7 +234,7 @@ def handle_img(element, box, get_image_from_uri, base_url):
 def handle_embed(element, box, get_image_from_uri, base_url):
     """Handle ``<embed>`` elements, return either an image or nothing."""
     # See: https://www.w3.org/TR/html5/embedded-content-0.html#the-embed-element.
-    if src := get_url_attribute(element, 'src', base_url):
+    if src := parse_url(element.get('src'), base_url):
         mime_type = element.get('type', '').strip()
         orientation = box.style['image_orientation']
         image = get_image_from_uri(
@@ -273,7 +249,7 @@ def handle_embed(element, box, get_image_from_uri, base_url):
 def handle_object(element, box, get_image_from_uri, base_url):
     """Handle ``<object>`` elements, return either an image or the fallback."""
     # See: https://www.w3.org/TR/html5/embedded-content-0.html#the-object-element.
-    if data := get_url_attribute(element, 'data', base_url):
+    if data := parse_url(element.get('data'), base_url):
         mime_type = element.get('type', '').strip()
         orientation = box.style['image_orientation']
         image = get_image_from_uri(
@@ -372,7 +348,7 @@ def get_html_metadata(html):
                 custom[name] = content
         elif element.tag == 'link' and element_has_link_type(
                 element, 'attachment'):
-            url = get_url_attribute(element, 'href', html.base_url)
+            url = parse_url(element.get('href'), html.base_url)
             attachment_title = element.get('title', None)
             if url is None:
                 LOGGER.error('Missing href in <link rel="attachment">')

--- a/weasyprint/html.py
+++ b/weasyprint/html.py
@@ -18,7 +18,7 @@ from .css.counters import CounterStyle
 from .formatting_structure import boxes
 from .images import SVGImage
 from .logger import LOGGER
-from .urls import get_url_attribute
+from .urls import url_join
 
 UA_COUNTER_STYLE = CounterStyle()
 UA = (files(css) / 'html5_ua.css').read_text('utf-8')
@@ -28,11 +28,34 @@ UA_STYLESHEET = CSS(string=UA, counter_style=UA_COUNTER_STYLE)
 UA_FORM_STYLESHEET = CSS(string=UA_FORM, counter_style=UA_COUNTER_STYLE)
 PH_STYLESHEET = CSS(string=PH)
 
-# https://html.spec.whatwg.org/multipage/#space-character
+# https://infra.spec.whatwg.org/#ascii-whitespace
 WHITESPACE = ' \t\n\f\r'
+TAB_OR_NEWLINE = '\t\n\r'
 SPACE_SEPARATED_TOKENS_RE = re.compile(f'[^{WHITESPACE}]+')
 INTEGER_RE = re.compile(f'^[{WHITESPACE}]*([+-]?)([0-9]+)')
 DIMENSION_RE = re.compile(f'^[{WHITESPACE}]*([0-9]+([.][0-9]*)?)(%)?')
+
+
+def get_url_attribute(element, attr_name, base_url, allow_relative=False):
+    """Get the URI corresponding to the ``attr_name`` attribute.
+
+    Return ``None`` if:
+
+    * the attribute is empty or missing or,
+    * the value is a relative URI but the document has no base URI and
+      ``allow_relative`` is ``False``.
+
+    Otherwise return an URI, absolute if possible.
+
+    """
+    value = element.get(attr_name, '')
+    value = value.strip(WHITESPACE)
+    for character in TAB_OR_NEWLINE:
+        value = value.replace(character, '')
+
+    if value:
+        context = f'<{element.tag} {attr_name}="{value}">'
+        return url_join(base_url or '', value, allow_relative, context)
 
 
 def parse_integer(string):

--- a/weasyprint/html.py
+++ b/weasyprint/html.py
@@ -18,7 +18,7 @@ from .css.counters import CounterStyle
 from .formatting_structure import boxes
 from .images import SVGImage
 from .logger import LOGGER
-from .urls import url_join
+from .urls import get_link, url_join
 
 UA_COUNTER_STYLE = CounterStyle()
 UA = (files(css) / 'html5_ua.css').read_text('utf-8')
@@ -228,6 +228,14 @@ def handle_img(element, box, get_image_from_uri, base_url):
         return [box]
     # TODO: find some indicator that an image is missing.
     return []
+
+
+@handler('a')
+def handle_a(element, box, get_image_from_uri, base_url):
+    """Handle ``<a>`` elements, set the link attribute on the box."""
+    if href := parse_url(element.get('href'), base_url, allow_relative=True):
+        box.link = get_link(href, base_url)
+    return [box]
 
 
 @handler('embed')

--- a/weasyprint/pdf/anchors.py
+++ b/weasyprint/pdf/anchors.py
@@ -10,6 +10,7 @@ from urllib.parse import unquote, urlsplit
 import pydyf
 
 from .. import Attachment
+from ..html import get_url_attribute
 from ..logger import LOGGER
 from ..text.ffi import ffi, gobject, pango
 from ..text.fonts import get_font_description
@@ -268,22 +269,24 @@ def add_forms(forms, matrix, pdf, page, resources, stream, font_map):
             pdf.add_object(field)
 
         elif input_type == 'submit' or element.tag == 'button':
-            flags = 1 << (3 - 1)  # HTML form format
-            if form.element.get('method', '').lower() != 'post':
-                flags += 1 << (4 - 1)  # GET method
-            fields = pydyf.Array(field.reference for field in forms[form].values())
-            field['FT'] = '/Btn'
-            field['DA'] = pydyf.String(b' '.join(field_stream.stream))
-            field['V'] = pydyf.String(form.element.get('value', ''))
-            field['Ff'] = 1 << (17 - 1)  # Push-button
-            field['A'] = pydyf.Dictionary({
-                'Type': '/Action',
-                'S': '/SubmitForm',
-                'F': pydyf.String(form.element.get('action')),
-                'Fields': fields,
-                'Flags': flags,
-            })
-            pdf.add_object(field)
+            if action_url := get_url_attribute(form.element, 'action', None):
+                flags = 1 << (3 - 1)  # HTML form format
+                if form.element.get('method', '').lower() != 'post':
+                    flags += 1 << (4 - 1)  # GET method
+                    fields = pydyf.Array(
+                        field.reference for field in forms[form].values())
+                    field['FT'] = '/Btn'
+                    field['DA'] = pydyf.String(b' '.join(field_stream.stream))
+                    field['V'] = pydyf.String(form.element.get('value', ''))
+                    field['Ff'] = 1 << (17 - 1)  # Push-button
+                    field['A'] = pydyf.Dictionary({
+                        'Type': '/Action',
+                        'S': '/SubmitForm',
+                        'F': pydyf.String(action_url),
+                        'Fields': fields,
+                        'Flags': flags,
+                    })
+                    pdf.add_object(field)
 
         else:
             # Text, password, textarea, files, and other unknown fields.

--- a/weasyprint/pdf/anchors.py
+++ b/weasyprint/pdf/anchors.py
@@ -10,7 +10,7 @@ from urllib.parse import unquote, urlsplit
 import pydyf
 
 from .. import Attachment
-from ..html import get_url_attribute
+from ..html import parse_url
 from ..logger import LOGGER
 from ..text.ffi import ffi, gobject, pango
 from ..text.fonts import get_font_description
@@ -269,7 +269,8 @@ def add_forms(forms, matrix, pdf, page, resources, stream, font_map):
             pdf.add_object(field)
 
         elif input_type == 'submit' or element.tag == 'button':
-            if action_url := get_url_attribute(form.element, 'action', None):
+            action = form.element.get('action')
+            if action_url := parse_url(action, base_url=None, allow_relative=True):
                 flags = 1 << (3 - 1)  # HTML form format
                 if form.element.get('method', '').lower() != 'post':
                     flags += 1 << (4 - 1)  # GET method

--- a/weasyprint/svg/__init__.py
+++ b/weasyprint/svg/__init__.py
@@ -201,10 +201,10 @@ class Node:
 
     def get_href(self, base_url):
         """Get the href attribute, with or without a namespace."""
-        from ..html import get_url_attribute
+        from ..html import parse_url
 
         for attr_name in ('{http://www.w3.org/1999/xlink}href', 'href'):
-            if url := get_url_attribute(self, attr_name, base_url, allow_relative=True):
+            if url := parse_url(self.get(attr_name), base_url, allow_relative=True):
                 return url
 
     def del_href(self):

--- a/weasyprint/svg/__init__.py
+++ b/weasyprint/svg/__init__.py
@@ -7,7 +7,6 @@ from xml.etree import ElementTree
 
 from cssselect2 import ElementWrapper
 
-from ..urls import get_url_attribute
 from .css import parse_declarations, parse_stylesheets
 from .defs import apply_filters, draw_gradient, draw_pattern, paint_mask, use
 from .images import image, svg
@@ -202,6 +201,8 @@ class Node:
 
     def get_href(self, base_url):
         """Get the href attribute, with or without a namespace."""
+        from ..html import get_url_attribute
+
         for attr_name in ('{http://www.w3.org/1999/xlink}href', 'href'):
             if url := get_url_attribute(self, attr_name, base_url, allow_relative=True):
                 return url

--- a/weasyprint/urls.py
+++ b/weasyprint/urls.py
@@ -97,23 +97,6 @@ def url_is_absolute(url):
     return bool(scheme.match(url))
 
 
-def get_url_attribute(element, attr_name, base_url, allow_relative=False):
-    """Get the URI corresponding to the ``attr_name`` attribute.
-
-    Return ``None`` if:
-
-    * the attribute is empty or missing or,
-    * the value is a relative URI but the document has no base URI and
-      ``allow_relative`` is ``False``.
-
-    Otherwise return an URI, absolute if possible.
-
-    """
-    if value := element.get(attr_name, '').strip():
-        context = f'<{element.tag} {attr_name}="{value}">'
-        return url_join(base_url or '', value, allow_relative, context)
-
-
 def get_url_tuple(url, base_url):
     """Get tuple describing internal or external URI."""
     if url.startswith('#'):


### PR DESCRIPTION
Remove dirty `-weasy-link` property.

Fix #2851.