### PR TITLE
fix(layout): clean up nested absolute boxes when a relative container  is deferred to the next page

### DIFF
--- a/tests/layout/test_position.py
+++ b/tests/layout/test_position.py
@@ -519,6 +519,46 @@ def test_flex_absolute_positioning():
 
 
 @assert_no_logs
+def test_absolute_in_absolute_next_page():
+    # Regression test for #2714: content nested in absolutely-positioned boxes was
+    # duplicated when a relative container with no in-flow break point is pushed to
+    # the next page. The out-of-flow continuation registered during the first page’s
+    # layout attempt was not cleaned up, and got re-rendered on the next page in
+    # addition to the fresh layout of the deferred container.
+    page_1, page_2 = render_pages('''
+      <style>
+        @page { size: 30px 90px; margin: 0 }
+        body { font-family: weasyprint; font-size: 10px; line-height: 10px;
+               margin: 0 }
+        .p1 { height: 80px }
+        .rel { height: 80px; position: relative }
+        .a1, .a2 { position: absolute; top: 0; left: 0 }
+      </style>
+      <div class="p1">x</div>
+      <div class="rel"><div class="a1"><div class="a2">a<br>b<br>c</div></div></div>
+    ''')
+
+    # Page 1 only holds the in-flow filler.
+    html_1, = page_1.children
+    body_1, = html_1.children
+    div_1, = body_1.children
+    line_1, = div_1.children
+    text_1, = line_1.children
+    assert text_1.text == 'x'
+
+    # Page 2 holds the deferred relative container. Its <html> must have a single
+    # <body> child: no spurious out-of-flow box is prepended (that was the bug).
+    html_2, = page_2.children
+    assert [child.element_tag for child in html_2.children] == ['body']
+    body_2, = html_2.children
+    rel, = body_2.children
+    a1, = rel.children
+    a2, = a1.children
+    lines = a2.children
+    assert [line.children[0].text for line in lines] == ['a', 'b', 'c']
+
+
+@assert_no_logs
 @pytest.mark.xfail
 def test_grid_absolute_positioning():
     """TODO: Absolutely positioned grid items are not replaced by placeholders ."""

--- a/weasyprint/layout/block.py
+++ b/weasyprint/layout/block.py
@@ -1095,8 +1095,13 @@ def remove_placeholders(context, box_list, absolute_boxes, fixed_boxes):
 
     """
     for box in box_list:
-        if isinstance(box, boxes.ParentBox):
-            remove_placeholders(context, box.children, absolute_boxes, fixed_boxes)
+        # Unwrap absolute placeholders so we also clean up out-of-flow boxes nested
+        # inside them (an absolute box inside another absolute box). The placeholder
+        # itself is kept for the membership checks below, as absolute_boxes,
+        # broken_out_of_flow and excluded_shapes are keyed by placeholders.
+        inner = box._box if isinstance(box, AbsolutePlaceholder) else box
+        if isinstance(inner, boxes.ParentBox):
+            remove_placeholders(context, inner.children, absolute_boxes, fixed_boxes)
         if box.style['position'] == 'absolute' and box in absolute_boxes:
             absolute_boxes.remove(box)
         elif box.style['position'] == 'fixed' and box in fixed_boxes:


### PR DESCRIPTION
## Summary

  Fixes #2714: content inside nested absolutely-positioned boxes was duplicated
  when a `position: relative` container gets pushed to the next page.

  ## Root cause

  Reproducing layout (from the issue):

  - `page1-content` (200mm) fills page 1.
  - `page2-content` (`position: relative`, 200mm) has no in-flow break point, so it
    is deferred **whole** to page 2. The parent cleans up the discarded fragment via
    `remove_placeholders` (`block.py` `_in_flow_layout`).
  - During page 1's *layout attempt* of `page2-content`, its relative absolute
    resolution lays out `inner1` (absolute) → `inner2` (absolute, `top: 10em`).
    `inner2`'s text overflows the page bottom, so `absolute_layout` registers a
    continuation with `context.add_broken_out_of_flow(inner2_placeholder, …)`.

  `remove_placeholders` is supposed to drop that `broken_out_of_flow` entry, but it
  only recursed into `boxes.ParentBox`. `AbsolutePlaceholder` is not a `ParentBox`
  (it proxies attributes via `__getattr__`), so recursion stopped at the `inner1`
  placeholder and never reached the nested `inner2` placeholder that is the
  `broken_out_of_flow` key. The orphaned entry survived to page 2, where it was
  resumed as an out-of-flow box prepended to `<html>` — while `page2-content` was
  also laid out fresh. Hence the duplicate.

  ## Fix

  Unwrap `AbsolutePlaceholder` before the `ParentBox` recursion guard so cleanup
  descends into nested out-of-flow placeholders. The placeholder is kept for the
  membership/style checks, since `absolute_boxes`, `broken_out_of_flow` and
  `excluded_shapes` are keyed by placeholders. The `ParentBox` guard on the
  unwrapped box preserves existing behavior for absolutely-positioned replaced
  boxes (which have no `children`).

  This only affects discard/defer paths — legitimate cross-page absolute
  continuations (which are kept, not discarded) are unchanged.

  ## Test

  Added `test_absolute_in_absolute_next_page` to `tests/layout/test_position.py`, a
  deterministic reproduction using the test font. It fails before the fix (page 2's
  `<html>` gets a spurious out-of-flow child and the content renders twice) and
  passes after. Full layout test suite passes with no new failures.