### PR TITLE
Fix crash on object-position with nested calc()

### DIFF
--- a/tests/css/test_math.py
+++ b/tests/css/test_math.py
@@ -6,7 +6,8 @@ import pytest
 
 from weasyprint.css.validation.properties import PROPERTIES
 
-from ..testing_utils import assert_no_logs, capture_logs, render_pages
+from ..testing_utils import (  # isort:skip
+    BASE_URL, FakeHTML, assert_no_logs, capture_logs, render_pages)
 
 
 @assert_no_logs
@@ -460,3 +461,26 @@ def test_math_vertical_align_page_percent():
       <style>@page{@top-left{content: "a"; vertical-align: calc(1em + 1%)}}</style>
       <body>abc
     ''')
+
+
+# 1x1 PNG so object-position is exercised without a network fetch.
+_PIXEL_PNG = (
+    'data:image/png;base64,'
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQ'
+    'AAAABJRU5ErkJggg==')
+
+
+@assert_no_logs
+@pytest.mark.parametrize('position', [
+    'calc(50% + 1px) 0',
+    'calc(50% + 1px) calc(0px)',
+])
+def test_math_object_position_nested_calc_2896(position):
+    # Regression test for #2896. object-position stores a nested tuple, so an
+    # inner calc(percentage + length) must be resolved without crashing.
+    html = f'''
+      <img src="{_PIXEL_PNG}" style="object-position: {position}">
+    '''
+    render_pages(html)
+    # Layout does not read object-position; drawing replaced boxes does.
+    FakeHTML(string=html, base_url=BASE_URL).write_pdf()

--- a/weasyprint/css/__init__.py
+++ b/weasyprint/css/__init__.py
@@ -1254,28 +1254,39 @@ class ComputedStyle(Style):
             self.specified[key] = value
 
         if check_math(value):
-            solved_tokens = []
-            values = value if type(value) is tuple else (value,)
+            function = value
             try:
-                for value in values:
-                    if check_math(value):
-                        function = value
+                def resolve_nested(item):
+                    nonlocal function
+                    if type(item) is tuple:
+                        return tuple(resolve_nested(part) for part in item)
+                    if check_math(item):
+                        function = item
                         try:
                             token = resolve_math(function, self, key)
                         except PercentageInMath:
-                            solved_tokens.append(function)
+                            return function
                         else:
                             if token is None:
                                 raise Exception
-                            solved_tokens.append(token)
-                    else:
-                        solved_tokens.append(value)
-                original_key = key.replace('_', '-')
-                value = validate_non_shorthand(solved_tokens, original_key)[0][1]
+                            return token
+                    return item
+
+                resolved = resolve_nested(value)
+                # Nested tuples (object-position) are already validated.
+                if type(value) is tuple and any(type(part) is tuple for part in value):
+                    value = resolved
+                else:
+                    solved_tokens = (
+                        list(resolved) if type(resolved) is tuple else [resolved])
+                    original_key = key.replace('_', '-')
+                    value = validate_non_shorthand(solved_tokens, original_key)[0][1]
             except Exception:
                 LOGGER.warning(
                     'Invalid math function at %d:%d: %s',
-                    function.source_line, function.source_column, function.serialize())
+                    getattr(function, 'source_line', 0),
+                    getattr(function, 'source_column', 0),
+                    getattr(function, 'serialize', lambda: function)())
                 if key in INHERITED and parent_style is not None:
                     # Values in parent_style are already computed.
                     self[key] = value = parent_style[key]


### PR DESCRIPTION
`object-position: calc(50% + 1px) 0` crashed because math resolution walked tuples only one level, then the warning path assumed a FunctionBlock.

Recurse nested tuples when resolving math, and make the invalid-math warning getattr-safe.

Thanks to @alexandergitter for the report.

Fixes #2896