### PR TITLE
Fix crash on object-position nested calc()

### DIFF
--- a/tests/css/test_math.py
+++ b/tests/css/test_math.py
@@ -6,7 +6,8 @@ import pytest
 
 from weasyprint.css.validation.properties import PROPERTIES
 
-from ..testing_utils import assert_no_logs, capture_logs, render_pages
+from ..testing_utils import (  # isort:skip
+    BASE_URL, FakeHTML, assert_no_logs, capture_logs, render_pages)
 
 
 @assert_no_logs
@@ -460,3 +461,25 @@ def test_math_vertical_align_page_percent():
       <style>@page{@top-left{content: "a"; vertical-align: calc(1em + 1%)}}</style>
       <body>abc
     ''')
+
+
+@assert_no_logs
+@pytest.mark.parametrize('position', [
+    'calc(50% + 1px) 0',
+    'calc(50% + 1px) calc(0px)',
+])
+def test_math_object_position_nested_calc(position):
+    # Regression test for #2896. object-position stores nested tuples, so
+    # calc(percentage + length) must be computed and drawn without crashing.
+    html = f'<img src="pattern.png" style="object-position: {position}">'
+    render_pages(html)
+    FakeHTML(string=html, base_url=BASE_URL).write_pdf()
+
+
+def test_math_object_position_nested_invalid_unit():
+    # Nested calc() must still be validated: 1deg is not a <length-percentage>.
+    html = '<img src="pattern.png" style="object-position: calc(50% + 1deg) 0">'
+    with capture_logs() as logs:
+        FakeHTML(string=html, base_url=BASE_URL).write_pdf()
+    assert logs
+    assert any('invalid' in log.lower() for log in logs)

--- a/weasyprint/css/__init__.py
+++ b/weasyprint/css/__init__.py
@@ -709,6 +709,9 @@ def _resolve_calc_sum(computed, tokens, property_name, refer_to):
                 if unit is None:
                     unit = product.unit.lower()
                 elif unit == '%':
+                    # Percentages mix with lengths, not with angles or other units.
+                    if product.unit.lower() not in LENGTH_UNITS:
+                        return
                     raise PercentageInMath
                 elif unit != product.unit.lower():
                     return
@@ -719,8 +722,10 @@ def _resolve_calc_sum(computed, tokens, property_name, refer_to):
                 else:
                     if unit is None or unit == '%':
                         unit = '%'
-                    else:
+                    elif unit in LENGTH_UNITS:
                         raise PercentageInMath
+                    else:
+                        return
             if sign == '+':
                 value += product.value
             else:
@@ -1252,22 +1257,16 @@ class ComputedStyle(Style):
             self.specified[key] = value
 
         if check_math(value):
-            solved_tokens = []
-            values = value if type(value) is tuple else (value,)
+            function = value
             try:
-                for value in values:
-                    if check_math(value):
-                        function = value
-                        try:
-                            token = resolve_math(function, self, key)
-                        except PercentageInMath:
-                            solved_tokens.append(function)
-                        else:
-                            if token is None:
-                                raise Exception
-                            solved_tokens.append(token)
-                    else:
-                        solved_tokens.append(value)
+                try:
+                    token = resolve_math(function, self, key)
+                except PercentageInMath:
+                    solved_tokens = [function]
+                else:
+                    if token is None:
+                        raise Exception
+                    solved_tokens = [token]
                 original_key = key.replace('_', '-')
                 value = validate_non_shorthand(solved_tokens, original_key)[0][1]
             except Exception:

--- a/weasyprint/css/computed_values.py
+++ b/weasyprint/css/computed_values.py
@@ -328,9 +328,26 @@ def break_before_after(style, name, value):
 @register_computer('text-decoration-thickness')
 def length(style, name, value, font_size=None, pixels_only=False):
     """Compute a length ``value``."""
-    if value in ('auto', 'content', 'from-font') or check_math(value):
+    if value in ('auto', 'content', 'from-font'):
         return value
-    elif value.value == 0:
+    if check_math(value):
+        from . import resolve_math
+        from .tokens import PercentageInMath, RelativeLengthInMath
+        try:
+            token = resolve_math(value, style, name)
+        except (PercentageInMath, RelativeLengthInMath):
+            return value
+        if token is None:
+            return value
+        if token.type == 'percentage':
+            value = Dimension(token.value, '%')
+        elif token.type == 'dimension':
+            value = Dimension(token.value, token.unit.lower())
+        elif token.type == 'number' and token.value == 0:
+            value = Dimension(0, None)
+        else:
+            return value
+    if value.value == 0:
         return 0 if pixels_only else ZERO_PIXELS
     elif value.unit not in LENGTH_UNITS:
         # A percentage or 'auto': no conversion needed.

--- a/weasyprint/css/functions.py
+++ b/weasyprint/css/functions.py
@@ -175,9 +175,7 @@ def check_var(token):
 
 def check_math(token):
     # TODO: validate for real.
-    if type(token) is tuple:
-        return any(check_math(item) for item in token)
-    elif getattr(token, 'type', None) != 'function':
+    if getattr(token, 'type', None) != 'function':
         return
     function = Function(token)
     name = function.name


### PR DESCRIPTION
## Problem

`object-position: calc(50% + 1px) 0` crashed while painting:

```
AttributeError: 'tuple' object has no attribute 'source_line'
```

`object-position` stores a nested tuple. `check_math()` walked that tuple, so the style layer treated the whole value as a math function. On invalid or mixed-unit calc the warning path then assumed a function token and crashed.

`object-position: calc(50% + 1deg) 0` hit the same path.

## Fix

- Stop treating tuples as math functions in `check_math()`.
- Resolve nested `calc()` in the length computer, which already walks `object-position` components.
- Reject mixed units (percentage with non-length, e.g. `1deg`) instead of raising `PercentageInMath` and crashing.

## Tests

```
pytest tests/css/test_math.py tests/layout/test_image.py tests/css
```

521 passed in math+image; 2179 passed in `tests/css`.

Fixes #2896