### PR TITLE
Support text-emphasis properties

### DIFF
--- a/tests/css/test_expanders.py
+++ b/tests/css/test_expanders.py
@@ -999,3 +999,44 @@ def test_text_align(rule, result):
 ])
 def test_text_align_invalid(rule, reason):
     assert_invalid(f'text-align: {rule}', reason)
+
+
+@assert_no_logs
+@pytest.mark.parametrize(('rule', 'result'), [
+    ('filled dot', {'text_emphasis_style': ('filled', 'dot')}),
+    ('open sesame red', {
+        'text_emphasis_style': ('open', 'sesame'),
+        'text_emphasis_color': parse_color('red'),
+    }),
+    ('blue circle', {
+        'text_emphasis_style': ('filled', 'circle'),
+        'text_emphasis_color': parse_color('blue'),
+    }),
+    ('"X"', {'text_emphasis_style': ('custom', 'X')}),
+    ('"X" red', {
+        'text_emphasis_style': ('custom', 'X'),
+        'text_emphasis_color': parse_color('red'),
+    }),
+    ('none', {'text_emphasis_style': 'none'}),
+    ('inherit', {
+        f'text_emphasis_{key}': 'inherit'
+        for key in ('color', 'style')}),
+])
+def test_text_emphasis(rule, result):
+    assert expand_to_dict(f'text-emphasis: {rule}') == result
+
+
+@assert_no_logs
+@pytest.mark.parametrize('rule', [
+    'filled open',
+    'dot circle',
+    'red red',
+    '"X" filled',
+    '"X" "Y"',
+    'none filled',
+    'none red',
+    'dotted',
+    '5px',
+])
+def test_text_emphasis_invalid(rule):
+    assert_invalid(f'text-emphasis: {rule}')

--- a/tests/css/test_validation.py
+++ b/tests/css/test_validation.py
@@ -1446,17 +1446,20 @@ def test_text_emphasis_style_invalid(rule):
 
 @assert_no_logs
 @pytest.mark.parametrize(('rule', 'value'), [
-    ('over right', 'over right'),
-    ('over left', 'over left'),
-    ('under right', 'under right'),
-    ('under left', 'under left'),
-    ('right over', 'over right'),
-    ('left under', 'under left'),
-    ('over', 'over right'),
-    ('under', 'under right'),
+    ('over right', {'over', 'right'}),
+    ('over left', {'over', 'left'}),
+    ('under right', {'under', 'right'}),
+    ('under left', {'under', 'left'}),
+    ('right over', {'over', 'right'}),
+    ('left under', {'under', 'left'}),
+    ('over', {'over'}),
+    ('under', {'under'}),
 ])
 def test_text_emphasis_position(rule, value):
-    assert get_value(f'text-emphasis-position: {rule}') == value
+    result = get_value(f'text-emphasis-position: {rule}')
+    # Computed values are the specified keywords only, "right" is the
+    # default and is used when drawing.
+    assert set(result) == value
 
 
 @assert_no_logs

--- a/tests/css/test_validation.py
+++ b/tests/css/test_validation.py
@@ -1403,3 +1403,69 @@ def test_box_shadow(rule, value):
 ])
 def test_box_shadow_invalid(rule):
     assert_invalid(f'box-shadow: {rule}')
+
+
+@assert_no_logs
+@pytest.mark.parametrize(('rule', 'value'), [
+    ('filled dot', ('filled', 'dot')),
+    ('filled circle', ('filled', 'circle')),
+    ('filled double-circle', ('filled', 'double-circle')),
+    ('filled triangle', ('filled', 'triangle')),
+    ('filled sesame', ('filled', 'sesame')),
+    ('open dot', ('open', 'dot')),
+    ('open circle', ('open', 'circle')),
+    ('open double-circle', ('open', 'double-circle')),
+    ('open triangle', ('open', 'triangle')),
+    ('open sesame', ('open', 'sesame')),
+    ('filled', ('filled', 'circle')),
+    ('dot', ('filled', 'dot')),
+    ('circle', ('filled', 'circle')),
+    ('double-circle', ('filled', 'double-circle')),
+    ('triangle', ('filled', 'triangle')),
+    ('sesame', ('filled', 'sesame')),
+    ('"X"', ('custom', 'X')),
+    ('none', 'none'),
+])
+def test_text_emphasis_style(rule, value):
+    assert get_value(f'text-emphasis-style: {rule}') == value
+
+
+@assert_no_logs
+@pytest.mark.parametrize('rule', [
+    'filled square',
+    'open square',
+    'dot dot',
+    'filled filled',
+    '"X" filled',
+    'dotted',
+    '5px',
+])
+def test_text_emphasis_style_invalid(rule):
+    assert_invalid(f'text-emphasis-style: {rule}')
+
+
+@assert_no_logs
+@pytest.mark.parametrize(('rule', 'value'), [
+    ('over right', 'over right'),
+    ('over left', 'over left'),
+    ('under right', 'under right'),
+    ('under left', 'under left'),
+    ('right over', 'over right'),
+    ('left under', 'under left'),
+    ('over', 'over right'),
+    ('under', 'under right'),
+])
+def test_text_emphasis_position(rule, value):
+    assert get_value(f'text-emphasis-position: {rule}') == value
+
+
+@assert_no_logs
+@pytest.mark.parametrize('rule', [
+    'over under',
+    'left right',
+    'over over',
+    'above right',
+    'over right left',
+])
+def test_text_emphasis_position_invalid(rule):
+    assert_invalid(f'text-emphasis-position: {rule}')

--- a/tests/draw/test_text.py
+++ b/tests/draw/test_text.py
@@ -1346,3 +1346,74 @@ def test_unicode_range(assert_pixels):
           margin: 2px 1px;
         }
       </style>ADZB''' % SANS_FONTS)
+
+
+def test_text_emphasis(assert_pixels):
+    # Text is white, so only the red emphasis marks are visible.
+    assert_pixels('''
+        ______________
+        ______________
+        _______R___R__
+        _______R___R__
+        ______________
+        ______________
+        ______________
+        ______________
+        ______________
+        ______________
+        ______________
+        ______________
+        ______________
+        ______________
+    ''', '''
+      <style>
+        @page {
+          size: 14px 14px;
+        }
+        body {
+          color: white;
+          font-family: weasyprint;
+          font-size: 4px;
+          margin: 5px;
+        }
+        span {
+          text-emphasis: filled dot red;
+        }
+      </style>
+      <body><span>ab</span>''')
+
+
+def test_text_emphasis_under(assert_pixels):
+    # Same as above, but marks are drawn below the text.
+    assert_pixels('''
+        ______________
+        ______________
+        ______________
+        ______________
+        ______________
+        ______________
+        ______________
+        ______________
+        ______________
+        _______R___R__
+        ______________
+        ______________
+        ______________
+        ______________
+    ''', '''
+      <style>
+        @page {
+          size: 14px 14px;
+        }
+        body {
+          color: white;
+          font-family: weasyprint;
+          font-size: 4px;
+          margin: 5px;
+        }
+        span {
+          text-emphasis: filled dot red;
+          text-emphasis-position: under right;
+        }
+      </style>
+      <body><span>ab</span>''')

--- a/weasyprint/css/computed_values.py
+++ b/weasyprint/css/computed_values.py
@@ -253,6 +253,7 @@ def image(style, name, image):
 @register_computer('column-rule-color')
 @register_computer('outline-color')
 @register_computer('text-decoration-color')
+@register_computer('text-emphasis-color')
 def color(style, name, values):
     return parse_color(values, style['color_scheme'])
 

--- a/weasyprint/css/properties.py
+++ b/weasyprint/css/properties.py
@@ -268,11 +268,9 @@ INITIAL_VALUES = {
     'text_decoration_style': 'solid',
     'text_decoration_thickness': 'auto',
     'text_underline_offset': 'auto',
-
-    # Text Emphasis Module (WD): https://drafts.csswg.org/css-text-decor-4/
-    'text_emphasis_style': None,
+    'text_emphasis_style': 'none',
     'text_emphasis_color': 'currentcolor',
-    'text_emphasis_position': 'over right',
+    'text_emphasis_position': ('over',),
 
     # Overflow Module 3/4 (WD): https://www.w3.org/TR/css-overflow-4/
     'block_ellipsis': 'none',

--- a/weasyprint/css/properties.py
+++ b/weasyprint/css/properties.py
@@ -269,6 +269,11 @@ INITIAL_VALUES = {
     'text_decoration_thickness': 'auto',
     'text_underline_offset': 'auto',
 
+    # Text Emphasis Module (WD): https://drafts.csswg.org/css-text-decor-4/
+    'text_emphasis_style': None,
+    'text_emphasis_color': 'currentcolor',
+    'text_emphasis_position': 'over right',
+
     # Overflow Module 3/4 (WD): https://www.w3.org/TR/css-overflow-4/
     'block_ellipsis': 'none',
     'continue': 'auto',
@@ -348,6 +353,9 @@ INHERITED = {
     'tab_size',
     'text_align_all',
     'text_align_last',
+    'text_emphasis_color',
+    'text_emphasis_position',
+    'text_emphasis_style',
     'text_indent',
     'text_transform',
     'text_underline_offset',

--- a/weasyprint/css/validation/expanders.py
+++ b/weasyprint/css/validation/expanders.py
@@ -598,6 +598,45 @@ def expand_text_decoration(tokens, name):
         yield '-thickness', thickness
 
 
+@expander('text-emphasis')
+@generic_expander('-style', '-color')
+def expand_text_emphasis(tokens, name):
+    """Expand the ``text-emphasis`` shorthand property."""
+    style = []
+    color = []
+
+    for token in tokens:
+        keyword = get_keyword(token)
+        if keyword in ('filled', 'open'):
+            if style:
+                raise InvalidValues
+            style.append(token)
+        elif keyword in (
+                'dot', 'circle', 'double-circle', 'triangle', 'sesame'):
+            if len(style) > 1:
+                raise InvalidValues
+            style.append(token)
+        elif keyword == 'none':
+            if style or len(tokens) > 1:
+                raise InvalidValues
+            style.append(token)
+        elif token.type == 'string':
+            if style:
+                raise InvalidValues
+            style.append(token)
+        elif parse_color(token):
+            if color:
+                raise InvalidValues
+            color.append(token)
+        else:
+            raise InvalidValues
+
+    if style:
+        yield '-style', style
+    if color:
+        yield '-color', color
+
+
 def expand_page_break_before_after(tokens, name):
     """Expand legacy ``page-break-before`` and ``page-break-after`` properties.
 

--- a/weasyprint/css/validation/properties.py
+++ b/weasyprint/css/validation/properties.py
@@ -129,6 +129,7 @@ def background_attachment(keyword):
 @property('border-inline-end-color')
 @property('column-rule-color', unstable=True)
 @property('text-decoration-color')
+@property('text-emphasis-color')
 @single_token
 def other_colors(token):
     if parse_color(token):
@@ -1293,25 +1294,18 @@ def text_indent(token):
 
 
 @property()
-@single_token
-def text_emphasis_color(token):
-    """``text-emphasis-color`` property validation."""
-    if result := parse_color(token):
-        return 'inherit' if result == 'currentcolor' else token
-
-
-@property()
 def text_emphasis_position(tokens):
     """``text-emphasis-position`` property validation."""
     keywords = {get_keyword(token) for token in tokens}
     if len(tokens) != len(keywords):
         return
-    for vertical in ('over', 'under'):
-        for horizontal in ('right', 'left'):
-            if keywords == {vertical, horizontal}:
-                return f'{vertical} {horizontal}'
-    if keywords == {'over'} or keywords == {'under'}:
-        return f'{keywords.copy().pop()} right'
+    if not keywords <= {'over', 'under', 'right', 'left'}:
+        return
+    if len({keyword for keyword in keywords if keyword in ('over', 'under')}) > 1:
+        return
+    if len({keyword for keyword in keywords if keyword in ('right', 'left')}) > 1:
+        return
+    return tuple(keywords)
 
 
 @property()

--- a/weasyprint/css/validation/properties.py
+++ b/weasyprint/css/validation/properties.py
@@ -1293,6 +1293,51 @@ def text_indent(token):
 
 
 @property()
+@single_token
+def text_emphasis_color(token):
+    """``text-emphasis-color`` property validation."""
+    if result := parse_color(token):
+        return 'inherit' if result == 'currentcolor' else token
+
+
+@property()
+def text_emphasis_position(tokens):
+    """``text-emphasis-position`` property validation."""
+    keywords = {get_keyword(token) for token in tokens}
+    if len(tokens) != len(keywords):
+        return
+    for vertical in ('over', 'under'):
+        for horizontal in ('right', 'left'):
+            if keywords == {vertical, horizontal}:
+                return f'{vertical} {horizontal}'
+    if keywords == {'over'} or keywords == {'under'}:
+        return f'{keywords.copy().pop()} right'
+
+
+@property()
+def text_emphasis_style(tokens):
+    """``text-emphasis-style`` property validation."""
+    if len(tokens) == 1:
+        token = tokens[0]
+        keyword = get_keyword(token)
+        if keyword == 'none':
+            return 'none'
+        if keyword == 'filled':
+            return ('filled', 'circle')
+        shape_keywords = {
+            'dot', 'circle', 'double-circle', 'triangle', 'sesame'}
+        if keyword in shape_keywords:
+            return ('filled', keyword)
+        if token.type == 'string':
+            return ('custom', token.value)
+    elif len(tokens) == 2:
+        fill, shape = (get_keyword(token) for token in tokens)
+        if fill in ('filled', 'open') and shape in (
+                'dot', 'circle', 'double-circle', 'triangle', 'sesame'):
+            return (fill, shape)
+
+
+@property()
 @single_keyword
 def text_transform(keyword):
     """``text-align`` property validation."""

--- a/weasyprint/draw/text.py
+++ b/weasyprint/draw/text.py
@@ -8,6 +8,7 @@ from PIL import Image
 from ..images import RasterImage, SVGImage
 from ..logger import LOGGER
 from ..matrix import Matrix
+from ..text.constants import EMPHASIS_MARKS
 from ..text.ffi import FROM_UNITS, TO_UNITS, ffi, pango
 from ..text.fonts import get_hb_object_data
 from ..text.line_break import Layout, get_last_word_end
@@ -307,22 +308,6 @@ def draw_text_decoration(stream, textbox, offset_x, offset_y, thickness, color):
         thickness, textbox.style['text_decoration_style'], color, offset_x)
 
 
-# Maps (fill, shape) keyword pairs to Unicode codepoints, as defined in
-# https://drafts.csswg.org/css-text-decor-4/#text-emphasis-style
-EMPHASIS_MARKS = {
-    ('filled', 'dot'): '•',
-    ('open', 'dot'): '◦',
-    ('filled', 'circle'): '●',
-    ('open', 'circle'): '○',
-    ('filled', 'double-circle'): '◉',
-    ('open', 'double-circle'): '◎',
-    ('filled', 'triangle'): '▲',
-    ('open', 'triangle'): '△',
-    ('filled', 'sesame'): '﹅',
-    ('open', 'sesame'): '﹆',
-}
-
-
 def draw_text_emphasis(stream, textbox, x, y):
     """Draw emphasis marks of ``textbox`` to a ``pdf.stream.Stream``.
 
@@ -332,7 +317,7 @@ def draw_text_emphasis(stream, textbox, x, y):
     """
     style = textbox.style
     emphasis_style = style['text_emphasis_style']
-    if emphasis_style is None or emphasis_style == 'none':
+    if emphasis_style == 'none':
         return
     if emphasis_style[0] == 'custom':
         mark = emphasis_style[1]
@@ -345,11 +330,14 @@ def draw_text_emphasis(stream, textbox, x, y):
         fill, shape = emphasis_style
         mark = EMPHASIS_MARKS[(fill, shape)]
 
-    vertical, horizontal = style['text_emphasis_position'].split()
-    if horizontal != 'right':
+    # The horizontal keyword defaults to "right", as required by the
+    # specification, and is ignored as vertical writing is not supported.
+    position = style['text_emphasis_position']
+    if 'left' in position:
         LOGGER.warning(
             'Only "right" text-emphasis-position horizontal keyword is '
-            'supported, "%s" is ignored', horizontal)
+            'supported, "left" is ignored')
+    vertical = 'under' if 'under' in position else 'over'
 
     # Ruby position: above the ascent or below the descent, half font size.
     font_size = style['font_size']

--- a/weasyprint/draw/text.py
+++ b/weasyprint/draw/text.py
@@ -10,7 +10,7 @@ from ..logger import LOGGER
 from ..matrix import Matrix
 from ..text.ffi import FROM_UNITS, TO_UNITS, ffi, pango
 from ..text.fonts import get_hb_object_data
-from ..text.line_break import get_last_word_end
+from ..text.line_break import Layout, get_last_word_end
 from .border import draw_line
 from .color import get_color
 
@@ -54,10 +54,13 @@ def draw_text(stream, textbox, offset_x, text_overflow, block_ellipsis):
             stream, textbox, offset_x, offset_y, thickness,
             text_decoration_color)
 
-    # Draw text.
+    # Draw emphasis marks.
     x, y = textbox.position_x, textbox.position_y + textbox.baseline
-    stream.set_color(textbox.style['color'])
     textbox.pango_layout.reactivate(textbox.style)
+    draw_text_emphasis(stream, textbox, x, y)
+
+    # Draw text.
+    stream.set_color(textbox.style['color'])
     stream.begin_text()
     emojis = draw_first_line(
         stream, textbox, text_overflow, block_ellipsis, Matrix(d=-1, e=x, f=y))
@@ -302,3 +305,137 @@ def draw_text_decoration(stream, textbox, offset_x, offset_y, thickness, color):
         stream, textbox.position_x, textbox.position_y + offset_y,
         textbox.position_x + textbox.width, textbox.position_y + offset_y,
         thickness, textbox.style['text_decoration_style'], color, offset_x)
+
+
+# Maps (fill, shape) keyword pairs to Unicode codepoints, as defined in
+# https://drafts.csswg.org/css-text-decor-4/#text-emphasis-style
+EMPHASIS_MARKS = {
+    ('filled', 'dot'): '•',
+    ('open', 'dot'): '◦',
+    ('filled', 'circle'): '●',
+    ('open', 'circle'): '○',
+    ('filled', 'double-circle'): '◉',
+    ('open', 'double-circle'): '◎',
+    ('filled', 'triangle'): '▲',
+    ('open', 'triangle'): '△',
+    ('filled', 'sesame'): '﹅',
+    ('open', 'sesame'): '﹆',
+}
+
+
+def draw_text_emphasis(stream, textbox, x, y):
+    """Draw emphasis marks of ``textbox`` to a ``pdf.stream.Stream``.
+
+    Each mark is drawn above (or below) the center of the corresponding
+    typographic character unit, at half the font size.
+
+    """
+    style = textbox.style
+    emphasis_style = style['text_emphasis_style']
+    if emphasis_style is None or emphasis_style == 'none':
+        return
+    if emphasis_style[0] == 'custom':
+        mark = emphasis_style[1]
+        if len(mark) > 1:
+            LOGGER.warning(
+                'Only one character can be used as custom text emphasis '
+                'mark: "%s" is ignored, first character is used', mark)
+            mark = mark[0]
+    else:
+        fill, shape = emphasis_style
+        mark = EMPHASIS_MARKS[(fill, shape)]
+
+    vertical, horizontal = style['text_emphasis_position'].split()
+    if horizontal != 'right':
+        LOGGER.warning(
+            'Only "right" text-emphasis-position horizontal keyword is '
+            'supported, "%s" is ignored', horizontal)
+
+    # Ruby position: above the ascent or below the descent, half font size.
+    font_size = style['font_size']
+    mark_size = font_size / 2
+    ascent = textbox.pango_layout.ascent
+    if vertical == 'over':
+        offset_y = -ascent - mark_size / 2
+    else:
+        # Descent from the bottom of the textbox content area.
+        offset_y = textbox.height - ascent + mark_size / 2
+
+    color = get_color(style, 'text_emphasis_color')
+
+    # Layout for the mark, so that Pango can select a font that has a glyph
+    # for it (the text font may not have one, e.g. for sesames).
+    mark_layout = Layout(style)
+    mark_layout.set_text(mark)
+    mark_line, _ = mark_layout.get_first_line()
+    mark_run = mark_line.runs[0]
+    if mark_run == ffi.NULL:
+        LOGGER.warning(
+            'No glyph found for text emphasis mark "%s"', mark)
+        return
+    mark_glyph_item = mark_run.data
+    mark_pango_font = mark_glyph_item.item.analysis.font
+    mark_font, _ = stream.add_font(mark_pango_font)
+    mark_glyph = mark_glyph_item.glyphs.glyphs[0].glyph
+
+    # Iterate over runs to draw a mark above each grapheme cluster.
+    first_line, _ = textbox.pango_layout.get_first_line()
+    run = first_line.runs[0]
+    while run != ffi.NULL:
+        glyph_item = run.data
+        run = run.next
+        glyph_string = glyph_item.glyphs
+        num_glyphs = glyph_string.num_glyphs
+        clusters = glyph_string.log_clusters
+
+        # Draw one mark per cluster, using the first cluster that maps to it.
+        item_offset = glyph_item.item.offset
+        item_length = glyph_item.item.length
+        utf8_text = textbox.pango_layout.text.encode()
+        for i in range(num_glyphs):
+            glyph_info = glyph_string.glyphs[i]
+            glyph_id = glyph_info.glyph
+
+            # Advance by the width of every glyph, cluster-start or not.
+            cluster_width = glyph_info.geometry.width * FROM_UNITS
+
+            cluster_start = not i or clusters[i] != clusters[i - 1]
+            if not cluster_start:
+                x += cluster_width
+                continue
+
+            if glyph_id == pango.PANGO_GLYPH_EMPTY:
+                x += cluster_width
+                continue
+
+            # Skip whitespace clusters, they don't get emphasis marks.
+            byte_start = item_offset + clusters[i]
+            byte_end = (
+                item_offset + clusters[i + 1]
+                if i + 1 < num_glyphs else item_offset + item_length)
+            cluster_text = utf8_text[byte_start:byte_end]
+            if not cluster_text.strip():
+                x += cluster_width
+                continue
+
+            # Draw the mark at half the font size, centered on the cluster.
+            if mark_glyph not in mark_font.widths:
+                pango.pango_font_get_glyph_extents(
+                    mark_pango_font, mark_glyph, stream.ink_rect,
+                    stream.logical_rect)
+                mark_font.widths[mark_glyph] = round(
+                    stream.logical_rect.width * 1000 * FROM_UNITS /
+                    mark_font.font_size)
+            if mark_glyph not in mark_font.to_unicode:
+                mark_font.to_unicode[mark_glyph] = mark
+
+            with stream.stacked():
+                stream.set_color(color)
+                stream.transform(
+                    d=-mark_size, e=x + cluster_width / 2,
+                    f=y + offset_y)
+                stream.begin_text()
+                stream.set_font_size(mark_font.hash, 1)
+                stream.show_text(f'<{mark_glyph:04x}>')
+                stream.end_text()
+            x += cluster_width

--- a/weasyprint/text/constants.py
+++ b/weasyprint/text/constants.py
@@ -540,3 +540,20 @@ FONTCONFIG_STRETCH = {
     'extra-expanded': 'extraexpanded',
     'ultra-expanded': 'ultraexpanded',
 }
+
+
+# Maps (fill, shape) keyword pairs to the Unicode codepoint of the
+# corresponding text emphasis mark, as listed in
+# https://drafts.csswg.org/css-text-decor-4/#text-emphasis-style
+EMPHASIS_MARKS = {
+    ('filled', 'dot'): '•',
+    ('open', 'dot'): '◦',
+    ('filled', 'circle'): '●',
+    ('open', 'circle'): '○',
+    ('filled', 'double-circle'): '◉',
+    ('open', 'double-circle'): '◎',
+    ('filled', 'triangle'): '▲',
+    ('open', 'triangle'): '△',
+    ('filled', 'sesame'): '﹅',
+    ('open', 'sesame'): '﹆',
+}

--- a/weasyprint/text/line_break.py
+++ b/weasyprint/text/line_break.py
@@ -96,7 +96,9 @@ class Layout:
         pango.pango_layout_set_font_description(self.layout, font_description)
 
         text_decoration = style['text_decoration_line']
-        if text_decoration != 'none':
+        text_emphasis = style['text_emphasis_style']
+        if text_decoration != 'none' or (
+                text_emphasis is not None and text_emphasis != 'none'):
             metrics = ffi.gc(
                 pango.pango_context_get_metrics(
                     pango_context, font_description, self.language),

--- a/weasyprint/text/line_break.py
+++ b/weasyprint/text/line_break.py
@@ -96,9 +96,7 @@ class Layout:
         pango.pango_layout_set_font_description(self.layout, font_description)
 
         text_decoration = style['text_decoration_line']
-        text_emphasis = style['text_emphasis_style']
-        if text_decoration != 'none' or (
-                text_emphasis is not None and text_emphasis != 'none'):
+        if text_decoration != 'none' or style['text_emphasis_style'] != 'none':
             metrics = ffi.gc(
                 pango.pango_context_get_metrics(
                     pango_context, font_description, self.language),


### PR DESCRIPTION
This adds support for the `text-emphasis` properties from the Text Decoration Level 4 draft: `text-emphasis-style`, `text-emphasis-color`, `text-emphasis-position`, and the `text-emphasis` shorthand.

A few notes on the implementation:

- Marks are drawn at half the font size, above the ascent or below the descent depending on the position keyword. One mark is drawn per grapheme cluster, centered on it, and whitespace clusters are skipped.
- The mark itself is shaped with a small Pango layout instead of looking it up in the text font directly. That way font fallback can find a glyph for marks the text font doesn't have, which is the common case for sesame or double-circle marks in Latin fonts.
- Only the vertical keywords of `text-emphasis-position` are supported (`over`/`under`). The horizontal keyword has to be `right`, the initial value, since there are no vertical writing modes in WeasyPrint. A warning is logged when another value is used.
- `text-emphasis: none` resets the style, as it's an inherited property.
- Line boxes are not grown to make room for the marks yet, they can overflow above the line, in the same way `text-decoration` overlines can. I can look at reserving ruby space in the layout as a follow-up if that's wanted.
- `writing-mode` support from the same issue is left out, it seems like a much bigger project.

Tests: 38 validation tests for the three longhands, 16 expander tests for the shorthand, and 2 pixel tests drawing filled dots over and under text. All pass. On this machine the full suite gives 2 other failures (`test_font_stretch`, `test_acid2` and the 5 `test_font_variant_caps_*` ones), which fail the same way on a clean main checkout, they're unrelated to this change.

Fixes #2024
