### PR TITLE
Add initial support of CSS Notes

### DIFF
--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -443,6 +443,27 @@ over the rendering of difficult pages with ``footnote-policy``.
 .. _running elements: https://www.w3.org/TR/css-gcpm-3/#running-elements
 .. _Footnotes: https://www.w3.org/TR/css-gcpm-3/#footnotes
 
+CSS Notes
++++++++++
+
+The `CSS Notes Module`_ is an unofficial draft "for the creation and positioning of
+notes in both continuous and paged media."
+
+The properties and features proposed by this module are not stable and may change in the
+future, they should be used for testing purpose only.
+
+The ``note()`` function and the ``all-once`` parameter of the ``element`` function are
+supported.
+
+The ``@note-area`` at-block is supported, without the features of page floats.
+
+The ``::note-call``, ``::note-marker`` and ``::note-callback`` pseudo-elements are
+supported.
+
+The ``note-policy`` property is **not** implemented.
+
+.. _CSS Notes Module: https://css-print-lab.github.io/specs/notes-in-css-print/
+
 CSS Generated Content Module Level 3
 ++++++++++++++++++++++++++++++++++++
 

--- a/tests/draw/test_note.py
+++ b/tests/draw/test_note.py
@@ -1,0 +1,300 @@
+"""Test how notes are drawn."""
+
+from ..testing_utils import assert_no_logs
+
+
+@assert_no_logs
+def test_one_note(assert_pixels):
+    assert_pixels('''
+        BBBBBBBBBB
+        BBBBBBBBBB
+        RRRRRRRR__
+        RRRRRRRR__
+    ''', '''
+        <style>
+            @page {
+                size: 10px 4px;
+                @note-area {
+                    content: element(sidenotes, all-once);
+                }
+            }
+            div {
+                color: red;
+                font: 2px/1 weasyprint;
+            }
+            span {
+                color: blue;
+                display: block;
+                position: note(sidenotes);
+
+                &::note-call { color: red}
+            }
+        </style>
+        <div>abc<span>de</span></div>''')
+
+
+@assert_no_logs
+def test_several_note(assert_pixels):
+    assert_pixels('''
+        BBBBBBBBBB______
+        BBBBBBBBBB______
+        BBBBBBBBBB______
+        BBBBBBBBBB______
+        RRRRRRRRRRRRRRRR
+        RRRRRRRRRRRRRRRR
+    ''', '''
+        <style>
+            @page {
+                size: 16px 6px;
+                @note-area {
+                    content: element(sidenotes, all-once);
+                }
+            }
+            div {
+                color: red;
+                font: 2px/1 weasyprint;
+            }
+            span {
+                color: blue;
+                display: block;
+                position: note(sidenotes);
+
+                &::note-call { color: red}
+            }
+        </style>
+        <div>abc<span>de</span>fgh<span>ij</span></div>''')
+
+
+@assert_no_logs
+def test_inline_note(assert_pixels):
+    assert_pixels('''
+        BBBBBBBBBBBBBBBBBBBB
+        BBBBBBBBBBBBBBBBBBBB
+        RRRRRRRRRRRRRRRR____
+        RRRRRRRRRRRRRRRR____
+    ''', '''
+        <style>
+            @page {
+                size: 20px 4px;
+                @note-area {
+                    content: element(sidenotes, all-once);
+                    font: 2px/1 weasyprint;
+                }
+            }
+            div {
+                color: red;
+                font: 2px/1 weasyprint;
+            }
+            span {
+                color: blue;
+                display: inline;
+                position: note(sidenotes);
+
+                &::note-call { color: red }
+            }
+        </style>
+        <div>abc<span>de</span>fgh<span>ij</span></div>''')
+
+
+@assert_no_logs
+def test_absolute_note(assert_pixels):
+    assert_pixels('''
+        RRRRRRRRRRRRRRRR
+        RRRRRRRRRRRRRRRR
+        ________________
+        ________________
+        ______RRRRRRRRRR
+        ______RRRRRRRRRR
+        ______RRRRRRRRRR
+        ______RRRRRRRRRR
+    ''', '''
+        <style>
+            @page {
+                size: 16px 8px;
+                @note-area {
+                    content: element(sidenotes, all-once);
+                    position: absolute;
+                    bottom: 0;
+                    right: 0;
+                    width: calc(10 / 16 * 100%);
+                }
+            }
+            div {
+                color: red;
+                font-family: weasyprint;
+                font-size: 2px;
+                line-height: 1;
+            }
+            span {
+                display: block;
+                position: note(sidenotes);
+            }
+        </style>
+        <div>abc<span>de</span>fgh<span>ij</span></div>''')
+
+
+@assert_no_logs
+def test_float_left_note(assert_pixels):
+    assert_pixels('''
+        BBBBBBBBRRRRRRBB
+        BBBBBBBBRRRRRRBB
+        BBBBBBBBRRRRRRBB
+        BBBBBBBBRRRRRRBB
+    ''', '''
+        <style>
+            @page {
+                size: 16px 4px;
+                @note-area {
+                    content: element(sidenotes, all-once);
+                    float: left;
+                    width: 50%;
+                }
+            }
+            div {
+                color: red;
+                font: 2px/1 weasyprint;
+            }
+            span {
+                color: blue;
+                display: block;
+                position: note(sidenotes);
+            }
+        </style>
+        <div>abc<span>d</span>
+          fgh<span>i</span></div>''')
+
+
+@assert_no_logs
+def test_float_right_note(assert_pixels):
+    assert_pixels('''
+        RRRRRRBBBBBBBBBB
+        RRRRRRBBBBBBBBBB
+        RRRRRRBBBBBBBBBB
+        RRRRRRBBBBBBBBBB
+    ''', '''
+        <style>
+            @page {
+                size: 16px 4px;
+                @note-area {
+                    content: element(sidenotes, all-once);
+                    float: right;
+                    width: 50%;
+                }
+            }
+            div {
+                color: red;
+                font: 2px/1 weasyprint;
+            }
+            span {
+                color: blue;
+                display: block;
+                position: note(sidenotes);
+            }
+        </style>
+        <div>abc<span>d</span>
+          fgh<span>i</span></div>''')
+
+
+@assert_no_logs
+def test_float_left_margin_note(assert_pixels):
+    assert_pixels('''
+        ________________________
+        ________________________
+        __BBBBBBBB______________
+        __BBBBBBBB______________
+        __BBBBBBBB__RRRRRRBB____
+        __BBBBBBBB__RRRRRRBB____
+        ____________RRRRRRBB____
+        ____________RRRRRRBB____
+        ____RRRRRRRRRR__________
+        ____RRRRRRRRRR__________
+        ________________________
+        ________________________
+        ________________________
+        ________________________
+    ''', '''
+        <style>
+            @page {
+                size: 24px 14px;
+                margin: 4px;
+                @note-area {
+                    content: element(sidenotes, all-once);
+                    float: left;
+                    margin: -2px 2px 2px -2px;
+                    width: 50%;
+                }
+            }
+            div {
+                color: red;
+                font: 2px/1 weasyprint;
+            }
+            span {
+                color: blue;
+                display: block;
+                position: note(sidenotes);
+            }
+        </style>
+        <div>abc<span>d</span>
+          fgh<span>i</span>
+          jklmn</div>''')
+
+
+@assert_no_logs
+def test_flex_note(assert_pixels):
+    assert_pixels('''
+        BBBBBBBBBBBBBBBB
+        BBBBBBBBBBBBBBBB
+        RRRRRRBBRRRRRRBB
+        RRRRRRBBRRRRRRBB
+    ''', '''
+        <style>
+            @page {
+                size: 16px 4px;
+                @note-area {
+                    content: element(sidenotes, all-once);
+                    display: flex;
+                    flex-wrap: wrap;
+                }
+            }
+            div {
+                color: red;
+                font: 2px/1 weasyprint;
+            }
+            span {
+                color: blue;
+                display: block;
+                position: note(sidenotes);
+            }
+        </style>
+        <div>abc<span>d</span>fgh<span>i</span></div>''')
+
+
+@assert_no_logs
+def test_grid_note(assert_pixels):
+    assert_pixels('''
+        BBBBBBBB__BBBBBBBB
+        BBBBBBBB__BBBBBBBB
+        RRRRRRBBRRRRRRBB__
+        RRRRRRBBRRRRRRBB__
+    ''', '''
+        <style>
+            @page {
+                size: 18px 4px;
+                @note-area {
+                    content: element(sidenotes, all-once);
+                    display: grid;
+                    grid-template-columns: 1fr 1fr;
+                    gap: 2px;
+                }
+            }
+            div {
+                color: red;
+                font: 2px/1 weasyprint;
+            }
+            span {
+                color: blue;
+                display: block;
+                position: note(sidenotes);
+            }
+        </style>
+        <div>abc<span>d</span>fgh<span>i</span></div>''')

--- a/tests/draw/test_note.py
+++ b/tests/draw/test_note.py
@@ -386,20 +386,62 @@ def test_next_page_split_not_fitted_note(assert_pixels):
         RRRRRRRRRRRRRRRR
         RRRRRRRRRRRRRRRR
         RRRRRRRRRRRRRRRR
+        RRRRRRBB________
+        RRRRRRBB________
+        BBBBBBBB________
+        BBBBBBBB________
+        RRRRRRRRRRRRRRRR
+        RRRRRRRRRRRRRRRR
+        RRRRRRBB________
+        RRRRRRBB________
+        BBBBBBBB________
+        BBBBBBBB________
         ________________
         ________________
+    ''', '''
+        <style>
+            @page {
+                size: 16px 6px;
+                @note-area {
+                    content: element(sidenotes, all-once);
+                }
+            }
+            div {
+                color: red;
+                font: 2px/1 weasyprint;
+            }
+            span {
+                color: blue;
+                display: block;
+                position: note(sidenotes);
+            }
+        </style>
+        <div>
+          aaaaaaaa
+          aaaaaaaa
+          abc<span>d</span>
+          aaaaaaaa
+          fgh<span>i</span></div>''')
+
+
+
+
+@pytest.mark.xfail
+@assert_no_logs
+def test_next_page_split_not_fitted_note_2(assert_pixels):
+    assert_pixels('''
+        RRRRRRRRRRRRRRRR
+        RRRRRRRRRRRRRRRR
+        RRRRRRRRRRRRRRRR
+        RRRRRRRRRRRRRRRR
+        RRRRRRBB________
+        RRRRRRBB________
+        BBBBBBBB________
+        BBBBBBBB________
         BBBBBBBB________
         BBBBBBBB________
         RRRRRRBB________
         RRRRRRBB________
-        ________________
-        ________________
-        BBBBBBBB________
-        BBBBBBBB________
-        RRRRRRBB________
-        RRRRRRBB________
-        ________________
-        ________________
     ''', '''
         <style>
             @page {
@@ -427,7 +469,7 @@ def test_next_page_split_not_fitted_note(assert_pixels):
 
 @pytest.mark.xfail
 @assert_no_logs
-def test_next_page_split_not_fitted_note_2(assert_pixels):
+def test_next_page_split_not_fitted_note_3(assert_pixels):
     assert_pixels('''
         BBBBBBBB________
         BBBBBBBB________

--- a/tests/draw/test_note.py
+++ b/tests/draw/test_note.py
@@ -378,21 +378,28 @@ def test_next_page_split_note(assert_pixels):
           fgh<span>i</span></div>''')
 
 
+@pytest.mark.xfail
 @assert_no_logs
 def test_next_page_split_not_fitted_note(assert_pixels):
     assert_pixels('''
-        BBBBBBBB________
-        BBBBBBBB________
         RRRRRRRRRRRRRRRR
         RRRRRRRRRRRRRRRR
         RRRRRRRRRRRRRRRR
         RRRRRRRRRRRRRRRR
+        ________________
+        ________________
         BBBBBBBB________
         BBBBBBBB________
         RRRRRRBB________
         RRRRRRBB________
+        ________________
+        ________________
+        BBBBBBBB________
+        BBBBBBBB________
         RRRRRRBB________
         RRRRRRBB________
+        ________________
+        ________________
     ''', '''
         <style>
             @page {

--- a/tests/draw/test_note.py
+++ b/tests/draw/test_note.py
@@ -1,5 +1,7 @@
 """Test how notes are drawn."""
 
+import pytest
+
 from ..testing_utils import assert_no_logs
 
 
@@ -298,3 +300,158 @@ def test_grid_note(assert_pixels):
             }
         </style>
         <div>abc<span>d</span>fgh<span>i</span></div>''')
+
+
+@assert_no_logs
+def test_next_page_note(assert_pixels):
+    assert_pixels('''
+        BBBBBBBB________
+        BBBBBBBB________
+        BBBBBBBB________
+        BBBBBBBB________
+        RRRRRRRRRRRRRRRR
+        RRRRRRRRRRRRRRRR
+        RRRRRRBBRRRRRRBB
+        RRRRRRBBRRRRRRBB
+        ________________
+        ________________
+        ________________
+        ________________
+    ''', '''
+        <style>
+            @page {
+                size: 16px 6px;
+                @note-area {
+                    content: element(sidenotes, all-once);
+                }
+            }
+            div {
+                color: red;
+                font: 2px/1 weasyprint;
+            }
+            span {
+                color: blue;
+                display: block;
+                position: note(sidenotes);
+            }
+        </style>
+        <div>aaaaaaaa
+          abc<span>d</span>fgh<span>i</span></div>''')
+
+
+@assert_no_logs
+def test_next_page_split_note(assert_pixels):
+    assert_pixels('''
+        BBBBBBBB________
+        BBBBBBBB________
+        RRRRRRBB________
+        RRRRRRBB________
+        RRRRRRRRRRRRRRRR
+        RRRRRRRRRRRRRRRR
+        BBBBBBBB________
+        BBBBBBBB________
+        RRRRRRRRRRRRRRRR
+        RRRRRRRRRRRRRRRR
+        RRRRRRBB________
+        RRRRRRBB________
+    ''', '''
+        <style>
+            @page {
+                size: 16px 6px;
+                @note-area {
+                    content: element(sidenotes, all-once);
+                }
+            }
+            div {
+                color: red;
+                font: 2px/1 weasyprint;
+            }
+            span {
+                color: blue;
+                display: block;
+                position: note(sidenotes);
+            }
+        </style>
+        <div>abc<span>d</span>
+          aaaaaaaa
+          aaaaaaaa
+          fgh<span>i</span></div>''')
+
+
+@assert_no_logs
+def test_next_page_split_not_fitted_note(assert_pixels):
+    assert_pixels('''
+        BBBBBBBB________
+        BBBBBBBB________
+        RRRRRRRRRRRRRRRR
+        RRRRRRRRRRRRRRRR
+        RRRRRRRRRRRRRRRR
+        RRRRRRRRRRRRRRRR
+        BBBBBBBB________
+        BBBBBBBB________
+        RRRRRRBB________
+        RRRRRRBB________
+        RRRRRRBB________
+        RRRRRRBB________
+    ''', '''
+        <style>
+            @page {
+                size: 16px 6px;
+                @note-area {
+                    content: element(sidenotes, all-once);
+                }
+            }
+            div {
+                color: red;
+                font: 2px/1 weasyprint;
+            }
+            span {
+                color: blue;
+                display: block;
+                position: note(sidenotes);
+            }
+        </style>
+        <div>
+          aaaaaaaa
+          aaaaaaaa
+          abc<span>d</span>
+          fgh<span>i</span></div>''')
+
+
+@pytest.mark.xfail
+@assert_no_logs
+def test_next_page_split_not_fitted_note_2(assert_pixels):
+    assert_pixels('''
+        BBBBBBBB________
+        BBBBBBBB________
+        RRRRRRBB________
+        RRRRRRBB________
+        RRRRRRRRRRRRRRRR
+        RRRRRRRRRRRRRRRR
+        BBBBBBBB________
+        BBBBBBBB________
+        RRRRRRBB________
+        RRRRRRBB________
+        ________________
+        ________________
+    ''', '''
+        <style>
+            @page {
+                size: 16px 6px;
+                @note-area {
+                    content: element(sidenotes, all-once);
+                }
+            }
+            div {
+                color: red;
+                font: 2px/1 weasyprint;
+            }
+            span {
+                color: blue;
+                display: block;
+                position: note(sidenotes);
+            }
+        </style>
+        <div>abc<span>d</span>
+          aaaaaaaa
+          fgh<span>i</span></div>''')

--- a/tests/draw/test_note.py
+++ b/tests/draw/test_note.py
@@ -398,6 +398,8 @@ def test_next_page_split_not_fitted_note(assert_pixels):
         BBBBBBBB________
         ________________
         ________________
+        ________________
+        ________________
     ''', '''
         <style>
             @page {

--- a/tests/layout/test_notes.py
+++ b/tests/layout/test_notes.py
@@ -1,7 +1,5 @@
 """Tests for notes layout."""
 
-import pytest
-
 from ..testing_utils import assert_no_logs, render_pages
 
 

--- a/tests/layout/test_notes.py
+++ b/tests/layout/test_notes.py
@@ -1,0 +1,91 @@
+"""Tests for notes layout."""
+
+import pytest
+
+from ..testing_utils import assert_no_logs, render_pages
+
+
+@assert_no_logs
+def test_one_note():
+    page, = render_pages('''
+        <style>
+            @page {
+                size: 10px 4px;
+                @note-area {
+                    content: element(sidenotes, all-once);
+                }
+            }
+            div {
+                font: 2px/1 weasyprint;
+            }
+            span {
+                position: note(sidenotes);
+                display: block;
+            }
+        </style>
+        <div>abc<span>de</span></div>''')
+    html, note_area = page.children
+    div, = html.children[0].children
+    div_textbox, note_call = div.children[0].children
+    assert div_textbox.text == 'abc'
+    assert note_call.children[0].text == '1'
+    assert div_textbox.position_y == 2
+
+    note_marker, note_textbox, note_callback = (
+        note_area.children[0].children[0].children)
+    assert note_marker.children[0].text == '1.'
+    assert note_textbox.text == 'de'
+    assert note_callback.children[0].text == 'b'
+
+
+@assert_no_logs
+def test_several_block_notes():
+    page, = render_pages('''
+        <style>
+            @page {
+                size: 30px 8px;
+                @note-area {
+                    content: element(sidenotes, all-once);
+                }
+            }
+            div {
+                font: 2px/1 weasyprint;
+            }
+            span {
+                position: note(sidenotes);
+                display: block;
+            }
+        </style>
+        <div>abc<span>de</span>
+          fgh<span>ij</span>
+          klm<span>no</span></div>''')
+    html, note_area = page.children
+    div, = html.children[0].children
+    div_children = div.children[0].children
+    textbox1, note_call1 = div_children[0], div_children[1]
+    textbox2, note_call2 = div_children[2], div_children[3]
+    textbox3, note_call3 = div_children[4], div_children[5]
+    assert textbox1.text == 'abc'
+    assert note_call1.children[0].text == '1'
+    assert textbox2.text == ' fgh'
+    assert note_call2.children[0].text == '2'
+    assert textbox3.text == ' klm'
+    assert note_call3.children[0].text == '3'
+    assert textbox1.position_y == 6
+    assert textbox1.position_y == textbox2.position_y == textbox3.position_y
+
+    note_marker1, note_textbox1, note_callback1 = (
+        note_area.children[0].children[0].children)
+    assert note_marker1.children[0].text == '1.'
+    assert note_textbox1.text == 'de'
+    assert note_callback1.children[0].text == 'b'
+    note_marker2, note_textbox2, note_callback2 = (
+        note_area.children[1].children[0].children)
+    assert note_marker2.children[0].text == '2.'
+    assert note_textbox2.text == 'ij'
+    assert note_callback2.children[0].text == 'b'
+    note_marker3, note_textbox3, note_callback3 = (
+        note_area.children[2].children[0].children)
+    assert note_marker3.children[0].text == '3.'
+    assert note_textbox3.text == 'no'
+    assert note_callback2.children[0].text == 'b'

--- a/tests/resources/tests_ua.css
+++ b/tests/resources/tests_ua.css
@@ -1,7 +1,7 @@
 /* Simplified user-agent stylesheet for HTML5 in tests. */
 
 @font-face { src: url(weasyprint.otf); font-family: weasyprint }
-@page { background: white; bleed: 0; @footnote { margin: 0 }; @note-area { margin: 0 } }
+@page { background: white; bleed: 0 }
 
 html, body, div, h1, h2, h3, h4, ol, p, ul, hr, pre, section, article { display: block }
 
@@ -30,11 +30,8 @@ h4        { bookmark-level: 4; bookmark-label: content(text) }
 h5        { bookmark-level: 5; bookmark-label: content(text) }
 h6        { bookmark-level: 6; bookmark-label: content(text) }
 
-::marker  { font-variant-numeric: tabular-nums }
-
 ::footnote-call   { content: counter(footnote) }
 ::footnote-marker { content: counter(footnote) '.' }
-
-::note-call { content: counter(note) }
-::note-marker { content: counter(note) '.' }
-::note-callback { content: 'b' }
+::note-call       { content: counter(note) }
+::note-marker     { content: counter(note) '.' }
+::note-callback   { content: 'b' }

--- a/tests/resources/tests_ua.css
+++ b/tests/resources/tests_ua.css
@@ -1,7 +1,7 @@
 /* Simplified user-agent stylesheet for HTML5 in tests. */
 
 @font-face { src: url(weasyprint.otf); font-family: weasyprint }
-@page { background: white; bleed: 0; @footnote { margin: 0 } }
+@page { background: white; bleed: 0; @footnote { margin: 0 }; @note-area { margin: 0 } }
 
 html, body, div, h1, h2, h3, h4, ol, p, ul, hr, pre, section, article { display: block }
 

--- a/tests/resources/tests_ua.css
+++ b/tests/resources/tests_ua.css
@@ -34,3 +34,7 @@ h6        { bookmark-level: 6; bookmark-label: content(text) }
 
 ::footnote-call   { content: counter(footnote) }
 ::footnote-marker { content: counter(footnote) '.' }
+
+::note-call { content: counter(note) }
+::note-marker { content: counter(note) '.' }
+::note-callback { content: 'b' }

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -926,3 +926,21 @@ def test_svg_gradient_color_ops_before_path():
     lineto_offset = pdf.find(b'100 5 l')
     assert lineto_offset != -1
     assert cs_offset < lineto_offset
+
+
+@assert_no_logs
+def test_links_note():
+    pdf = FakeHTML(string='''
+      <style>
+        @page {
+          @note-area {
+            content: element(sidenotes, all-once);
+          }
+        }
+        span {
+          display: block;
+          position: note(sidenotes);
+        }
+      </style>
+      <div>abc<span>de</span>fgh<span>ij</span></div>''').write_pdf()
+    assert b'/Dest (note-1)' in pdf

--- a/weasyprint/css/__init__.py
+++ b/weasyprint/css/__init__.py
@@ -46,12 +46,12 @@ from .tokens import (  # isort:skip
 # Reject anything not in here:
 PSEUDO_ELEMENTS = frozenset((
     None, 'before', 'after', 'marker', 'first-line', 'first-letter',
-    'footnote-call', 'footnote-marker'))
+    'footnote-call', 'footnote-marker', 'note-call', 'note-marker', 'note-callback'))
 PAGE_MARGIN_BOXES = frozenset((
     'bottom-center', 'bottom-left', 'bottom-left-corner', 'bottom-right',
     'bottom-right-corner', 'left-bottom', 'left-middle', 'left-top',
     'right-bottom', 'right-middle', 'right-top', 'top-center', 'top-left',
-    'top-left-corner', 'top-right', 'top-right-corner', 'footnote'))
+    'top-left-corner', 'top-right', 'top-right-corner', 'footnote', 'note-area'))
 
 PageSelectorType = namedtuple(
     'PageSelectorType', ['side', 'blank', 'first', 'index', 'name'])

--- a/weasyprint/css/computed_values.py
+++ b/weasyprint/css/computed_values.py
@@ -552,7 +552,7 @@ def compute_float(style, name, value):
     """Compute the ``float`` property."""
     # See https://www.w3.org/TR/CSS21/visuren.html#dis-pos-flo.
     position = style.specified['position']
-    if position in ('absolute', 'fixed') or position[0] == 'running()':
+    if position in ('absolute', 'fixed') or position[0] in ('running()', 'note()'):
         return 'none'
     else:
         return value

--- a/weasyprint/css/functions.py
+++ b/weasyprint/css/functions.py
@@ -149,7 +149,8 @@ def check_string_or_element(string_or_element, token):
             ident = arguments.pop(0)
             if ident.type != 'ident':
                 return
-            if ident.lower_value not in ('first', 'start', 'last', 'first-except'):
+            values = ('first', 'start', 'last', 'first-except', 'all-once')
+            if ident.lower_value not in values:
                 return
             ident = ident.lower_value
         else:

--- a/weasyprint/css/html5_ua.css
+++ b/weasyprint/css/html5_ua.css
@@ -134,10 +134,13 @@ img, svg { overflow: hidden }
 video { object-fit: contain }
 table { box-sizing: border-box }
 
-/* Footnotes */
+/* Notes */
 
 ::footnote-call { content: counter(footnote); vertical-align: super; font-size: smaller; line-height: inherit }
 ::footnote-marker { content: counter(footnote) ". " }
+::note-call { content: counter(note); vertical-align: super; font-size: smaller; line-height: inherit }
+::note-marker { content: counter(note) ". " }
+::note-callback { content: " ↩" }
 
 /* Counters and bookmarks */
 
@@ -181,7 +184,8 @@ fieldset { border: groove 2px; margin-left: 2px; margin-right: 2px; padding: .35
 
 @page {
   margin: 75px;
-  @footnote { margin-top: 1em }
+  @footnote            { margin-top: 1em }
+  @note-area           { content: element(note, all-once) }
   @top-left-corner     { text-align: right;  vertical-align: middle }
   @top-left            { text-align: left;   vertical-align: middle }
   @top-center          { text-align: center; vertical-align: middle }

--- a/weasyprint/css/html5_ua.css
+++ b/weasyprint/css/html5_ua.css
@@ -1,6 +1,6 @@
 /*
 
-User agent stylsheet for HTML.
+User agent stylesheet for HTML.
 
 Contributed by Peter Moulder.
 Based on suggested styles in the HTML5 specification, CSS 2.1, and
@@ -140,7 +140,7 @@ table { box-sizing: border-box }
 ::footnote-marker { content: counter(footnote) ". " }
 ::note-call { content: counter(note); vertical-align: super; font-size: smaller; line-height: inherit }
 ::note-marker { content: counter(note) ". " }
-::note-callback { content: " ↩" }
+::note-callback { content: " ↩" }
 
 /* Counters and bookmarks */
 

--- a/weasyprint/css/validation/properties.py
+++ b/weasyprint/css/validation/properties.py
@@ -1215,9 +1215,9 @@ def text_overflow(keyword):
 @single_token
 def position(token):
     """``position`` property validation."""
-    if token.type == 'function' and token.name == 'running':
+    if token.type == 'function' and token.name in ('running', 'note'):
         if len(token.arguments) == 1 and token.arguments[0].type == 'ident':
-            return ('running()', token.arguments[0].value)
+            return (f'{token.name}()', token.arguments[0].value)
     keyword = get_single_keyword([token])
     if keyword in ('static', 'relative', 'absolute', 'fixed'):
         return keyword

--- a/weasyprint/formatting_structure/boxes.py
+++ b/weasyprint/formatting_structure/boxes.py
@@ -81,6 +81,8 @@ class Box:
     bookmark_label = None
     string_set = None
     footnote = None
+    note_call = None
+    note_callback = None
     cached_counter_values = None
     link = None
     missing_link = None
@@ -298,6 +300,10 @@ class Box:
         """Return whether this box is a footnote."""
         return self.style['float'] == 'footnote'
 
+    def is_note(self):
+        """Return whether this box is a note."""
+        return self.style['position'][0] == 'note()'
+
     def is_absolutely_positioned(self):
         """Return whether this box is in the absolute positioning scheme."""
         return self.style['position'] in ('absolute', 'fixed')
@@ -310,7 +316,7 @@ class Box:
         """Return whether this box is in normal flow."""
         return not (
             self.is_floated() or self.is_absolutely_positioned() or
-            self.is_running() or self.is_footnote())
+            self.is_running() or self.is_footnote() or self.is_note())
 
     def is_monolithic(self):
         """Return whether this box is monolithic."""
@@ -388,7 +394,7 @@ class Box:
         return following_collapsible_space
 
     def process_text_transform(self):
-        if not self.is_running():
+        if not (self.is_running() or self.is_footnote() or self.is_note()):
             for child in self.children:
                 child.process_text_transform()
 

--- a/weasyprint/formatting_structure/boxes.py
+++ b/weasyprint/formatting_structure/boxes.py
@@ -81,6 +81,7 @@ class Box:
     bookmark_label = None
     string_set = None
     footnote = None
+    note = None
     note_call = None
     note_callback = None
     cached_counter_values = None

--- a/weasyprint/formatting_structure/build.py
+++ b/weasyprint/formatting_structure/build.py
@@ -330,6 +330,8 @@ def marker_to_box(element, state, parent_style, style_for, get_image_from_uri,
 
     """
     style = style_for(element, 'marker')
+    if style is None:
+        style = parent_style.anonymous_style
 
     children = []
 

--- a/weasyprint/formatting_structure/build.py
+++ b/weasyprint/formatting_structure/build.py
@@ -205,7 +205,7 @@ def element_to_box(element, style_for, get_image_from_uri, base_url,
             note_call.children = content_to_boxes(
                 call_style, note_call, quote_depth, counter_values,
                 get_image_from_uri, target_collector, counter_style)
-            note.note_call = note_call
+            note.note_call, note_call.note = note_call, note
             child_boxes = [note_call, note]
 
         children.extend(child_boxes)

--- a/weasyprint/formatting_structure/build.py
+++ b/weasyprint/formatting_structure/build.py
@@ -141,10 +141,10 @@ def element_to_box(element, style_for, get_image_from_uri, base_url,
         state = (
             # Shared mutable objects:
             [0],  # quote_depth: single integer
-            # TODO: define the footnote counter where it can be updated by page
-            {'footnote': [0]},  # counter_values: name -> stacked/scoped values
-            [{'footnote'}],  # counter_scopes: element depths -> counter names
-            [] # page_groups
+            # TODO: define the note counters where it can be updated by page.
+            {'footnote': [0], 'note': [0]},  # counter_values: name -> stacked values
+            [{'footnote', 'note'}],  # counter_scopes: element depths -> counter names
+            [], # page_groups
         )
     quote_depth, counter_values, counter_scopes, _page_groups = state
 
@@ -196,6 +196,17 @@ def element_to_box(element, style_for, get_image_from_uri, base_url,
                 get_image_from_uri, target_collector, counter_style)
             footnote_call.footnote = footnote
             child_boxes = [footnote_call]
+        if child_boxes and child_boxes[0].is_note():
+            note = child_boxes[0]
+            note.style = note.style.copy()
+            call_style = style_for(note.element, 'note-call')
+            note_call = make_box(
+                f'{note.element.tag}::note-call', call_style, [], note.element)
+            note_call.children = content_to_boxes(
+                call_style, note_call, quote_depth, counter_values,
+                get_image_from_uri, target_collector, counter_style)
+            note.note_call = note_call
+            child_boxes = [note_call, note]
 
         children.extend(child_boxes)
         text = child_element.tail
@@ -244,6 +255,22 @@ def element_to_box(element, style_for, get_image_from_uri, base_url,
             marker_style, marker, quote_depth, counter_values, get_image_from_uri,
             target_collector, counter_style)
         box.children.insert(0, marker)
+    elif style['position'][0] == 'note()':
+        counter_values['note'][-1] += 1
+        marker_style = style_for(element, 'note-marker')
+        marker = make_box(f'{element.tag}::note-marker', marker_style, [], element)
+        marker.children = content_to_boxes(
+            marker_style, marker, quote_depth, counter_values, get_image_from_uri,
+            target_collector, counter_style)
+        box.children.insert(0, marker)
+        callback_style = style_for(element, 'note-callback')
+        callback = make_box(
+            f'{element.tag}::note-callback', callback_style, [], element)
+        callback.children = content_to_boxes(
+            callback_style, callback, quote_depth, counter_values, get_image_from_uri,
+            target_collector, counter_style)
+        box.children.append(callback)
+        box.note_callback = callback
 
     # Specific handling for the element. (eg. replaced element)
     return html.handle_element(element, box, get_image_from_uri, base_url)
@@ -430,7 +457,7 @@ def compute_content_list(content_list, parent_box, counter_values, css_token,
                     '"string(%s)" is only allowed in page margins',
                     ' '.join(value))
                 continue
-            add_text(context.get_string_set_for(page, *value))
+            add_text(''.join(context.get_string_set_for(page, *value)))
         elif type_ in ('counter()', 'counters()'):
             counter_name, counter_type = value[0], value[-1]
             if counter_type == 'none':
@@ -509,19 +536,20 @@ def compute_content_list(content_list, parent_box, counter_values, css_token,
                     '"element(%s)" is only allowed in page margins',
                     ' '.join(value))
                 continue
-            new_box = context.get_running_element_for(page, *value)
-            if new_box is None:
-                continue
-            new_box = new_box.deepcopy()
-            new_box.style['position'] = 'relative'
-            for child in new_box.descendants():
-                if child.style['content'] in ('normal', 'none'):
-                    continue
-                child.children = content_to_boxes(
-                    child.style, child, quote_depth, counter_values,
-                    get_image_from_uri, target_collector, counter_style,
-                    context=context, page=page)
-            content_boxes.append(new_box)
+            for new_box in context.get_running_element_for(page, *value):
+                new_box = new_box.deepcopy()
+                new_box.style = new_box.style.copy()
+                new_box.style['position'] = 'relative'
+                if value[1] != 'all-once':
+                    # Use page counters instead of box counters.
+                    for child in new_box.descendants():
+                        if child.style['content'] in ('normal', 'none'):
+                            continue
+                        child.children = content_to_boxes(
+                            child.style, child, quote_depth, counter_values,
+                            get_image_from_uri, target_collector, counter_style,
+                            context=context, page=page)
+                content_boxes.append(new_box)
         elif type_ == 'leader()':
             if not value[1]:
                 continue
@@ -1102,7 +1130,7 @@ def inline_in_block(box):
         ]
 
     """
-    if not box.children or box.is_running():
+    if not box.children or box.is_running() or box.is_note():
         return box
 
     box_children = list(box.children)
@@ -1237,7 +1265,7 @@ def block_in_inline(box):
         ]
 
     """
-    if not box.children or box.is_running():
+    if not box.children or box.is_running() or box.is_note():
         return box
 
     new_children = []

--- a/weasyprint/layout/__init__.py
+++ b/weasyprint/layout/__init__.py
@@ -368,13 +368,13 @@ class LayoutContext:
         if box.is_note():
             assert box.note_call
             assert box.note_callback
-            index = len(self.running_elements)
+            index = sum(
+                len(boxes) for names in self.running_elements.values()
+                for boxes in names.values())
             box.style['anchor'] = f'note-{index}'
             box.note_call.style['anchor'] = f'call-{index}'
-            box.note_call.style['link'] = get_link(
-                f'#note-{index}', box.style.base_url)
-            box.note_callback.style['link'] = get_link(
-                f'#call-{index}', box.style.base_url)
+            box.note_call.link = get_link(f'#note-{index}', box.style.base_url)
+            box.note_callback.link = get_link(f'#call-{index}', box.style.base_url)
         self.running_elements[running_name][self.current_page].append(box)
 
     def layout_footnote(self, footnote):

--- a/weasyprint/layout/__init__.py
+++ b/weasyprint/layout/__init__.py
@@ -241,6 +241,7 @@ class LayoutContext:
         self.page_footnotes = {}
         self.current_page_footnotes = []
         self.reported_footnotes = []
+        self.rendered_notes = None
         self.current_footnote_area = None  # Not initialized yet
         self.page_bottom = None
         self.string_set = defaultdict(lambda: defaultdict(list))
@@ -375,7 +376,8 @@ class LayoutContext:
             box.note_call.style['anchor'] = f'call-{index}'
             box.note_call.link = get_link(f'#note-{index}', box.style.base_url)
             box.note_callback.link = get_link(f'#call-{index}', box.style.base_url)
-        self.running_elements[running_name][self.current_page].append(box)
+        if box not in self.rendered_notes:
+            self.running_elements[running_name][self.current_page].append(box)
 
     def remove_running_element(self, box):
         """Remove a running element from the list of running elements."""

--- a/weasyprint/layout/__init__.py
+++ b/weasyprint/layout/__init__.py
@@ -366,9 +366,7 @@ class LayoutContext:
     def add_running_element(self, box):
         """Add a running element to the list of running elements."""
         running_name = box.style['position'][1]
-        if box.is_note():
-            assert box.note_call
-            assert box.note_callback
+        if box.is_note() and box.style['anchor'] is None:
             index = sum(
                 len(boxes) for names in self.running_elements.values()
                 for boxes in names.values())

--- a/weasyprint/layout/__init__.py
+++ b/weasyprint/layout/__init__.py
@@ -16,6 +16,7 @@ from math import inf
 
 from ..formatting_structure import boxes, build
 from ..logger import PROGRESS_LOGGER
+from ..urls import get_link
 from .absolute import absolute_box_layout, absolute_layout
 from .background import layout_backgrounds
 from .block import block_level_layout
@@ -199,7 +200,7 @@ def layout_document(html, root_box, context, max_loops=8):
     # Add margin boxes
     for i, page in enumerate(pages):
         root_children = []
-        root, footnote_area = page.children
+        root, footnote_area, note_area = page.children
         root_children.extend(layout_fixed_boxes(context, pages[:i], page))
         root_children.extend(root.children)
         root_children.extend(layout_fixed_boxes(context, pages[i + 1:], page))
@@ -208,10 +209,14 @@ def layout_document(html, root_box, context, max_loops=8):
 
         # page_maker's page_state is ready for the MarginBoxes
         state = context.page_maker[context.current_page][3]
-        page.children = (root,)
+        children = []
+        children.append(root)
         if footnote_area.children:
-            page.children += (footnote_area,)
-        page.children += tuple(make_margin_boxes(context, page, state))
+            children.append(footnote_area)
+        if note_area.children:
+            children.append(note_area)
+        children.extend(make_margin_boxes(context, page, state))
+        page.children = tuple(children)
         layout_backgrounds(page, context.get_image_from_uri)
         yield page
 
@@ -329,30 +334,48 @@ class LayoutContext:
 
         """
         if self.current_page in store[name]:
-            # A value was assigned on this page
-            first_string = store[name][self.current_page][0]
-            last_string = store[name][self.current_page][-1]
+            # A value was assigned on this page.
+            current = store[name][self.current_page]
             if keyword == 'first':
-                return first_string
+                return (current[0],)
             elif keyword == 'start':
                 element = page
                 while element:
                     if element.style['string_set'] != 'none':
                         for (string_name, _) in element.style['string_set']:
                             if string_name == name:
-                                return first_string
+                                return (current[0],)
                     if element.children:
                         element = element.children[0]
                         continue
                     break
             elif keyword == 'last':
-                return last_string
+                return (current[-1],)
             elif keyword == 'first-except':
-                return
-        # Search backwards through previous pages
-        for previous_page in range(self.current_page - 1, 0, -1):
-            if previous_page in store[name]:
-                return store[name][previous_page][-1]
+                return ()
+            elif keyword == 'all-once':
+                return tuple(current)
+        # Search backwards through previous pages.
+        if keyword != 'all-once':
+            for previous_page in range(self.current_page - 1, 0, -1):
+                if previous_page in store[name]:
+                    return (store[name][previous_page][-1],)
+        return ()
+
+    def add_running_element(self, box):
+        """Add a running element to the list of running elements."""
+        running_name = box.style['position'][1]
+        if box.is_note():
+            assert box.note_call
+            assert box.note_callback
+            index = len(self.running_elements)
+            box.style['anchor'] = f'note-{index}'
+            box.note_call.style['anchor'] = f'call-{index}'
+            box.note_call.style['link'] = get_link(
+                f'#note-{index}', box.style.base_url)
+            box.note_callback.style['link'] = get_link(
+                f'#call-{index}', box.style.base_url)
+        self.running_elements[running_name][self.current_page].append(box)
 
     def layout_footnote(self, footnote):
         """Add a footnote to the layout for this page."""

--- a/weasyprint/layout/__init__.py
+++ b/weasyprint/layout/__init__.py
@@ -377,6 +377,14 @@ class LayoutContext:
             box.note_callback.link = get_link(f'#call-{index}', box.style.base_url)
         self.running_elements[running_name][self.current_page].append(box)
 
+    def remove_running_element(self, box):
+        """Remove a running element from the list of running elements."""
+        running_name = box.style['position'][1]
+        if pages := self.running_elements.get(running_name):
+            if boxes := pages.get(self.current_page):
+                if box in boxes:
+                    boxes.remove(box)
+
     def layout_footnote(self, footnote):
         """Add a footnote to the layout for this page."""
         self.footnotes.remove(footnote)

--- a/weasyprint/layout/block.py
+++ b/weasyprint/layout/block.py
@@ -378,8 +378,10 @@ def _linebox_layout(context, box, index, child, new_children, page_is_empty,
             # report footnotes and see if we don’t overflow.
             could_break_before = can_break_now = True
             needed = box.style['widows'] - 1
-            for _ in lines_iterator:
+            for next_line, _ in lines_iterator:
                 needed -= 1
+                remove_placeholders(
+                    context, next_line.children, absolute_boxes, fixed_boxes)
                 # Don’t iterate over all lines as it can be long.
                 if needed == -1:
                     break
@@ -1105,6 +1107,8 @@ def remove_placeholders(context, box_list, absolute_boxes, fixed_boxes):
             context.broken_out_of_flow.pop(box)
         if box in context.excluded_shapes:
             context.excluded_shapes.remove(box)
+        if box.note:
+            context.remove_running_element(box.note)
 
 
 def avoid_page_break(page_break, context):

--- a/weasyprint/layout/block.py
+++ b/weasyprint/layout/block.py
@@ -296,10 +296,8 @@ def _out_of_flow_layout(context, box, index, child, new_children,
                     new_child = None
 
     # Running element layout.
-    elif child.is_running():
-        running_name = child.style['position'][1]
-        page = context.current_page
-        context.running_elements[running_name][page].append(child)
+    elif child.is_running() or child.is_note():
+        context.add_running_element(child)
 
     return stop, resume_at, new_child, out_of_flow_resume_at
 

--- a/weasyprint/layout/flex.py
+++ b/weasyprint/layout/flex.py
@@ -143,10 +143,8 @@ def flex_layout(context, box, bottom_space, skip_stack, containing_block, page_i
                     absolute_boxes.append(placeholder)
                 else:
                     fixed_boxes.append(placeholder)
-            elif child.is_running():
-                running_name = child.style['position'][1]
-                page = context.current_page
-                context.running_elements[running_name][page].append(child)
+            elif child.is_running() or child.is_note():
+                context.add_running_element(child)
             continue
         # See https://www.w3.org/TR/css-flexbox-1/#min-size-auto.
         if main == 'width':

--- a/weasyprint/layout/inline.py
+++ b/weasyprint/layout/inline.py
@@ -627,10 +627,8 @@ def _out_of_flow_layout(context, box, containing_block, index, child,
                 if float_align:
                     old_child.translate(dx=dx)
 
-    elif child.is_running():
-        running_name = child.style['position'][1]
-        page = context.current_page
-        context.running_elements[running_name][page].append(child)
+    elif child.is_running() or child.is_note():
+        context.add_running_element(child)
 
 
 def _break_waiting_children(context, box, max_x, bottom_space, initial_skip_stack,

--- a/weasyprint/layout/page.py
+++ b/weasyprint/layout/page.py
@@ -699,14 +699,14 @@ def make_page(context, root_box, page_type, resume_at, page_number,
     initial_root_box = root_box
     initial_resume_at = resume_at
     previous_running_elements = {
-        name: {page_number: running_elements.get(page_number)}
-        for name, running_elements in context.running_elements.items()
-    }
+        name: running_elements.get(page_number)
+        for name, running_elements in context.running_elements.items()}
     for running_elements in context.running_elements.values():
         running_elements.pop(page_number, None)
-    for name, elements in previous_running_elements.items():
-        if elements:
-            context.rendered_notes.extend(elements)
+    notes = (
+        element for elements in previous_running_elements.values()
+        for element in (elements or ()) if element.is_note())
+    context.rendered_notes.extend(notes)
     root_box, resume_at, next_page, _, _, _ = block_level_layout(
         context, root_box, 0, resume_at, initial_containing_block,
         page_is_empty, positioned_boxes, positioned_boxes, adjoining_margins)
@@ -728,12 +728,14 @@ def make_page(context, root_box, page_type, resume_at, page_number,
         resume_at = initial_resume_at
     root_box.children = out_of_flow_boxes + root_box.children
     running_elements = {
-        name: {page_number: running_elements.get(page_number)}
-        for name, running_elements in context.running_elements.items()
-    }
+        name: running_elements.get(page_number)
+        for name, running_elements in context.running_elements.items()}
     if previous_running_elements != running_elements:
-        remake_state = context.page_maker[page_number - 1][-1]
-        remake_state['content_changed'] = True
+        for name, previous_runnings in previous_running_elements.items():
+            if runnings := running_elements[name]:
+                if previous_runnings is None or len(previous_runnings) > len(runnings):
+                    remake_state = context.page_maker[page_number - 1][-1]
+                    remake_state['content_changed'] = True
 
     footnote_area = build.create_anonymous_boxes(footnote_area.deepcopy())
     footnote_area = block_level_layout(

--- a/weasyprint/layout/page.py
+++ b/weasyprint/layout/page.py
@@ -591,9 +591,7 @@ def make_page(context, root_box, page_type, resume_at, page_number,
         context.style_for.initial_page_sizes['box'] = device_size
         context.style_for.initial_page_sizes['area'] = (page.width, page.height)
 
-    root_box.position_x = page.content_box_x()
-    root_box.position_y = page.content_box_y()
-    context.page_bottom = root_box.position_y + page.height
+    context.page_bottom = page.content_box_y() + page.height
     initial_containing_block = page
 
     footnote_area_style = context.style_for(page_type, '@footnote')
@@ -622,6 +620,38 @@ def make_page(context, root_box, page_type, resume_at, page_number,
             context.report_footnote(reported_footnote)
             context.reported_footnotes = reported_footnotes[i:]
             break
+
+    page_is_empty = True
+    adjoining_margins = []
+    positioned_boxes = []  # Mixed absolute and fixed
+    note_area_style = context.style_for(page_type, '@note-area')
+    note_area = build.blockify(build.make_box('@note-area', note_area_style, (), None))
+    note_area.position_x = page.content_box_x()
+    note_area.position_y = page.content_box_y()
+    quote_depth, counter_values, _, _ = page_state
+    if note_area.style['content'] != 'normal':
+        note_area.children = build.content_to_boxes(
+            note_area.style, note_area, quote_depth, counter_values,
+            context.get_image_from_uri, context.target_collector,
+            context.counter_style, context, page)
+        note_area = build.create_anonymous_boxes(note_area)
+
+    root_box.position_x = page.content_box_x()
+    root_box.position_y = page.content_box_y()
+    if note_area.is_in_normal_flow():
+        note_area, _, _, _, _, _ = block_level_layout(
+            context, note_area, 0, resume_at, initial_containing_block,
+            page_is_empty, positioned_boxes, positioned_boxes, adjoining_margins)
+        root_box.position_y = note_area.position_y + note_area.margin_height()
+    elif note_area.is_floated():
+        note_area, _ = float_layout(
+            context, note_area, initial_containing_block, positioned_boxes,
+            positioned_boxes, 0, None)
+        context._excluded_shapes[root_box] = note_area
+    else:
+        note_area, _ = absolute_box_layout(
+            context, note_area, page, positioned_boxes, bottom_space=0,
+            skip_stack=None)
 
     # Display out-of-flow boxes broken on the previous page.
     # TODO: we shouldn’t separate broken in-flow and out-of-flow layout.
@@ -662,6 +692,12 @@ def make_page(context, root_box, page_type, resume_at, page_number,
     # Display in-flow content.
     initial_root_box = root_box
     initial_resume_at = resume_at
+    previous_running_elements = {
+        name: {page_number: running_elements.get(page_number)}
+        for name, running_elements in context.running_elements.items()
+    }
+    for running_elements in context.running_elements.values():
+        running_elements.pop(page_number, None)
     root_box, resume_at, next_page, _, _, _ = block_level_layout(
         context, root_box, 0, resume_at, initial_containing_block,
         page_is_empty, positioned_boxes, positioned_boxes, adjoining_margins)
@@ -682,6 +718,13 @@ def make_page(context, root_box, page_type, resume_at, page_number,
             True, positioned_boxes, positioned_boxes, adjoining_margins)
         resume_at = initial_resume_at
     root_box.children = out_of_flow_boxes + root_box.children
+    running_elements = {
+        name: {page_number: running_elements.get(page_number)}
+        for name, running_elements in context.running_elements.items()
+    }
+    if previous_running_elements != running_elements:
+        remake_state = context.page_maker[page_number - 1][-1]
+        remake_state['content_changed'] = True
 
     footnote_area = build.create_anonymous_boxes(footnote_area.deepcopy())
     footnote_area = block_level_layout(
@@ -700,7 +743,7 @@ def make_page(context, root_box, page_type, resume_at, page_number,
 
     context.finish_block_formatting_context()
 
-    page.children = [root_box, footnote_area]
+    page.children = [root_box, footnote_area, note_area]
 
     # Update page counter values
     _standardize_page_based_counters(style, None)

--- a/weasyprint/layout/page.py
+++ b/weasyprint/layout/page.py
@@ -644,7 +644,7 @@ def make_page(context, root_box, page_type, resume_at, page_number,
     root_box.position_y = page.content_box_y()
     if note_area.is_in_normal_flow():
         note_area, _, _, _, _, _ = block_level_layout(
-            context, note_area, 0, resume_at, initial_containing_block,
+            context, note_area, 0, None, initial_containing_block,
             page_is_empty, positioned_boxes, positioned_boxes, adjoining_margins)
         if note_area.children:
             root_box.position_y = note_area.position_y + note_area.margin_height()

--- a/weasyprint/layout/page.py
+++ b/weasyprint/layout/page.py
@@ -704,6 +704,9 @@ def make_page(context, root_box, page_type, resume_at, page_number,
     }
     for running_elements in context.running_elements.values():
         running_elements.pop(page_number, None)
+    for name, elements in previous_running_elements.items():
+        if elements:
+            context.rendered_notes.extend(elements)
     root_box, resume_at, next_page, _, _, _ = block_level_layout(
         context, root_box, 0, resume_at, initial_containing_block,
         page_is_empty, positioned_boxes, positioned_boxes, adjoining_margins)
@@ -1040,6 +1043,7 @@ def make_all_pages(context, root_box, html, pages):
     """
     i = 0
     reported_footnotes = None
+    context.rendered_notes = []
     while True:
         remake_state = context.page_maker[i][-1]
         if (len(pages) == 0 or

--- a/weasyprint/layout/page.py
+++ b/weasyprint/layout/page.py
@@ -646,12 +646,14 @@ def make_page(context, root_box, page_type, resume_at, page_number,
         note_area, _, _, _, _, _ = block_level_layout(
             context, note_area, 0, resume_at, initial_containing_block,
             page_is_empty, positioned_boxes, positioned_boxes, adjoining_margins)
-        root_box.position_y = note_area.position_y + note_area.margin_height()
+        if note_area.children:
+            root_box.position_y = note_area.position_y + note_area.margin_height()
     elif note_area.is_floated():
         note_area, _ = float_layout(
             context, note_area, initial_containing_block, positioned_boxes,
             positioned_boxes, 0, None)
-        context._excluded_shapes[root_box] = note_area
+        if note_area.children:
+            context._excluded_shapes[root_box] = note_area
     else:
         note_area, _ = absolute_box_layout(
             context, note_area, page, positioned_boxes, bottom_space=0,

--- a/weasyprint/layout/page.py
+++ b/weasyprint/layout/page.py
@@ -595,6 +595,8 @@ def make_page(context, root_box, page_type, resume_at, page_number,
     initial_containing_block = page
 
     footnote_area_style = context.style_for(page_type, '@footnote')
+    if footnote_area_style is None:
+        footnote_area_style = style.anonymous_style
     footnote_area = boxes.FootnoteAreaBox(page, footnote_area_style)
     resolve_percentages(footnote_area, page)
     footnote_area.position_x = page.content_box_x()
@@ -625,6 +627,8 @@ def make_page(context, root_box, page_type, resume_at, page_number,
     adjoining_margins = []
     positioned_boxes = []  # Mixed absolute and fixed
     note_area_style = context.style_for(page_type, '@note-area')
+    if note_area_style is None:
+        note_area_style = style.anonymous_style
     note_area = build.blockify(build.make_box('@note-area', note_area_style, (), None))
     note_area.position_x = page.content_box_x()
     note_area.position_y = page.content_box_y()

--- a/weasyprint/layout/preferred.py
+++ b/weasyprint/layout/preferred.py
@@ -99,7 +99,7 @@ def _block_content_width(context, box, function, outer):
         # https://dbaron.org/css/intrinsic/#outer-intrinsic
         children_widths = [
             function(context, child, outer=True) for child in box.children
-            if not child.is_absolutely_positioned()]
+            if not child.is_absolutely_positioned() and not child.is_note()]
         width = max(children_widths) if children_widths else 0
     elif box.style['box_sizing'] == 'content-box':
         width = width.value
@@ -281,7 +281,7 @@ def table_cell_min_content_width(context, box, outer):
     children_widths = [
         min_content_width(context, child)
         for child in box.children
-        if not child.is_absolutely_positioned()]
+        if not child.is_absolutely_positioned() and not child.is_note()]
     children_min_width = adjust(
         box,
         outer,
@@ -323,7 +323,7 @@ def inline_line_widths(context, box, outer, is_line_start, minimum, skip_stack=N
         (skip, skip_stack), = skip_stack.items()
     for child in box.children[skip:]:
         # Skip absolutely positioned elements.
-        if child.is_absolutely_positioned():
+        if child.is_absolutely_positioned() or child.is_note():
             continue
 
         # None is used in "lines" to track line breaks, transformed to 0 when yielded.


### PR DESCRIPTION
This pull request adds an initial support of [CSS Notes](https://css-print-lab.github.io/specs/notes-in-css-print/), including:

- notes in the `@note-area` or in page margins,
- the `::note-call`, `::note-callback` and `::note-marker` pseudo-elements,
- note counters,
- links on call and callback elements,
- the `note()` function,
- the `all-once` parameter of the `element()` function.

It does not include other features, defined in this specification draft or elsewhere, including:

- the `note-policy` property,
- named page areas,
- complex cases of reported notes,
- notes split between multiple areas,
- page floats.