### PR TITLE
Reserve bottom padding and border when detecting overflow

### DIFF
--- a/tests/layout/test_page.py
+++ b/tests/layout/test_page.py
@@ -1832,3 +1832,33 @@ def test_running_float():
         Hello!
       </footer>
     ''')
+
+
+@assert_no_logs
+def test_fixed_height_root_keeps_overflowing_siblings():
+    """Content after an overflowing bottom decoration must still be laid out.
+
+    See https://github.com/Kozea/WeasyPrint/issues/2798
+    """
+    pages = render_pages('''
+      <html style="height:100%">
+        <body>
+          <h3 style="padding-top: 914.8px;">Header</h3>
+          <hr/>
+          Overflow
+        </body>
+      </html>
+    ''')
+    texts = []
+
+    def collect(box):
+        if isinstance(box, boxes.TextBox) and box.text:
+            texts.append(box.text)
+        children = getattr(box, 'children', None)
+        if children:
+            for child in children:
+                collect(child)
+
+    for page in pages:
+        collect(page)
+    assert 'Overflow' in ''.join(texts)

--- a/weasyprint/layout/block.py
+++ b/weasyprint/layout/block.py
@@ -673,8 +673,13 @@ def block_container_layout(context, box, bottom_space, skip_stack, page_is_empty
     if adjoining_margins is None:
         adjoining_margins = []
 
+    # Always reserve bottom padding/border for overflow detection. With the
+    # default box-decoration-break:slice those were ignored, so an unbreakable
+    # bottom decoration could overflow the page and remaining siblings were
+    # discarded (#2798).
+    bottom_space += box.padding_bottom + box.border_bottom_width
     if draw_bottom_decoration:
-        bottom_space += box.padding_bottom + box.border_bottom_width + box.margin_bottom
+        bottom_space += box.margin_bottom
 
     adjoining_margins.append(box.margin_top)
     this_box_adjoining_margins = adjoining_margins


### PR DESCRIPTION
With the default `box-decoration-break: slice`, layout ignored bottom padding and border when deciding whether a block overflowed the page. An unbreakable bottom decoration (the `<hr>` in #2798) could then overflow unnoticed, and remaining siblings were dropped.

Bottom padding and border are now always reserved for overflow detection. Margin is still only added when the fragment actually draws the bottom decoration.

Fixes #2798
