### PR TITLE
Restore nested SVG viewport size on the SVG object

### DIFF
--- a/tests/draw/svg/test_units.py
+++ b/tests/draw/svg/test_units.py
@@ -99,3 +99,81 @@ def test_units_unknown(assert_pixels):
               stroke-width="2px" stroke="red" fill="none" />
       </svg>
     ''')
+
+
+@assert_no_logs
+def test_units_percentage(assert_pixels):
+    assert_pixels('''
+        ________
+        ________
+        ________
+        ________
+        ____BB__
+        ____BB__
+        ________
+        ________
+    ''', '''
+      <style>
+        @page { size: 8px }
+        svg { display: block }
+      </style>
+      <svg width="8px" height="8px" xmlns="http://www.w3.org/2000/svg">
+        <rect x="50%" y="50%" width="2" height="2" fill="blue" />
+      </svg>
+    ''')
+
+
+@assert_no_logs
+def test_units_percentage_after_nested_svg(assert_pixels):
+    # Percentages must be resolved against the current viewport, not against
+    # the viewport of a nested "svg" tag that has already been drawn.
+    assert_pixels('''
+        RR______
+        RR______
+        ________
+        ________
+        ____BB__
+        ____BB__
+        ________
+        ________
+    ''', '''
+      <style>
+        @page { size: 8px }
+        svg { display: block }
+      </style>
+      <svg width="8px" height="8px" xmlns="http://www.w3.org/2000/svg">
+        <svg width="100%" height="100%" viewBox="0 0 4 4">
+          <rect width="1" height="1" fill="red" />
+        </svg>
+        <rect x="50%" y="50%" width="2" height="2" fill="blue" />
+      </svg>
+    ''')
+
+
+@assert_no_logs
+def test_units_percentage_sibling_nested_svg(assert_pixels):
+    # Each nested "svg" tag must resolve its own percentages against the
+    # parent viewport, including when a sibling has been drawn before.
+    assert_pixels('''
+        ________
+        ________
+        __RR____
+        __RR____
+        ____BB__
+        ____BB__
+        ________
+        ________
+    ''', '''
+      <style>
+        @page { size: 8px }
+        svg { display: block }
+      </style>
+      <svg width="8px" height="8px" xmlns="http://www.w3.org/2000/svg">
+        <svg x="25%" y="25%" width="1" height="1" overflow="visible">
+          <rect width="2" height="2" fill="red" />
+        </svg>
+        <svg x="50%" y="50%" width="1" height="1" overflow="visible">
+          <rect width="2" height="2" fill="blue" />
+        </svg>
+      </svg>
+    ''')

--- a/weasyprint/svg/__init__.py
+++ b/weasyprint/svg/__init__.py
@@ -559,7 +559,7 @@ class SVG:
 
         # Restore concrete and inner size of root svg tag
         if node.tag == 'svg':
-            self.tree.set_svg_size(svg, concrete_width, concrete_height)
+            self.tree.set_svg_size(self, concrete_width, concrete_height)
 
         # Handle text anchor
         if text_anchor_shift:


### PR DESCRIPTION
Fixes [Issue 2914](https://github.com/Kozea/WeasyPrint/issues/2914):

The concrete size of the svg tag is properly restored.

