### PR TITLE
Resolve userSpaceOnUse pattern percentages against the viewport

### DIFF
--- a/tests/draw/svg/test_patterns.py
+++ b/tests/draw/svg/test_patterns.py
@@ -235,3 +235,40 @@ def test_pattern_inherit_no_override(assert_pixels):
         <rect x="0" y="0" width="8" height="8" fill="url(#pat)" />
       </svg>
     ''')
+
+
+@assert_no_logs
+def test_pattern_user_space_percentage(assert_pixels):
+    """A percentage on a userSpaceOnUse pattern refers to the viewport.
+
+    Same tiling as test_pattern, with the 4px tile written as 50% of the
+    8px viewport instead of an absolute length.
+    """
+    assert_pixels('''
+        BBrrBBrr
+        BBrrBBrr
+        rrBBrrBB
+        rrBBrrBB
+        BBrrBBrr
+        BBrrBBrr
+        rrBBrrBB
+        rrBBrrBB
+    ''', '''
+      <style>
+        @page { size: 8px }
+        svg { display: block }
+      </style>
+      <svg width="8px" height="8px" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <pattern id="pat" x="0" y="0" width="50%" height="50%"
+            patternUnits="userSpaceOnUse"
+            patternContentUnits="userSpaceOnUse">
+            <rect x="0" y="0" width="2" height="2" fill="blue" />
+            <rect x="0" y="2" width="2" height="2" fill="red" />
+            <rect x="2" y="0" width="2" height="2" fill="red" />
+            <rect x="2" y="2" width="2" height="2" fill="blue" />
+          </pattern>
+        </defs>
+        <rect x="0" y="0" width="8" height="8" fill="url(#pat)" />
+      </svg>
+    ''')

--- a/weasyprint/svg/defs.py
+++ b/weasyprint/svg/defs.py
@@ -400,8 +400,15 @@ def draw_pattern(svg, node, pattern, font_size, opacity, stroke):
     x, y = bounding_box[0], bounding_box[1]
     matrix = Matrix(e=x, f=y)
     if pattern.get('patternUnits') == 'userSpaceOnUse':
-        pattern_width = size(pattern.get('width', 0), font_size, 1)
-        pattern_height = size(pattern.get('height', 0), font_size, 1)
+        # Percentages refer to the viewport, as they do for masks. The
+        # resolved lengths replace the attributes, because the pattern is
+        # drawn as an "svg" node that would otherwise resolve them again.
+        pattern_width = size(
+            pattern.get('width', 0), font_size, svg.inner_width)
+        pattern_height = size(
+            pattern.get('height', 0), font_size, svg.inner_height)
+        pattern.attrib['width'] = pattern_width
+        pattern.attrib['height'] = pattern_height
     else:
         width, height = bounding_box[2], bounding_box[3]
         pattern_width = (


### PR DESCRIPTION
A percentage width or height on a `patternUnits="userSpaceOnUse"` pattern is resolved against `1`, so `width="50%"` becomes half a *user unit* rather than half the viewport, and the pattern is too small to be visible:

```python
size('50%', font_size, 1)     # 0.5   <- what draw_pattern does today
size('50%', font_size, 8)     # 4.0   <- 50% of an 8px viewport
```

`paint_mask` a few hundred lines down already does this correctly — `maskUnits="userSpaceOnUse"` resolves percentages against `svg.inner_width` / `svg.inner_height` — so the two units branches in the same file disagree.

The added test is `test_pattern` with the 4px tile written as `50%` of the 8px viewport instead of an absolute length; it expects the identical tiling and fails on `main`. The existing pattern tests do cover a percentage (`test_pattern_2`), but only with `patternUnits="objectBoundingBox"`, so the `userSpaceOnUse` percentage path was untested.

Two changes are needed, not one. Resolving against the viewport gets the computed size right, but the pattern element is retagged as an `svg` node and resolves its own `width`/`height` attributes again, so `50%` would be applied a second time. The resolved lengths therefore replace the attributes, which is what the `objectBoundingBox` branch already does a few lines below.

`pytest tests/draw/svg/`: **210 passed, 6 xfailed** (209 with the change reverted, the one failure being the new test). Full `pytest tests/`: **4331 passed, 7 failed, 43 xfailed** — those 7 are identical on unmodified `main` here (`font_variant_caps` ×5, `font_stretch`, `acid2`), and are missing-font artefacts of my machine rather than anything to do with this change. `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011M5uTyCU4WcNTsPvGrErDo
