### PR TITLE
Fix style edition for markers

### DIFF
--- a/tests/layout/test_list.py
+++ b/tests/layout/test_list.py
@@ -129,3 +129,22 @@ def test_lists_page_break_margin():
             assert (
                 li.children[0].position_y ==
                 li.children[1].children[0].position_y)
+
+
+def test_lists_marker_content():
+    # Regression test for #2918.
+    page, = render_pages('''
+      <style>
+        ::marker { content: 'a' }
+      </style>
+      <ul>
+        <li>b</li>
+      </ul>
+    ''')
+    html, = page.children
+    body, = html.children
+    ul, = body.children
+    li, = ul.children
+    marker, li = li.children
+    assert marker.children[0].children[0].text == 'a'
+    assert li.children[0].children[0].text == 'b'

--- a/tests/resources/tests_ua.css
+++ b/tests/resources/tests_ua.css
@@ -30,6 +30,8 @@ h4        { bookmark-level: 4; bookmark-label: content(text) }
 h5        { bookmark-level: 5; bookmark-label: content(text) }
 h6        { bookmark-level: 6; bookmark-label: content(text) }
 
+::marker  { white-space: pre }
+
 ::footnote-call   { content: counter(footnote) }
 ::footnote-marker { content: counter(footnote) '.' }
 ::note-call       { content: counter(note) }

--- a/weasyprint/formatting_structure/build.py
+++ b/weasyprint/formatting_structure/build.py
@@ -366,7 +366,6 @@ def marker_to_box(element, state, parent_style, style_for, get_image_from_uri,
             counter_type = style['list_style_type']
             if marker_text := counter_style.render_marker(counter_type, counter_value):
                 box = boxes.TextBox.anonymous_from(box, marker_text)
-                box.style['white_space'] = 'pre-wrap'
                 children.append(box)
 
     if not children:

--- a/weasyprint/formatting_structure/build.py
+++ b/weasyprint/formatting_structure/build.py
@@ -376,6 +376,7 @@ def marker_to_box(element, state, parent_style, style_for, get_image_from_uri,
         marker_box = boxes.BlockBox.anonymous_from(box, children)
         # We can safely edit everything that can't be changed by user style
         # See https://drafts.csswg.org/css-pseudo-4/#marker-pseudo
+        marker_box.style = marker_box.style.copy()
         marker_box.style['position'] = 'absolute'
         marker_box.is_outside_marker = True
     else:


### PR DESCRIPTION
Now that style can be shared between boxes, we have to be more careful when we edit the style dictionary. Here, the position was set to absolute, poisoning the anonymous style of the parent.

Fix #2918.

Another useless style modification was done above to keep spaces. Using the default stylesheet is a cleaner and more reliable way to handle this.

(That’s another reason why we should forbid style modification, see #497.)