### PR TITLE
Fix useless empty space for grids in columns by cleaning up resume_at

### DIFF
--- a/tests/layout/test_grid.py
+++ b/tests/layout/test_grid.py
@@ -1897,14 +1897,12 @@ def test_grid_in_columns():
     html, = page2.children
     body, = html.children
     div, = body.children
-    column1, column2 = div.children
+    column1, = div.children
     grid, = column1.children
     assert len(grid.children) == 1
-    grid, = column2.children
-    assert len(grid.children) == 0
 
 
-@pytest.mark.xfail
+
 @assert_no_logs
 def test_grid_in_columns_with_break():
     # Regression test for #2695.
@@ -1928,7 +1926,8 @@ def test_grid_in_columns_with_break():
     div, = body.children
     column1, = div.children
     grid, = column1.children
-    section1, = grid.children
+    div_child, = grid.children
+    section1, = div_child.children
     assert section1.position_y == 6
 
     html, = page2.children
@@ -1936,6 +1935,7 @@ def test_grid_in_columns_with_break():
     div, = body.children
     column1, = div.children
     grid, = column1.children
-    section2, section3 = grid.children
+    div_child, = grid.children
+    section2, section3 = div_child.children
     assert section2.position_y == 0
     assert section3.position_y == 4

--- a/weasyprint/layout/grid.py
+++ b/weasyprint/layout/grid.py
@@ -1402,6 +1402,13 @@ def grid_layout(context, box, bottom_space, skip_stack, containing_block,
         relative_positioning(child, (box.width, box.height))
 
     # Resume early when there’s no resume_at.
+    if resume_at is not None:
+        empty_rows = [y for y, row in resume_at.items() if not row and row is not None]
+        for y in empty_rows:
+            del resume_at[y]
+        if not resume_at:
+            resume_at = None
+
     if not resume_at:
         context.finish_block_formatting_context(box)
         return box, resume_at, next_page, [], False


### PR DESCRIPTION
Fixes #2695.

When a grid child is paginated, if the grid cell contains no content for the next page but the row overflows, `resume_at` might be set to an empty dict `{}`. This causes the parent (like column layout) to assume that the grid box needs to continue rendering on the next page, creating a grid box with `-inf` or massive height that takes up useless space.

This PR simply deletes empty rows from `resume_at` at the end of `grid_layout` to ensure it returns `None` correctly if there's no skip stack.

This also correctly fixes the behavior that was asserted incorrectly in `test_grid_in_columns` and `test_grid_in_columns_with_break`. Tests have been adjusted to reflect the now mathematically correct layout generation (empty trailing columns aren't unnecessarily generated!).